### PR TITLE
chore(release): v0.4.0 — manual divulgativo publicado (Phase 3.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,48 @@ El formato sigue [Keep a Changelog](https://keepachangelog.com/es-ES/1.1.0/) y e
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-04-29
+
+Manual divulgativo del motor publicado en GitHub Pages: explica la cadena de cálculo paso a paso y la **progresividad en frío** en lenguaje llano, con gráficos generados desde el propio motor.
+
+### Added
+
+- Sitio MkDocs Material bajo `docs/`, desplegado en <https://ceballosiker.github.io/auditor-irpf-es/>:
+  - `motor/01-cotizacion.md` … `motor/07-smi-y-43.md` — siete páginas trazando la cadena fiscal (cotización, SS, MEI, Solidaridad, Art. 19, Art. 20, escala IRPF + mínimo personal como cuota, deducción SMI, tope 43 %), con permalinks commit-pinned a `src/`.
+  - `progresividad-en-frio.md` — concepto + ejemplo numérico con bruto nominal fijo en 30 000 € de 2012 a 2026, mostrando una caída de 6 549 € reales de neto.
+  - `anual/2012.md` … `anual/2026.md` + `anual/index.md` — 15 stubs auto-generados desde `obtenerParametros()` (la redacción completa con prosa BOE llegará en v1.1.0).
+  - `auditoria/progreso.md` ya existente, ahora linkeable desde el manual con columna **Manual** indicando estado de cada año.
+  - `index.md`, `contribuir.md` — landing page con misión, audiencias y guía rápida por perfil.
+- `scripts/render-charts.ts` — renderer SVG hand-rolled (sin Vega/Chart.js) que produce 3 gráficos para el manual a partir de `src/pipeline.ts` y `src/inflacion.ts`. Idempotente vía `npm run charts`.
+- `scripts/render-anual-stubs.ts` — generador de los 15 stubs anuales desde `obtenerParametros()`. Idempotente vía `npm run anual:stubs`. Encadena `prettier --write` para que la salida sea siempre prettier-clean.
+- `.github/workflows/docs.yml` — workflow GitHub Pages: `mkdocs build --strict` en cada PR a `develop`/`main`; deploy vía `actions/deploy-pages@v4` en push a `main`. Concurrency group `pages` con `cancel-in-progress: false`.
+- `requirements-docs.txt` — `mkdocs 1.6.1`, `mkdocs-material 9.5.49`, `pymdown-extensions 10.12` (pinned).
+- `mkdocs.yml` — tema Material, paleta light/dark, `repo_url`, `edit_uri` apuntando a `develop/docs/`, navegación completa.
+
+### Changed
+
+- README — nuevo aviso de una línea sobre el doble propósito del repo (proyecto + práctica de flujos OSS asistidos por agente). Sección "Manual divulgativo" con enlace al sitio publicado. Estado actualizado a v0.4.0. Roadmap añade fila para `v1.1.0` (redacción completa de los anuales). Árbol de arquitectura incluye `docs/` y los scripts nuevos.
+- `eslint.config.js` — añade `.venv-*/` y `site/` a ignores para que `npm run lint` no se rompa en local cuando existen artefactos de mkdocs.
+- `docs/auditoria/progreso.md` — nueva columna **Manual** marcando el estado (`stub` / `redactado`) de cada `anual/YYYY.md`.
+
+### Removed
+
+- `SECURITY.md` — era un stub de una tabla sin contenido real; para un repo pre-1.0 educativo no aporta valor.
+
+## [0.3.0] - 2026-04-27
+
+Workflow de auditoría fiscal año a año: 15 issues `audit-YYYY` con checklist normativo + referencias BOE, abriendo la puerta a fiscalistas no-técnicos.
+
+### Added
+
+- 15 issues de auditoría (`audit-2012` … `audit-2026`, #17–#31) etiquetados `area/fiscal` + `type/audit` + `audit/<year>`. Cada issue lleva checklist por elemento (base máx, tipos SS, MEI, Solidaridad, escala IRPF, gastos Art. 19, reducción Art. 20, mínimo personal, mínimo exento, tope 43 %, deducción SMI) con permalinks al motor anclados al SHA de v0.2.0.
+- `docs/auditoria/progreso.md` — tabla agregada de progreso 2012–2026 enlazando a cada issue, con columnas para los elementos opcionales (MEI 2023+, Solidaridad 2025+, SMI 2025+).
+- `.github/PULL_REQUEST_TEMPLATE/audit.md` — plantilla específica para PRs `audit:` (correcciones normativas), accesible vía `?template=audit.md`. Incluye sección para referencia BOE y casillas que recuerdan la regeneración del fixture afectado.
+
+### Changed
+
+- README y `CONTRIBUTING.md` actualizados con la guía del workflow de auditoría: cómo reclamar un año, cómo validar contra el BOE, cómo abrir un PR `audit:` cuando se detecta una discrepancia.
+
 ## [0.2.0] - 2026-04-27
 
 Port del motor de cálculo desde Python a TypeScript, validado al céntimo contra los fixtures-oráculo de v0.1.0.
@@ -51,6 +93,8 @@ Primera release pública. Establece los cimientos para el porting del motor a Ty
 
 - README reformulado para reflejar la misión pública (democratizar el cálculo del IRPF), la llamada a tres perfiles colaboradores (fiscalistas, _techies_, divulgadores) y el pivote a TypeScript.
 
-[Unreleased]: https://github.com/ceballosiker/auditor-irpf-es/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/ceballosiker/auditor-irpf-es/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/ceballosiker/auditor-irpf-es/releases/tag/v0.4.0
+[0.3.0]: https://github.com/ceballosiker/auditor-irpf-es/releases/tag/v0.3.0
 [0.2.0]: https://github.com/ceballosiker/auditor-irpf-es/releases/tag/v0.2.0
 [0.1.0]: https://github.com/ceballosiker/auditor-irpf-es/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -3,13 +3,18 @@
 ![TypeScript](https://img.shields.io/badge/typescript-5.5%2B-blue.svg)
 ![Node](https://img.shields.io/badge/node-%3E%3D18.18-brightgreen.svg)
 ![License](https://img.shields.io/badge/license-MIT-green.svg)
-![Estado](<https://img.shields.io/badge/estado-en%20curso%20(v0.3)-yellow.svg>)
+![Estado](<https://img.shields.io/badge/estado-en%20curso%20(v0.4)-yellow.svg>)
+[![Manual](https://img.shields.io/badge/manual-ceballosiker.github.io-blue.svg)](https://ceballosiker.github.io/auditor-irpf-es/)
 
 > **Aviso.** El objetivo de este repositorio es **practicar flujos de trabajo OSS con asistencia de agentes de IA** (Claude Code).
 
 Auditor fiscal que calcula el salario neto en España (2012–2026) euro a euro: IRPF, Seguridad Social, MEI y Cuota de Solidaridad, con análisis de pérdida de poder adquisitivo ajustada a la inflación real (IPC oficial del INE). Se expondrá como una **calculadora interactiva 100 % en el navegador** (sin servidor) acompañada de un manual divulgativo y un proceso de auditoría pública año a año.
 
-> **Estado actual:** motor TypeScript completo y validado al céntimo contra los fixtures-oráculo de la implementación Python original (v0.2.0, 2026-04). Fase en curso (v0.3.0): **workflow de auditoría fiscal** con 15 issues abiertos (uno por año fiscal 2012–2026), cada uno con checklist normativo y permalinks al motor. Ver [`docs/auditoria/progreso.md`](docs/auditoria/progreso.md).
+> **Estado actual:** motor TypeScript completo y validado al céntimo (v0.2.0), workflow de auditoría fiscal con 15 issues `audit-YYYY` abiertos (v0.3.0), y **manual divulgativo publicado** en GitHub Pages (v0.4.0). Próximo hito: calculadora web interactiva (v1.0.0).
+
+## 📖 Manual divulgativo
+
+El manual está publicado en **<https://ceballosiker.github.io/auditor-irpf-es/>**. Contiene siete páginas explicando paso a paso la cadena de cálculo (cotización, SS, MEI/Solidaridad, Art. 19/20, escala IRPF, SMI/tope 43 %), una página dedicada a la **progresividad en frío** con gráficos generados desde el propio motor, y un esqueleto de 15 resúmenes anuales (uno por año entre 2012 y 2026) cuya redacción completa irá llegando en `v1.1.0` en paralelo con la auditoría fiscal.
 
 ---
 
@@ -59,17 +64,18 @@ Para maximizar la precisión antes de ampliar casuística, el motor modela delib
 
 ### Hoja de ruta de desarrollo
 
-| Versión                 | Hito                                                                                                        |
-| ----------------------- | ----------------------------------------------------------------------------------------------------------- |
-| **v0.1.0** ✅           | Infraestructura OSS, tooling TypeScript, fixtures JSON desde el motor Python (oráculo).                     |
-| **v0.2.0** ✅           | Port del motor a TypeScript validado al céntimo contra los fixtures de v0.1.0.                              |
-| **v0.3.0** _(en curso)_ | Workflow de auditoría fiscal: 15 issues (uno por año, 2012–2026) con checklist normativo + referencias BOE. |
-| **v0.4.0**              | Manual divulgativo en MkDocs publicado en GitHub Pages.                                                     |
-| **v1.0.0**              | Calculadora web interactiva: SPA estático, 100 % en el navegador, GitHub Pages.                             |
+| Versión       | Hito                                                                                                        |
+| ------------- | ----------------------------------------------------------------------------------------------------------- |
+| **v0.1.0** ✅ | Infraestructura OSS, tooling TypeScript, fixtures JSON desde el motor Python (oráculo).                     |
+| **v0.2.0** ✅ | Port del motor a TypeScript validado al céntimo contra los fixtures de v0.1.0.                              |
+| **v0.3.0** ✅ | Workflow de auditoría fiscal: 15 issues (uno por año, 2012–2026) con checklist normativo + referencias BOE. |
+| **v0.4.0** ✅ | Manual divulgativo en MkDocs Material publicado en GitHub Pages.                                            |
+| **v1.0.0**    | Calculadora web interactiva: SPA estático, 100 % en el navegador, GitHub Pages.                             |
+| **v1.1.0**    | Redacción completa de los 15 resúmenes anuales con referencias BOE, en paralelo con los `audit-YYYY`.       |
 
 Sigue el progreso en los [issues abiertos](https://github.com/ceballosiker/auditor-irpf-es/issues) y [milestones](https://github.com/ceballosiker/auditor-irpf-es/milestones).
 
-### Hoja de ruta normativa (post-v1.0)
+### Hoja de ruta normativa (post-v1.1)
 
 - Tramos autonómicos específicos por Comunidad Autónoma.
 - Deducciones familiares (hijos, ascendientes, discapacidad).
@@ -137,8 +143,17 @@ Para regenerar los fixtures JSON (operación idempotente):
 ├── test/                         # Vitest (664 cases: fixtures + invariantes + smoke)
 ├── tests/fixtures/               # Golden JSON fixtures: oráculo inmutable
 │   └── golden_YYYY.json          # 10 brutos representativos por año (2012-2026)
+├── docs/                         # Manual MkDocs Material (GitHub Pages)
+│   ├── index.md, contribuir.md
+│   ├── motor/                    # 7 páginas: cadena de cálculo paso a paso
+│   ├── progresividad-en-frio.md  # Concepto + gráficos generados del motor
+│   ├── anual/                    # Stubs 2012-2026 (redacción completa en v1.1.0)
+│   ├── auditoria/progreso.md     # Estado de los 15 audit-YYYY
+│   └── assets/*.svg              # Charts hand-rolled desde src/pipeline.ts
 ├── scripts/
-│   └── generate_fixtures.py      # Regenera fixtures desde el motor Python
+│   ├── generate_fixtures.py      # Regenera fixtures desde el motor Python
+│   ├── render-charts.ts          # `npm run charts` — SVGs para el manual
+│   └── render-anual-stubs.ts     # `npm run anual:stubs` — stubs anuales
 ├── legacy/python-reference/      # Motor Python original (archivado tras v0.2.0)
 │   ├── Calculo_Salario_IRPF.py
 │   └── requirements.txt

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auditor-irpf-es",
-  "version": "0.2.0",
+  "version": "0.4.0",
   "private": true,
   "description": "Auditor histórico de nóminas e IRPF en España (2012-2026) con ajuste de inflación.",
   "license": "MIT",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 // Public API barrel for the auditor-irpf-es engine.
 
-export const VERSION = '0.2.0';
+export const VERSION = '0.4.0';
 
 export type {
   Art20Meta,

--- a/test/version.test.ts
+++ b/test/version.test.ts
@@ -3,6 +3,6 @@ import { VERSION } from '../src/index';
 
 describe('VERSION', () => {
   it('matches package.json', () => {
-    expect(VERSION).toBe('0.2.0');
+    expect(VERSION).toBe('0.4.0');
   });
 });


### PR DESCRIPTION
## Summary

Phase 3.7 — preparación del release **v0.4.0**. README/CHANGELOG/version bumps. Después de merge a `develop`, abriré PR separado `develop → main` (sin nuevos commits) que disparará el deploy del manual a GitHub Pages y permitirá tagear v0.4.0.

## Cambios

### Version bump (0.2.0 → 0.4.0)

- `package.json` → `version: "0.4.0"`.
- `src/index.ts` → `VERSION = "0.4.0"`.
- `test/version.test.ts` → expected `'0.4.0'`. (El test sigue siendo "hardcoded vs. package.json" — refactorizar a leer dinámicamente queda fuera de scope.)

Nótese el salto 0.2.0 → 0.4.0 en `VERSION`/`package.json`: la v0.3.0 nunca actualizó la constante (oversight de aquel release; lo arreglo aquí de paso).

### README

- Badge \"estado\": v0.3 → v0.4.
- Nuevo badge enlazando al sitio publicado (`shields.io/badge/manual-...`).
- \"Estado actual\" actualizado: motor TS validado (v0.2.0) + auditoría fiscal (v0.3.0) + manual publicado (v0.4.0); próximo hito v1.0.0.
- Nueva sección **Manual divulgativo** justo después del aviso, con enlace a https://ceballosiker.github.io/auditor-irpf-es/ y resumen del contenido.
- Hoja de ruta: ✅ en v0.3.0 y v0.4.0; nueva fila **v1.1.0** (redacción completa de los 15 anuales, en paralelo con `audit-YYYY`); roadmap normativa pasa a \"post-v1.1\".
- Árbol de arquitectura incluye `docs/` (manual MkDocs) y los dos scripts nuevos (`render-charts.ts`, `render-anual-stubs.ts`).

### CHANGELOG

- **Backfill de `[0.3.0] - 2026-04-27`** — la release de v0.3.0 ya está publicada en GitHub pero el CHANGELOG nunca se actualizó. Lo arreglo aquí citando los 15 issues `audit-YYYY`, la `progreso.md` agregada, la plantilla PR `audit:` y el refresh de README/CONTRIBUTING.
- **Nueva entrada `[0.4.0] - 2026-04-29`** con added/changed/removed cubriendo:
  - Sitio MkDocs Material desplegado en GitHub Pages: 7 páginas de motor, progresividad-en-frio, 15 stubs anuales + index, auditoria/progreso, landing page.
  - `scripts/render-charts.ts` (3 SVGs) y `scripts/render-anual-stubs.ts` (15 stubs auto-generados desde `obtenerParametros()`).
  - `.github/workflows/docs.yml` (build + deploy a Pages).
  - `requirements-docs.txt` y `mkdocs.yml`.
  - `eslint.config.js` ajustado para ignorar `.venv-*/` y `site/`.
  - `auditoria/progreso.md` con columna **Manual**.
  - `SECURITY.md` removido.
- Enlaces de comparación actualizados a `v0.4.0...HEAD`.

## Flujo después del merge

1. Este PR aterriza en `develop` y cierra #40.
2. Abro PR \"release\" `develop → main` (sin nuevos commits, sólo promueve el estado completo de develop).
3. Tras merge a `main`: el workflow `Docs` dispara el job `deploy` por primera vez → sitio live en `ceballosiker.github.io/auditor-irpf-es`.
4. Tag `v0.4.0` sobre el merge commit + GitHub Release con notas extraídas del CHANGELOG.

> **Recordatorio**: para que el deploy funcione, **Settings → Pages → Source** debe estar en **\"GitHub Actions\"**. El job de `build` sigue pasando sin ese ajuste, sólo `deploy` lo necesita.

## Test plan

- [x] `npm test` — 664 tests passing (incluyendo el version test actualizado).
- [x] `npm run typecheck`, `npm run lint`, `npm run format:check` — verde.
- [x] `mkdocs build --strict` localmente — 0 warnings.
- [ ] CI verde en este PR.

Closes #40
Refs #4