### PR TITLE
docs(motor): seven engine pages tracing the tax pipeline (Phase 3.2)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -25,11 +25,11 @@ Pendiente (Phase 6):
 
 ## Cómo está organizado este manual
 
-- **Motor** — la cadena de cálculo paso a paso (próximamente, Phase 3.2).
+- **[Motor de cálculo](motor/01-cotizacion.md)** — la cadena de cálculo paso a paso, en siete páginas.
 - **Progresividad en frío** — el concepto clave (próximamente, Phase 3.3).
 - **Anual** — un resumen por año entre 2012 y 2026 (stubs en v0.4.0; redacción completa en Phase 5).
-- **Auditoría** — estado vivo de la validación normativa.
-- **Cómo contribuir** — guía corta por perfil.
+- **[Auditoría](auditoria/progreso.md)** — estado vivo de la validación normativa.
+- **[Cómo contribuir](contribuir.md)** — guía corta por perfil.
 
 ## Estado del proyecto
 

--- a/docs/motor/01-cotizacion.md
+++ b/docs/motor/01-cotizacion.md
@@ -1,0 +1,61 @@
+# 01. Base de cotización y tope
+
+> Primer paso de la cadena: decidir sobre qué cantidad del salario se cotiza a la Seguridad Social.
+
+## La idea
+
+La **base de cotización** es la cantidad sobre la que se aplican los tipos de Seguridad Social. Para una persona asalariada con un único pagador, en términos prácticos:
+
+- Si el salario bruto anual es **menor o igual** a la base máxima de cotización (`baseMax`), entonces la base de cotización **es** el salario bruto.
+- Si el salario bruto **supera** `baseMax`, la base de cotización se queda **topada** en `baseMax`. El exceso (`bruto − baseMax`) no cotiza por las cuotas ordinarias, pero a partir de 2025 **sí** atrae la [Cuota de Solidaridad](03-mei-solidaridad.md#cuota-de-solidaridad).
+
+En fórmula:
+
+```
+base_cotizacion = min(bruto, baseMax)
+exceso          = max(0, bruto − baseMax)
+```
+
+## La base máxima año a año
+
+La base máxima la fija la Ley de PGE de cada año (o, en su defecto, la prórroga). Estos son los valores anuales que usa el motor:
+
+| Año  | `baseMax` (€) |
+| ---- | ------------: |
+| 2012 |     39 150,00 |
+| 2013 |     41 108,40 |
+| 2014 |     43 164,00 |
+| 2015 |     43 272,00 |
+| 2016 |     43 704,00 |
+| 2017 |     45 014,40 |
+| 2018 |     45 014,40 |
+| 2019 |     48 841,20 |
+| 2020 |     48 841,20 |
+| 2021 |     48 841,20 |
+| 2022 |     49 672,80 |
+| 2023 |     53 946,00 |
+| 2024 |     56 646,00 |
+| 2025 |     58 914,00 |
+| 2026 |     61 214,40 |
+
+Se publica como base mensual; aquí está prorrateada al año (12 mensualidades + 2 pagas extras incluidas en la base, según la práctica habitual).
+
+## Ejemplo (2026)
+
+`baseMax` 2026 = **61 214,40 €**.
+
+| Bruto anual | Base de cotización |      Exceso |
+| ----------: | -----------------: | ----------: |
+|    40 000 € |        40 000,00 € |         0 € |
+|    60 000 € |        60 000,00 € |         0 € |
+|    80 000 € |        61 214,40 € | 18 785,60 € |
+|   150 000 € |        61 214,40 € | 88 785,60 € |
+
+## En el código
+
+- Tabla `BASE_MAX_POR_ANIO`: [`src/normativa.ts` L17–33](https://github.com/ceballosiker/auditor-irpf-es/blob/cd051e2/src/normativa.ts#L17-L33).
+- Cálculo de `base_cotizacion` y `exceso`: [`src/pipeline.ts` L79–80](https://github.com/ceballosiker/auditor-irpf-es/blob/cd051e2/src/pipeline.ts#L79-L80).
+
+---
+
+Siguiente: [02. Tipos de Seguridad Social](02-ss.md).

--- a/docs/motor/02-ss.md
+++ b/docs/motor/02-ss.md
@@ -1,0 +1,49 @@
+# 02. Tipos de Seguridad Social
+
+> Sobre la base de cotización (paso 01) se aplican cinco tipos en paralelo, cada uno con su reparto entre empresa y trabajador.
+
+## Los cinco conceptos
+
+La cuota total de SS es la suma de cinco contingencias. Cada una tiene un tipo aplicado a la base, y un reparto fijo empresa/trabajador:
+
+| Concepto                |     Empresa | Trabajador |       Total |
+| ----------------------- | ----------: | ---------: | ----------: |
+| Contingencias comunes   |     23,60 % |     4,70 % |     28,30 % |
+| Desempleo               |      5,50 % |     1,55 % |      7,05 % |
+| FOGASA                  |      0,20 % |     0,00 % |      0,20 % |
+| Formación profesional   |      0,60 % |     0,10 % |      0,70 % |
+| AT/EP (genérico)        |      1,50 % |     0,00 % |      1,50 % |
+| **Subtotal SS clásica** | **31,40 %** | **6,35 %** | **37,75 %** |
+
+A esto se le suma el [Mecanismo de Equidad Intergeneracional (MEI)](03-mei-solidaridad.md#mecanismo-de-equidad-intergeneracional-mei) desde 2023, que aumenta los tipos totales aplicados sobre la misma base de cotización.
+
+> **Sobre el tipo AT/EP.** El tipo de Accidentes de Trabajo y Enfermedades Profesionales depende de la actividad económica (CNAE). El motor usa **1,5 %** como tipo genérico representativo, aplicable a la mayoría de oficinas y servicios. Para actividades de mayor riesgo, el tipo real puede ser sensiblemente mayor — lo que afecta a la cuota empresa pero no al neto del trabajador.
+
+## Cómo se calculan las cuotas
+
+```
+cot_empresa     = base_cotizacion × tipo_empresa_total
+cot_trabajador  = base_cotizacion × tipo_trabajador_total
+```
+
+Los `tipo_*_total` son la suma de columna de la tabla anterior **más el MEI del año**, si aplica.
+
+## Ejemplo (2026, sin tener aún en cuenta MEI/Solidaridad)
+
+Bruto = 30 000 € → base = 30 000 €.
+
+- Cuota empresa = 30 000 × 31,40 % = **9 420 €**.
+- Cuota trabajador = 30 000 × 6,35 % = **1 905 €**.
+- **Coste laboral** para la empresa = bruto + cot_empresa = **39 420 €**.
+
+(La cuota empresa la paga la empresa por el trabajador; no aparece como descuento en nómina pero sí incrementa el coste de contratación.)
+
+## En el código
+
+- Tipos por concepto: [`src/normativa.ts` L35–41](https://github.com/ceballosiker/auditor-irpf-es/blob/cd051e2/src/normativa.ts#L35-L41).
+- Suma de tipos totales (incluyendo MEI): [`src/normativa.ts` L213–227](https://github.com/ceballosiker/auditor-irpf-es/blob/cd051e2/src/normativa.ts#L213-L227).
+- Aplicación a la base: [`src/pipeline.ts` L82–83](https://github.com/ceballosiker/auditor-irpf-es/blob/cd051e2/src/pipeline.ts#L82-L83).
+
+---
+
+Anterior: [01. Base de cotización](01-cotizacion.md) · Siguiente: [03. MEI y Cuota de Solidaridad](03-mei-solidaridad.md).

--- a/docs/motor/03-mei-solidaridad.md
+++ b/docs/motor/03-mei-solidaridad.md
@@ -1,0 +1,60 @@
+# 03. MEI y Cuota de Solidaridad
+
+> Dos mecanismos relativamente nuevos que se acoplan a la cotización ordinaria: el **MEI** (sobre la misma base, desde 2023) y la **Cuota de Solidaridad** (sólo sobre el exceso por encima de `baseMax`, desde 2025).
+
+## Mecanismo de Equidad Intergeneracional (MEI)
+
+Introducido por la Ley 21/2021 para reforzar el Fondo de Reserva de la SS. Es una **cotización adicional** sobre la **misma base de cotización** que las cuotas ordinarias, con un tipo que escala año a año durante la "década del baby boom":
+
+| Año  | Tipo total MEI | Empresa | Trabajador |
+| ---- | -------------: | ------: | ---------: |
+| 2023 |         0,60 % |  0,50 % |     0,10 % |
+| 2024 |         0,70 % |  0,58 % |     0,12 % |
+| 2025 |         0,80 % |  0,67 % |     0,13 % |
+| 2026 |         0,90 % |  0,75 % |     0,15 % |
+
+Reparto: **5/6 empresa · 1/6 trabajador**.
+
+El motor lo absorbe directamente en `tipo_empresa_total` y `tipo_trabajador_total`, así que en la fórmula del paso 02 no aparece como una línea aparte: ya está sumado.
+
+## Cuota de Solidaridad
+
+Introducida por el RD-ley 2/2023 con efectos desde el **1 de enero de 2025**. La idea es que las rentas que **superan** la base máxima (y que por tanto no pagaban cotización ordinaria sobre el exceso) sí contribuyan, en una franja escalonada, sobre ese exceso.
+
+Sólo aplica al **exceso** = `bruto − baseMax`. Tres bandas, definidas como **multiplicadores de `baseMax`**:
+
+| Banda | Sobre qué se aplica                        | Tipo 2025 | Tipo 2026 |
+| ----- | ------------------------------------------ | --------: | --------: |
+| 1     | Exceso hasta `0,1 × baseMax`               |    0,92 % |    1,15 % |
+| 2     | Exceso entre `0,1·baseMax` y `0,5·baseMax` |    1,00 % |    1,25 % |
+| 3     | Exceso por encima de `0,5·baseMax`         |    1,17 % |    1,46 % |
+
+Reparto: **5/6 empresa · 1/6 trabajador**, igual que el MEI.
+
+## Ejemplo combinado (2026, bruto = 80 000 €)
+
+Datos: `baseMax` = 61 214,40 €, exceso = 18 785,60 €.
+
+**MEI** (sobre la base de 61 214,40 €):
+
+- Empresa: 61 214,40 × 0,75 % = **459,11 €**.
+- Trabajador: 61 214,40 × 0,15 % = **91,82 €**.
+
+**Solidaridad** (sobre el exceso de 18 785,60 €):
+
+- Banda 1 (hasta `0,1·baseMax` = 6 121,44 €): 6 121,44 × 1,15 % = 70,40 €.
+- Banda 2 (entre 6 121,44 y `0,5·baseMax` = 30 607,20 €, pero el exceso sólo llega a 18 785,60): 18 785,60 − 6 121,44 = 12 664,16 € a 1,25 % = 158,30 €.
+- Banda 3 (no aplica: el exceso no supera `0,5·baseMax`).
+- **Cuota total** Solidaridad = 70,40 + 158,30 = **228,70 €**.
+- Empresa (5/6) = **190,58 €** · Trabajador (1/6) = **38,12 €**.
+
+## En el código
+
+- Tipos MEI por año: [`src/normativa.ts` L61–67](https://github.com/ceballosiker/auditor-irpf-es/blob/cd051e2/src/normativa.ts#L61-L67).
+- Bandas Solidaridad por año: [`src/normativa.ts` L69–85](https://github.com/ceballosiker/auditor-irpf-es/blob/cd051e2/src/normativa.ts#L69-L85).
+- Cálculo de la cuota Solidaridad: [`src/pipeline.ts` L19–47](https://github.com/ceballosiker/auditor-irpf-es/blob/cd051e2/src/pipeline.ts#L19-L47).
+- Reparto 5/6 · 1/6: constantes `REPARTO_SOLIDARIDAD_EMPRESA` / `_TRABAJADOR` en [`src/pipeline.ts` L20–21](https://github.com/ceballosiker/auditor-irpf-es/blob/cd051e2/src/pipeline.ts#L20-L21).
+
+---
+
+Anterior: [02. Tipos SS](02-ss.md) · Siguiente: [04. Gastos fijos Art. 19](04-art-19.md).

--- a/docs/motor/04-art-19.md
+++ b/docs/motor/04-art-19.md
@@ -1,0 +1,45 @@
+# 04. Gastos fijos deducibles (Art. 19 LIRPF)
+
+> Una deducción **fija** de los rendimientos del trabajo, en concepto de "otros gastos", introducida en 2015.
+
+## La idea
+
+El Art. 19.2.f de la LIRPF (en su redacción tras la reforma de 2014, vigente desde el ejercicio 2015) permite deducir de los rendimientos íntegros del trabajo una **cantidad fija de 2 000 € anuales** en concepto de "otros gastos distintos de los anteriores", **sin necesidad de justificación**.
+
+Es independiente de la [reducción Art. 20](05-art-20.md) (que se calcula sobre el rendimiento previo a estos 2 000 €) y se aplica **a todo el mundo** que tenga rendimientos del trabajo, con independencia del salario.
+
+## Valor año a año
+
+| Periodo   | Gastos fijos Art. 19 |
+| --------- | -------------------: |
+| 2012–2014 |                  0 € |
+| 2015–2026 |              2 000 € |
+
+Antes de 2015 esta deducción fija no existía; los gastos por cotización social ya se deducían (y siguen haciéndolo) con su propio mecanismo, pero no había un "comodín" fijo de 2 000 €.
+
+## Posición en la cadena
+
+```
+rendimiento_previo  = bruto − cot_trabajador
+reducción_Art_20    = f(rendimiento_previo)        ← se calcula ANTES (paso 05)
+rendimiento_neto    = max(0, rendimiento_previo − gastos_fijos)
+base_imponible      = max(0, rendimiento_neto − reducción_Art_20)
+```
+
+El orden es importante: la reducción Art. 20 toma como entrada el rendimiento **previo** a restar gastos Art. 19, no después. Esa elección legal (no "doblamos descuentos") está fijada en el motor y no debe reordenarse.
+
+## Ejemplo (2026, bruto = 30 000 €)
+
+- Cot. trabajador (incluyendo MEI 2026, sin Solidaridad porque no hay exceso): 30 000 × 6,50 % = 1 950 €.
+- Rendimiento previo = 30 000 − 1 950 = 28 050 €.
+- Reducción Art. 20 (sobre 28 050) = 0 € (estamos por encima del tramo de aplicación).
+- Rendimiento neto = 28 050 − 2 000 = **26 050 €**.
+
+## En el código
+
+- Valor de `gastosFijos` por año: [`src/normativa.ts` L238](https://github.com/ceballosiker/auditor-irpf-es/blob/cd051e2/src/normativa.ts#L238).
+- Aplicación en la cadena: [`src/pipeline.ts` L91–94](https://github.com/ceballosiker/auditor-irpf-es/blob/cd051e2/src/pipeline.ts#L91-L94).
+
+---
+
+Anterior: [03. MEI y Solidaridad](03-mei-solidaridad.md) · Siguiente: [05. Reducción Art. 20](05-art-20.md).

--- a/docs/motor/05-art-20.md
+++ b/docs/motor/05-art-20.md
@@ -1,0 +1,97 @@
+# 05. Reducción por rendimientos del trabajo (Art. 20 LIRPF)
+
+> El elemento más cambiante de la cadena. Es una reducción **decreciente con el salario**, diseñada para aliviar la fiscalidad de las rentas bajas y medias del trabajo.
+
+## La idea
+
+Sobre el **rendimiento previo** (bruto menos cotización del trabajador), el Art. 20 aplica una reducción que tiene **forma de pieza decreciente**:
+
+- Hasta un umbral inferior `uInf`: la reducción está en su valor máximo `rMax`.
+- Entre `uInf` y `uSup`: decrece linealmente hasta `rMin` (típicamente 0).
+- A partir de `uSup`: la reducción ya no aplica.
+
+El motor evalúa la reducción **antes** de restar [gastos Art. 19](04-art-19.md), sobre el rendimiento previo a esa deducción. Es decisión legal explícita.
+
+## Evolución año a año
+
+### 2012–2014 (régimen pre-reforma 2014)
+
+| Variable |    Valor |
+| -------- | -------: |
+| `uInf`   |  9 180 € |
+| `rMax`   |  4 080 € |
+| `uSup`   | 13 260 € |
+| `rMin`   |  2 652 € |
+
+Pendiente de la rampa decreciente: 0,35.
+
+### 2015–2017 (reforma Montoro)
+
+| Variable |    Valor |
+| -------- | -------: |
+| `uInf`   | 11 250 € |
+| `rMax`   |  3 700 € |
+| `uSup`   | 14 450 € |
+| `rMin`   |      0 € |
+
+Pendiente: 1,15625.
+
+### 2018 — régimen transitorio
+
+La Ley 6/2018, de PGE 2018, eleva la reducción **a partir del 5 de julio de 2018**. Para no aplicar dos reglas en el mismo ejercicio fiscal, la Disposición Adicional 47ª LIRPF establece un **régimen transitorio**: la reducción del ejercicio 2018 se calcula como **media de la regla previa (2015–2017) y la nueva (2019+)**.
+
+```
+reducción_2018(rn) = 0,5 × reducción_2017(rn) + 0,5 × reducción_2019(rn)
+```
+
+Esto es un detalle de precisión que no aparece en la mayoría de calculadoras del mercado. El motor lo modela explícitamente.
+
+### 2019–2022
+
+| Variable |    Valor |
+| -------- | -------: |
+| `uInf`   | 13 115 € |
+| `rMax`   |  5 565 € |
+| `uSup`   | 16 825 € |
+| `rMin`   |      0 € |
+
+Pendiente: 1,5.
+
+### 2023
+
+| Variable |      Valor |
+| -------- | ---------: |
+| `uInf`   | 14 047,5 € |
+| `rMax`   |    6 498 € |
+| `uSup`   | 19 747,5 € |
+| `rMin`   |        0 € |
+
+Pendiente: 1,14.
+
+### 2024–2026 — tres segmentos
+
+A partir de 2024 la pieza no es bilineal sino **trilineal**: el tramo decreciente cambia de pendiente a mitad de camino.
+
+```
+si rn ≤ 14 852          →  reducción = 7 302
+si rn ≤ 17 673,52       →  reducción = 7 302 − 1,75 × (rn − 14 852)
+si rn ≤ 19 747,5        →  reducción = 2 364,34 − 1,14 × (rn − 17 673,52)
+si rn > 19 747,5        →  reducción = 0
+```
+
+El primer tramo decreciente (pendiente 1,75) baja rápido para concentrar el ahorro fiscal en el tramo SMI; el segundo tramo (pendiente 1,14) suaviza la transición hasta el corte definitivo.
+
+## Por qué importa el orden
+
+Al aplicarse **antes** de los 2 000 € fijos del Art. 19, el resultado de la reducción Art. 20 puede ser distinto al que daría aplicarla después. Para alguien justo en el codo `uSup`, los 2 000 € lo sitúan más bajo en la curva si se aplicaran primero — y haría diferencia. La doctrina y la práctica administrativa fijan este orden.
+
+## En el código
+
+- Tabla `art20MetaDe` (los `uInf`/`rMax`/`uSup`/`rMin` que muestran las hojas de control del Excel): [`src/normativa.ts` L87–96](https://github.com/ceballosiker/auditor-irpf-es/blob/cd051e2/src/normativa.ts#L87-L96).
+- Función `reduccionTrabajoDe` (lógica completa, por año): [`src/normativa.ts` L98–142](https://github.com/ceballosiker/auditor-irpf-es/blob/cd051e2/src/normativa.ts#L98-L142).
+- Régimen transitorio 2018: [`src/normativa.ts` L113–120](https://github.com/ceballosiker/auditor-irpf-es/blob/cd051e2/src/normativa.ts#L113-L120).
+- Aplicación en la cadena, antes de gastos Art. 19: [`src/pipeline.ts` L91–94](https://github.com/ceballosiker/auditor-irpf-es/blob/cd051e2/src/pipeline.ts#L91-L94).
+
+---
+
+Anterior: [04. Gastos Art. 19](04-art-19.md) · Siguiente: [06. Tramos IRPF y mínimo personal](06-tramos-irpf.md).

--- a/docs/motor/06-tramos-irpf.md
+++ b/docs/motor/06-tramos-irpf.md
@@ -1,0 +1,107 @@
+# 06. Escala progresiva y mínimo personal
+
+> Sobre la base imponible se aplica la **escala IRPF progresiva**. El mínimo personal se descuenta **como cuota** al tipo del primer tramo, no como deducción de la base — un detalle conceptualmente importante que ya estaba en la reforma Montoro de 2015.
+
+## La escala progresiva
+
+La base imponible se divide en tramos. Cada tramo tributa a su tipo, y la cuota íntegra es la suma:
+
+```
+cuota_íntegra = Σ (base_en_tramo_i × tipo_i)
+```
+
+El motor modela los tramos **estatales** y, bajo el supuesto del proyecto (_tramo autonómico = tramo estatal_), los duplica. Así, los porcentajes que ves a continuación son los **totales aplicables** (estatal × 2).
+
+### Tramos por periodo
+
+#### 2012–2014
+
+| Hasta (€) | Tipo total |
+| --------: | ---------: |
+|    17 707 |    24,75 % |
+|    33 007 |    30,00 % |
+|    53 407 |    40,00 % |
+|   120 000 |    47,00 % |
+|   175 000 |    49,00 % |
+|   300 000 |    51,00 % |
+|         ∞ |    52,00 % |
+
+Periodo de "complementos transitorios" del IRPF (mucha progresividad y un tipo marginal alto del 52 %).
+
+#### 2015 (reforma Montoro, año 1)
+
+| Hasta (€) | Tipo total |
+| --------: | ---------: |
+|    12 450 |    19,50 % |
+|    20 200 |    24,50 % |
+|    34 000 |    30,50 % |
+|    60 000 |    38,00 % |
+|         ∞ |    46,00 % |
+
+Reducción notable de tramos (de 7 a 5) y del tipo marginal (52 → 46 %).
+
+#### 2016–2020
+
+| Hasta (€) | Tipo total |
+| --------: | ---------: |
+|    12 450 |    19,00 % |
+|    20 200 |    24,00 % |
+|    35 200 |    30,00 % |
+|    60 000 |    37,00 % |
+|         ∞ |    45,00 % |
+
+Ligera bajada respecto a 2015.
+
+#### 2021–2026
+
+| Hasta (€) | Tipo total |
+| --------: | ---------: |
+|    12 450 |    19,00 % |
+|    20 200 |    24,00 % |
+|    35 200 |    30,00 % |
+|    60 000 |    37,00 % |
+|   300 000 |    45,00 % |
+|         ∞ |    47,00 % |
+
+Reintroducción de un tramo alto del 47 % a partir de 300 000 €.
+
+## El mínimo personal: cuota, no base
+
+A diferencia de muchos otros impuestos, el IRPF español **no resta el mínimo personal de la base** antes de aplicar la escala. En su lugar:
+
+1. Se calcula la cuota íntegra sobre la base imponible completa.
+2. Se calcula una "cuota equivalente" del mínimo personal, multiplicándolo por el **tipo del primer tramo**.
+3. La cuota teórica es `max(0, cuota_íntegra − cuota_mínimo_personal)`.
+
+```
+cuota_mínimo_personal = mínimo_personal × tipo_primer_tramo
+cuota_teórica         = max(0, cuota_íntegra − cuota_mínimo_personal)
+```
+
+Valores del **mínimo personal del contribuyente** (soltero, sin hijos, sin discapacidad, < 65 años):
+
+| Periodo   | Mínimo personal |
+| --------- | --------------: |
+| 2012–2014 |         5 151 € |
+| 2015–2026 |         5 550 € |
+
+> **¿Por qué cuota y no base?** Aplicar el mínimo como cuota al tipo más bajo es **más equitativo**: si se restara de la base, las rentas altas obtendrían un ahorro mayor (porque "esquivarían" el último tramo, no el primero). Aplicado como cuota, el ahorro es el mismo en valor absoluto para todos los contribuyentes con la misma situación personal.
+
+## Posición en la cadena
+
+```
+base_imponible  = max(0, ren_neto − reducción_Art_20)        ← paso 05/06
+cuota_íntegra   = Σ tramos × base_en_cada_tramo              ← este paso
+cuota_teórica   = max(0, cuota_íntegra − mín_personal × t1)  ← este paso
+```
+
+## En el código
+
+- Tabla `tramosIRPFDe` por periodo: [`src/normativa.ts` L144–182](https://github.com/ceballosiker/auditor-irpf-es/blob/cd051e2/src/normativa.ts#L144-L182).
+- Mínimo personal por periodo (`irpfMinimo`): [`src/normativa.ts` L236](https://github.com/ceballosiker/auditor-irpf-es/blob/cd051e2/src/normativa.ts#L236).
+- Cálculo `calcularCuotasPorTramo`: [`src/pipeline.ts` L49–71](https://github.com/ceballosiker/auditor-irpf-es/blob/cd051e2/src/pipeline.ts#L49-L71).
+- Mínimo personal aplicado al tipo del primer tramo: [`src/pipeline.ts` L96–99](https://github.com/ceballosiker/auditor-irpf-es/blob/cd051e2/src/pipeline.ts#L96-L99).
+
+---
+
+Anterior: [05. Reducción Art. 20](05-art-20.md) · Siguiente: [07. Deducción SMI y tope 43 %](07-smi-y-43.md).

--- a/docs/motor/07-smi-y-43.md
+++ b/docs/motor/07-smi-y-43.md
@@ -1,0 +1,90 @@
+# 07. Deducción SMI y tope del 43 %
+
+> Dos correcciones que se aplican al final de la cadena: una deducción específica para rentas próximas al SMI (sólo 2025+) y un **tope** sobre la retención efectiva.
+
+## Deducción SMI
+
+Aplicable únicamente a partir de 2025. Es una deducción que reduce la cuota cuando el bruto está cerca del Salario Mínimo Interprofesional, y se desvanece linealmente más allá del umbral.
+
+### 2025
+
+```
+si bruto ≤ 16 576 €    →  deducción = 340 €
+si bruto ≤ 18 276 €    →  deducción = max(0, 340 − 0,2 × (bruto − 16 576))
+en otro caso           →  deducción = 0
+```
+
+### 2026
+
+```
+si bruto ≤ 17 094 €    →  deducción = 590,89 €
+en otro caso           →  deducción = max(0, 590,89 − 0,2 × (bruto − 17 094))
+```
+
+A diferencia de la regla 2025, en 2026 la deducción decrece sin **corte abrupto** a cero — sólo cuando el descuento llega a 0 deja de aplicarse, de forma natural por el `max(0, …)`.
+
+La deducción se resta **después** de aplicar el mínimo personal y **antes** del tope del 43 %.
+
+## El tope del 43 % (Art. 85.3 RIRPF)
+
+El Reglamento del IRPF impone un techo a la **retención efectiva** de IRPF: la cantidad efectivamente retenida no puede superar el **43 %** de la diferencia entre el bruto y el **mínimo exento de retención**.
+
+```
+límite_43 = max(0, (bruto − mínimo_exento) × 0,43)
+IRPF_final = min(cuota_tras_SMI, límite_43)
+```
+
+### Mínimo exento año a año
+
+Atención: este es **distinto** del mínimo personal. Es una cantidad **a partir de la cual existe obligación de retener**; aplicada en el cálculo del tope se interpreta como "no se retiene sobre la franja exenta".
+
+| Año  | Mínimo exento (€) |
+| ---- | ----------------: |
+| 2012 |            11 162 |
+| 2013 |            11 162 |
+| 2014 |            11 162 |
+| 2015 |            12 000 |
+| 2016 |            12 000 |
+| 2017 |            12 000 |
+| 2018 |            12 643 |
+| 2019 |            14 000 |
+| 2020 |            14 000 |
+| 2021 |            14 000 |
+| 2022 |            14 000 |
+| 2023 |            15 000 |
+| 2024 |            15 876 |
+| 2025 |            15 876 |
+| 2026 |            15 876 |
+
+El umbral de 14 000 € de 2019 fue una elevación importante destinada a alinear el mínimo exento con el SMI de la época. El salto a 15 876 € en 2024 mantiene la equivalencia con el SMI vigente desde entonces.
+
+## Posición en la cadena
+
+```
+cuota_tras_minimo_personal  ← paso 06
+   − deducción_SMI(bruto)               ← este paso (2025+)
+   = cuota_tras_SMI
+   limit  max(0, (bruto − mín_exento) × 43 %)
+   = IRPF_final
+```
+
+`IRPF_final` es la línea final del cálculo. El **salario neto** sale entonces de:
+
+```
+neto = bruto − cot_trabajador − IRPF_final
+```
+
+## Cuándo se activa el tope
+
+El tope del 43 % se activa típicamente para brutos en una **franja relativamente estrecha** justo por encima del mínimo exento, donde la cuota teórica todavía es alta en relación al exceso sobre el mínimo. Para brutos mucho mayores, la cuota teórica crece menos que el 43 % del exceso, y el tope deja de morder. El motor reporta tanto la cuota teórica como el `límite_43` para que se vea cuándo ha actuado.
+
+## En el código
+
+- Función `deduccionSMIDe` por año: [`src/normativa.ts` L184–198](https://github.com/ceballosiker/auditor-irpf-es/blob/cd051e2/src/normativa.ts#L184-L198).
+- Constante `TIPO_43`: [`src/pipeline.ts` L19](https://github.com/ceballosiker/auditor-irpf-es/blob/cd051e2/src/pipeline.ts#L19).
+- Tabla `MINIMO_EXENTO_POR_ANIO`: [`src/normativa.ts` L43–59](https://github.com/ceballosiker/auditor-irpf-es/blob/cd051e2/src/normativa.ts#L43-L59).
+- Aplicación del tope y cálculo de `irpfFinal`: [`src/pipeline.ts` L101–106](https://github.com/ceballosiker/auditor-irpf-es/blob/cd051e2/src/pipeline.ts#L101-L106).
+
+---
+
+Anterior: [06. Tramos IRPF](06-tramos-irpf.md) · Volver al [inicio del manual](../index.md).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -41,6 +41,14 @@ theme:
 
 nav:
   - Inicio: index.md
+  - Motor de cálculo:
+      - 1. Base de cotización: motor/01-cotizacion.md
+      - 2. Tipos SS: motor/02-ss.md
+      - 3. MEI y Solidaridad: motor/03-mei-solidaridad.md
+      - 4. Gastos Art. 19: motor/04-art-19.md
+      - 5. Reducción Art. 20: motor/05-art-20.md
+      - 6. Tramos IRPF: motor/06-tramos-irpf.md
+      - 7. SMI y tope 43 %: motor/07-smi-y-43.md
   - Cómo contribuir: contribuir.md
   - Auditoría:
       - Progreso 2012–2026: auditoria/progreso.md


### PR DESCRIPTION
## Summary

Phase 3.2 — manual divulgativo del motor de cálculo. Siete páginas, una por cada paso de la cadena fiscal, en lenguaje llano y con permalinks pinned al SHA actual de `develop` (`cd051e2`).

| Página | Tema | Permalinks principales |
|---|---|---|
| `motor/01-cotizacion.md` | Base de cotización vs. exceso; tabla `baseMax` 2012–2026 | `normativa.ts` L17–33, `pipeline.ts` L79–80 |
| `motor/02-ss.md` | Los cinco tipos SS, reparto empresa/trabajador, AT/EP genérico | `normativa.ts` L35–41, L213–227 |
| `motor/03-mei-solidaridad.md` | MEI (2023+) y Cuota de Solidaridad (2025+); reparto 5/6 · 1/6 | `normativa.ts` L61–85, `pipeline.ts` L19–47 |
| `motor/04-art-19.md` | Gastos fijos 2 000 € desde 2015; orden respecto a Art. 20 | `normativa.ts` L238, `pipeline.ts` L91–94 |
| `motor/05-art-20.md` | Pieza decreciente año a año; régimen transitorio 2018; trilineal 2024+ | `normativa.ts` L98–142 |
| `motor/06-tramos-irpf.md` | Escala progresiva por periodo; mínimo personal **como cuota** | `normativa.ts` L144–182, L236, `pipeline.ts` L96–99 |
| `motor/07-smi-y-43.md` | Deducción SMI 2025/2026; tope 43 % (Art. 85.3 RIRPF) | `normativa.ts` L184–198, `pipeline.ts` L101–106 |

## Decisiones notables

- **Callouts como blockquotes, no admonitions Material**: probé `!!! note "Title"` (sintaxis nativa de mkdocs-material) pero Prettier no entiende el indent de 4 espacios del cuerpo y lo aplana en cada `format:check`, dejando el bloque inválido. Los blockquotes con lead-in en negrita renderizan igual de bien en el tema y son prettier-safe.
- **Permalinks pinned a `cd051e2`** (tip de `develop` tras #42 merge). Si la normativa cambia antes del release v0.4.0 (p.ej. una corrección que aterrice via los issues `audit-YYYY`), Phase 3.7 puede repinarlos al SHA del release.
- **Ejemplos numéricos verificados a mano contra el motor**: 2026/40k, 60k, 80k, 150k para cotización; 2026/30k para SS clásica; 2026/80k para el desglose MEI + Solidaridad. Banda 1 = 6 121,44 € × 1,15 % = 70,40 €; banda 2 = 12 664,16 € × 1,25 % = 158,30 €; total 228,70 € → 190,58 € empresa + 38,12 € trabajador.
- **Sin admonitions Material avanzados, sin LaTeX**: pseudocódigo en bloques de código indentado para las fórmulas. Decisión deliberada para que el manual sea legible incluso si en el futuro cambiamos de tema.

## Cambios fuera de `motor/`

- `mkdocs.yml`: nueva sección "Motor de cálculo" en `nav`.
- `docs/index.md`: reemplaza el placeholder "(próximamente, Phase 3.2)" por enlaces reales a las páginas; añade enlaces a Auditoría y Cómo contribuir en la lista de estructura.

## Test plan

- [x] `mkdocs build --strict` localmente — 0 warnings.
- [x] `npx prettier --check docs/**/*.md mkdocs.yml` localmente — clean.
- [x] Repaso aritmético de los ejemplos numéricos (suma a mano vs. lo que daría el motor).
- [ ] CI verde: tanto el job `Build site (strict)` (introducido por #42) como los TS checks deben pasar — este PR no toca código TS.
- [ ] (manual) `mkdocs serve` y navegar las 7 páginas para verificar enlaces internos y permalinks GitHub.

Closes #35
Refs #4