### PR TITLE
ci(docs): MkDocs build + GitHub Pages deploy workflow (Phase 3.6)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,58 @@
+name: Docs
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [develop, main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build site (strict)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+          cache-dependency-path: requirements-docs.txt
+
+      - name: Install dependencies
+        run: pip install -r requirements-docs.txt
+
+      - name: Build with strict mode
+        run: mkdocs build --strict
+
+      - name: Upload Pages artifact
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    name: Deploy to GitHub Pages
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary

Phase 3.6 — workflow `Docs` (`.github/workflows/docs.yml`) que valida el sitio en cada PR y lo despliega a GitHub Pages cuando algo aterriza en `main`.

- **Job `build`** — corre en PRs a `develop`/`main` y en push a `main`. Setup Python 3.12 con cache pip basado en `requirements-docs.txt`, instala deps y ejecuta `mkdocs build --strict`. En push a `main` también sube el `site/` como artefacto de Pages.
- **Job `deploy`** — solo en push a `main`, depende de `build`, usa `actions/deploy-pages@v4` con environment `github-pages` para que la URL del sitio aparezca en el resumen del run.
- Permisos mínimos: `contents: read` por defecto; el job `deploy` añade `pages: write` + `id-token: write` (requerido por `deploy-pages`).
- Concurrency group `pages` con `cancel-in-progress: false` para no corromper el ciclo de artefactos si llegan dos pushes muy seguidos a `main`.

## Decisiones notables

- **`actions/deploy-pages@v4` en lugar de `mkdocs gh-deploy`**: es el flujo recomendado actualmente por GitHub para Pages servido desde Actions. Da mejor visibilidad (URL en el run summary, ambiente `github-pages` con historial de deploys), no requiere rama `gh-pages` manchada con commits autogenerados, y separa "build" de "deploy" como dos jobs auditables.
- **Build estricto en PR**: aunque ningún PR aterrice todavía contenido en `motor/`, `progresividad-en-frio.md`, etc., el workflow ya bloquea regresiones. Cuando aterricen los PRs 3.2 y 3.3, este workflow va a ser la red de seguridad.
- **No badge en README**: ese cambio es de Phase 3.7 (release), donde se añaden el enlace al sitio publicado y los badges de los workflows. Mantiene este PR centrado solo en el workflow.

## Acción manual requerida (una sola vez, fuera de este PR)

Para que el job `deploy` funcione cuando `develop` se promueva a `main` en Phase 3.7:

> **Settings → Pages → Build and deployment → Source = "GitHub Actions"**

Sin ese ajuste, el job `build` sigue funcionando (PRs siguen validándose), pero el job `deploy` fallará en el primer push a `main`. Se puede hacer en cualquier momento antes del release v0.4.0.

## Test plan

- [x] YAML estructuralmente válido (parseado con `pyyaml`; la quirk `on:` → bool True es de YAML 1.1, GitHub Actions usa su propio parser y lo interpreta correctamente).
- [x] `mkdocs build --strict` localmente verde con el contenido actual (3.1).
- [ ] CI verde en este PR: el job `build` debe ejecutarse contra `develop` y pasar; los jobs `deploy` no deben dispararse (no es push a `main`).
- [ ] Una vez el setting de Pages esté en "GitHub Actions" y se publique v0.4.0, el deploy debe surfacear `https://ceballosiker.github.io/auditor-irpf-es/`.

Closes #39
Refs #4