### PR TITLE
docs: scaffold MkDocs Material manual site (Phase 3.1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,6 +138,7 @@ celerybeat.pid
 .env
 .envrc
 .venv
+.venv-*/
 env/
 venv/
 ENV/

--- a/docs/auditoria/progreso.md
+++ b/docs/auditoria/progreso.md
@@ -52,4 +52,4 @@ y `✓` "aplicable, validado".
 4. Si el valor es correcto, marca el ítem y deja la(s) referencia(s) en la sección "Referencias BOE" del issue.
 5. Si encuentras una discrepancia, abre un PR `audit:` con la plantilla `?template=audit.md`: corrige el valor, regenera el fixture afectado y cita la referencia BOE.
 
-Ver [`CONTRIBUTING.md`](../../CONTRIBUTING.md) para el flujo OSS general.
+Ver [`CONTRIBUTING.md`](https://github.com/ceballosiker/auditor-irpf-es/blob/main/CONTRIBUTING.md) para el flujo OSS general.

--- a/docs/contribuir.md
+++ b/docs/contribuir.md
@@ -6,12 +6,7 @@ Este proyecto necesita tres tipos de aportación. Elige tu perfil:
 
 Tu valor está en **validar la fidelidad normativa** del motor año a año.
 
-1. Mira la [tabla de progreso de auditoría](auditoria/progreso.md).
-2. Elige un año en estado *no iniciado*.
-3. Abre el issue `audit-YYYY` correspondiente y reclama el slot comentando "tomo este año".
-4. Para cada ítem del checklist, valida el valor en `src/normativa.ts` (o `src/pipeline.ts` para el tope 43 %) contra la referencia BOE oficial.
-5. Si el valor es correcto, marca el ítem y deja la(s) referencia(s) BOE en el issue.
-6. Si encuentras una discrepancia, abre un issue describiéndola y un *techie* la convertirá en un PR `audit:` con la corrección + actualización del fixture afectado.
+El flujo paso a paso —elegir año, reclamar slot, validar contra BOE, reportar discrepancias— vive en la sección «Cómo participar» de la [tabla de progreso de auditoría](auditoria/progreso.md), para mantener una única fuente de verdad.
 
 No necesitas saber programar para auditar; basta con saber leer normativa y citar BOE.
 

--- a/docs/contribuir.md
+++ b/docs/contribuir.md
@@ -1,0 +1,37 @@
+# Cómo contribuir
+
+Este proyecto necesita tres tipos de aportación. Elige tu perfil:
+
+## Si eres fiscalista o economista
+
+Tu valor está en **validar la fidelidad normativa** del motor año a año.
+
+1. Mira la [tabla de progreso de auditoría](auditoria/progreso.md).
+2. Elige un año en estado *no iniciado*.
+3. Abre el issue `audit-YYYY` correspondiente y reclama el slot comentando "tomo este año".
+4. Para cada ítem del checklist, valida el valor en `src/normativa.ts` (o `src/pipeline.ts` para el tope 43 %) contra la referencia BOE oficial.
+5. Si el valor es correcto, marca el ítem y deja la(s) referencia(s) BOE en el issue.
+6. Si encuentras una discrepancia, abre un issue describiéndola y un *techie* la convertirá en un PR `audit:` con la corrección + actualización del fixture afectado.
+
+No necesitas saber programar para auditar; basta con saber leer normativa y citar BOE.
+
+## Si eres developer
+
+Lee [`CONTRIBUTING.md`](https://github.com/ceballosiker/auditor-irpf-es/blob/main/CONTRIBUTING.md) para el flujo OSS completo (branch model, Conventional Commits, pnpm, Vitest, releases).
+
+Áreas con backlog activo:
+
+- `area/engine` — motor de cálculo TypeScript (`src/`).
+- `area/docs` — este manual (MkDocs Material).
+- `area/ui` — futura calculadora web (Phase 4).
+- `area/infra` — CI, releases, GitHub Pages.
+
+Issues etiquetados [`good first issue`](https://github.com/ceballosiker/auditor-irpf-es/labels/good%20first%20issue) son el punto de entrada recomendado.
+
+## Si quieres ayudar con la web
+
+La calculadora interactiva (Phase 4 — v1.0.0) aún no ha empezado. Si quieres aportar diseño o frontend, comenta en el [roadmap pinned issue](https://github.com/ceballosiker/auditor-irpf-es/issues/1) indicando tu perfil.
+
+## Código de conducta
+
+Al participar te adhieres al [Código de conducta](https://github.com/ceballosiker/auditor-irpf-es/blob/main/CODE_OF_CONDUCT.md) (Contributor Covenant v2.1).

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,7 +14,7 @@ Este manual acompaña al [motor de cálculo](https://github.com/ceballosiker/aud
 
 Modelado:
 
-- *Soltero / sin hijos / sin discapacidad*.
+- _Soltero / sin hijos / sin discapacidad_.
 - Tramo autonómico = tramo estatal (es decir, escala estatal duplicada; sin variación por CCAA).
 
 Pendiente (Phase 6):

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,42 @@
+# Auditor IRPF ES
+
+> **Implementación pública y auditable del cálculo del IRPF y del salario neto en España, 2012–2026.**
+
+Este manual acompaña al [motor de cálculo](https://github.com/ceballosiker/auditor-irpf-es) y traduce su lógica a lenguaje llano. Su objetivo es **democratizar** el conocimiento de cómo se calcula tu nómina y, en particular, qué efecto ha tenido la **progresividad en frío** entre 2012 y 2026.
+
+## A quién va dirigido
+
+- **Fiscalistas y economistas** que quieran auditar la fidelidad normativa año a año. → empieza por la [tabla de progreso](auditoria/progreso.md).
+- **Personas técnicas** que quieran entender el motor o aportar mejoras. → empieza por [Cómo contribuir](contribuir.md).
+- **Cualquier contribuyente** que quiera entender qué se descuenta de su nómina y por qué. → próximamente: la calculadora interactiva (Phase 4 — v1.0.0).
+
+## Alcance actual del motor
+
+Modelado:
+
+- *Soltero / sin hijos / sin discapacidad*.
+- Tramo autonómico = tramo estatal (es decir, escala estatal duplicada; sin variación por CCAA).
+
+Pendiente (Phase 6):
+
+- Escalas autonómicas por CCAA.
+- Deducciones por hijos, ascendientes y discapacidad.
+- Deducciones por edad.
+
+## Cómo está organizado este manual
+
+- **Motor** — la cadena de cálculo paso a paso (próximamente, Phase 3.2).
+- **Progresividad en frío** — el concepto clave (próximamente, Phase 3.3).
+- **Anual** — un resumen por año entre 2012 y 2026 (stubs en v0.4.0; redacción completa en Phase 5).
+- **Auditoría** — estado vivo de la validación normativa.
+- **Cómo contribuir** — guía corta por perfil.
+
+## Estado del proyecto
+
+Este sitio se construye sobre la versión `v0.4.0` del motor. Las versiones publicadas anteriores son:
+
+- **v0.1.0** — base OSS + fixtures-oráculo congelados desde el motor original en Python.
+- **v0.2.0** — port del motor a TypeScript, validado al céntimo contra los fixtures.
+- **v0.3.0** — workflow de auditoría fiscal por años (15 issues `audit-YYYY`).
+
+Ver el [CHANGELOG](https://github.com/ceballosiker/auditor-irpf-es/blob/main/CHANGELOG.md) para el detalle.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,69 @@
+site_name: Auditor IRPF ES
+site_description: Implementación pública y auditable del cálculo del IRPF y del salario neto en España, 2012–2026.
+site_url: https://ceballosiker.github.io/auditor-irpf-es/
+site_author: ceballosiker
+
+repo_url: https://github.com/ceballosiker/auditor-irpf-es
+repo_name: ceballosiker/auditor-irpf-es
+edit_uri: edit/develop/docs/
+
+docs_dir: docs
+site_dir: site
+
+theme:
+  name: material
+  language: es
+  features:
+    - navigation.sections
+    - navigation.top
+    - navigation.tracking
+    - content.code.copy
+    - content.action.edit
+    - search.highlight
+    - search.suggest
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-7
+        name: Cambiar a modo oscuro
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-4
+        name: Cambiar a modo claro
+  icon:
+    repo: fontawesome/brands/github
+
+nav:
+  - Inicio: index.md
+  - Cómo contribuir: contribuir.md
+  - Auditoría:
+      - Progreso 2012–2026: auditoria/progreso.md
+
+markdown_extensions:
+  - admonition
+  - attr_list
+  - md_in_html
+  - tables
+  - toc:
+      permalink: true
+  - pymdownx.details
+  - pymdownx.superfences
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.tabbed:
+      alternate_style: true
+
+plugins:
+  - search:
+      lang: es
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/ceballosiker/auditor-irpf-es

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -22,14 +22,14 @@ theme:
     - search.highlight
     - search.suggest
   palette:
-    - media: "(prefers-color-scheme: light)"
+    - media: '(prefers-color-scheme: light)'
       scheme: default
       primary: indigo
       accent: indigo
       toggle:
         icon: material/brightness-7
         name: Cambiar a modo oscuro
-    - media: "(prefers-color-scheme: dark)"
+    - media: '(prefers-color-scheme: dark)'
       scheme: slate
       primary: indigo
       accent: indigo

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,0 +1,3 @@
+mkdocs==1.6.1
+mkdocs-material==9.5.49
+pymdown-extensions==10.12


### PR DESCRIPTION
## Summary

Phase 3.1 — establece el esqueleto MkDocs Material del manual divulgativo. Sitio mínimo navegable (Inicio, Cómo contribuir, Auditoría → Progreso) que **build-pasa estricto**, listo para que las páginas del motor (3.2), progresividad-en-frío (3.3) y stubs anuales (3.5) aterricen en PRs subsiguientes.

- `mkdocs.yml` — tema Material, idioma `es`, paleta light/dark, `repo_url` + `edit_uri: edit/develop/docs/`.
- `requirements-docs.txt` — `mkdocs 1.6.1`, `mkdocs-material 9.5.49`, `pymdown-extensions 10.12` (pinned para builds reproducibles en CI cuando llegue 3.6).
- `docs/index.md` — landing: misión, audiencias, alcance actual vs. Phase 6, estructura del manual, historial de versiones.
- `docs/contribuir.md` — guía corta por perfil (fiscalista, developer, web) enlazando a `CONTRIBUTING.md` y a los issues `audit-YYYY`.
- `docs/auditoria/progreso.md` — parche puntual: el enlace relativo `../../CONTRIBUTING.md` → URL absoluta de GitHub para que `--strict` no lo flaguee como out-of-tree.
- `.gitignore` — ignora `.venv-*/` para que el venv local de docs no aparezca en `git status`.

## Decisiones notables

- **Yearly pages como stubs en v0.4.0**: el plan se actualizó para reflejar que la redacción completa de `anual/2012.md` … `anual/2026.md` se difiere a una nueva Phase 5 (v1.1.0). Esto deja el sitio publicable antes y permite que esa redacción avance en paralelo con el workflow de auditoría de Phase 2.
- **Phase 3.1 no toca el README**: el badge del workflow de docs y el enlace al sitio publicado se añaden en Phase 3.7 junto al release. Mantiene este PR puramente alrededor del scaffold.
- **No CI todavía**: el workflow `.github/workflows/docs.yml` llega en Phase 3.6. Build estricto verificado localmente; el bloqueo en PR se introduce con ese workflow.

## Test plan

- [x] `python3 -m venv .venv-docs && .venv-docs/bin/pip install -r requirements-docs.txt && .venv-docs/bin/mkdocs build --strict` → 0 warnings.
- [ ] (manual, opcional) `.venv-docs/bin/mkdocs serve` y navegar el sitio en `http://127.0.0.1:8000`.
- [ ] CI verde (Node lint/typecheck/test/build sigue pasando — este PR no toca código TS).

Closes #34
Refs #4