### PR TITLE
Release v0.4.0 — Manual divulgativo (Phase 3)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,58 @@
+name: Docs
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [develop, main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build site (strict)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+          cache-dependency-path: requirements-docs.txt
+
+      - name: Install dependencies
+        run: pip install -r requirements-docs.txt
+
+      - name: Build with strict mode
+        run: mkdocs build --strict
+
+      - name: Upload Pages artifact
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    name: Deploy to GitHub Pages
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -138,6 +138,7 @@ celerybeat.pid
 .env
 .envrc
 .venv
+.venv-*/
 env/
 venv/
 ENV/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,48 @@ El formato sigue [Keep a Changelog](https://keepachangelog.com/es-ES/1.1.0/) y e
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-04-29
+
+Manual divulgativo del motor publicado en GitHub Pages: explica la cadena de cálculo paso a paso y la **progresividad en frío** en lenguaje llano, con gráficos generados desde el propio motor.
+
+### Added
+
+- Sitio MkDocs Material bajo `docs/`, desplegado en <https://ceballosiker.github.io/auditor-irpf-es/>:
+  - `motor/01-cotizacion.md` … `motor/07-smi-y-43.md` — siete páginas trazando la cadena fiscal (cotización, SS, MEI, Solidaridad, Art. 19, Art. 20, escala IRPF + mínimo personal como cuota, deducción SMI, tope 43 %), con permalinks commit-pinned a `src/`.
+  - `progresividad-en-frio.md` — concepto + ejemplo numérico con bruto nominal fijo en 30 000 € de 2012 a 2026, mostrando una caída de 6 549 € reales de neto.
+  - `anual/2012.md` … `anual/2026.md` + `anual/index.md` — 15 stubs auto-generados desde `obtenerParametros()` (la redacción completa con prosa BOE llegará en v1.1.0).
+  - `auditoria/progreso.md` ya existente, ahora linkeable desde el manual con columna **Manual** indicando estado de cada año.
+  - `index.md`, `contribuir.md` — landing page con misión, audiencias y guía rápida por perfil.
+- `scripts/render-charts.ts` — renderer SVG hand-rolled (sin Vega/Chart.js) que produce 3 gráficos para el manual a partir de `src/pipeline.ts` y `src/inflacion.ts`. Idempotente vía `npm run charts`.
+- `scripts/render-anual-stubs.ts` — generador de los 15 stubs anuales desde `obtenerParametros()`. Idempotente vía `npm run anual:stubs`. Encadena `prettier --write` para que la salida sea siempre prettier-clean.
+- `.github/workflows/docs.yml` — workflow GitHub Pages: `mkdocs build --strict` en cada PR a `develop`/`main`; deploy vía `actions/deploy-pages@v4` en push a `main`. Concurrency group `pages` con `cancel-in-progress: false`.
+- `requirements-docs.txt` — `mkdocs 1.6.1`, `mkdocs-material 9.5.49`, `pymdown-extensions 10.12` (pinned).
+- `mkdocs.yml` — tema Material, paleta light/dark, `repo_url`, `edit_uri` apuntando a `develop/docs/`, navegación completa.
+
+### Changed
+
+- README — nuevo aviso de una línea sobre el doble propósito del repo (proyecto + práctica de flujos OSS asistidos por agente). Sección "Manual divulgativo" con enlace al sitio publicado. Estado actualizado a v0.4.0. Roadmap añade fila para `v1.1.0` (redacción completa de los anuales). Árbol de arquitectura incluye `docs/` y los scripts nuevos.
+- `eslint.config.js` — añade `.venv-*/` y `site/` a ignores para que `npm run lint` no se rompa en local cuando existen artefactos de mkdocs.
+- `docs/auditoria/progreso.md` — nueva columna **Manual** marcando el estado (`stub` / `redactado`) de cada `anual/YYYY.md`.
+
+### Removed
+
+- `SECURITY.md` — era un stub de una tabla sin contenido real; para un repo pre-1.0 educativo no aporta valor.
+
+## [0.3.0] - 2026-04-27
+
+Workflow de auditoría fiscal año a año: 15 issues `audit-YYYY` con checklist normativo + referencias BOE, abriendo la puerta a fiscalistas no-técnicos.
+
+### Added
+
+- 15 issues de auditoría (`audit-2012` … `audit-2026`, #17–#31) etiquetados `area/fiscal` + `type/audit` + `audit/<year>`. Cada issue lleva checklist por elemento (base máx, tipos SS, MEI, Solidaridad, escala IRPF, gastos Art. 19, reducción Art. 20, mínimo personal, mínimo exento, tope 43 %, deducción SMI) con permalinks al motor anclados al SHA de v0.2.0.
+- `docs/auditoria/progreso.md` — tabla agregada de progreso 2012–2026 enlazando a cada issue, con columnas para los elementos opcionales (MEI 2023+, Solidaridad 2025+, SMI 2025+).
+- `.github/PULL_REQUEST_TEMPLATE/audit.md` — plantilla específica para PRs `audit:` (correcciones normativas), accesible vía `?template=audit.md`. Incluye sección para referencia BOE y casillas que recuerdan la regeneración del fixture afectado.
+
+### Changed
+
+- README y `CONTRIBUTING.md` actualizados con la guía del workflow de auditoría: cómo reclamar un año, cómo validar contra el BOE, cómo abrir un PR `audit:` cuando se detecta una discrepancia.
+
 ## [0.2.0] - 2026-04-27
 
 Port del motor de cálculo desde Python a TypeScript, validado al céntimo contra los fixtures-oráculo de v0.1.0.
@@ -51,6 +93,8 @@ Primera release pública. Establece los cimientos para el porting del motor a Ty
 
 - README reformulado para reflejar la misión pública (democratizar el cálculo del IRPF), la llamada a tres perfiles colaboradores (fiscalistas, _techies_, divulgadores) y el pivote a TypeScript.
 
-[Unreleased]: https://github.com/ceballosiker/auditor-irpf-es/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/ceballosiker/auditor-irpf-es/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/ceballosiker/auditor-irpf-es/releases/tag/v0.4.0
+[0.3.0]: https://github.com/ceballosiker/auditor-irpf-es/releases/tag/v0.3.0
 [0.2.0]: https://github.com/ceballosiker/auditor-irpf-es/releases/tag/v0.2.0
 [0.1.0]: https://github.com/ceballosiker/auditor-irpf-es/releases/tag/v0.1.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,6 +114,22 @@ npm run test:coverage
 
 Los fixtures bajo `tests/fixtures/golden_YYYY.json` son **inmutables** salvo cuando una corrección de auditoría (`audit:`) modifique un valor normativo. En ese caso el mismo PR debe regenerarlos vía `python3 scripts/generate_fixtures.py` y documentar el motivo (referencia BOE) en el commit.
 
+## Manual divulgativo (MkDocs)
+
+El sitio bajo [`docs/`](docs/) se construye con MkDocs Material. Para iterar localmente:
+
+```bash
+python3 -m venv .venv-docs && .venv-docs/bin/pip install -r requirements-docs.txt
+.venv-docs/bin/mkdocs serve
+```
+
+Hay dos artefactos generados desde el motor TypeScript que viven dentro de `docs/`:
+
+- **`docs/assets/*.svg`** — gráficos para la página `progresividad-en-frio.md`. Regenerar con `npm run charts` cada vez que cambie `src/inflacion.ts`, `src/pipeline.ts` o el parámetro de un año relevante (los charts están pinned al SHA implícito del momento de la regeneración).
+- **`docs/anual/YYYY.md` + `docs/anual/index.md`** — los stubs anuales con los parámetros vigentes leídos desde `obtenerParametros()`. Regenerar con `npm run anual:stubs`.
+
+Ambos comandos son idempotentes y deterministas. Si una corrección de auditoría cambia un valor en `src/normativa.ts`, ejecuta los dos comandos en el mismo PR para que el manual no quede desincronizado del motor.
+
 ## Para fiscalistas
 
 Hay 15 issues de auditoría abiertos, uno por año fiscal 2012–2026. La tabla agregada de progreso vive en [`docs/auditoria/progreso.md`](docs/auditoria/progreso.md) y enlaza a cada issue. Cada issue contiene un checklist normativo con permalinks al motor (`src/normativa.ts`) anclados al commit de la última release.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 ![License](https://img.shields.io/badge/license-MIT-green.svg)
 ![Estado](<https://img.shields.io/badge/estado-en%20curso%20(v0.3)-yellow.svg>)
 
+> **Aviso.** El objetivo de este repositorio es **practicar flujos de trabajo OSS con asistencia de agentes de IA** (Claude Code).
+
 Auditor fiscal que calcula el salario neto en España (2012–2026) euro a euro: IRPF, Seguridad Social, MEI y Cuota de Solidaridad, con análisis de pérdida de poder adquisitivo ajustada a la inflación real (IPC oficial del INE). Se expondrá como una **calculadora interactiva 100 % en el navegador** (sin servidor) acompañada de un manual divulgativo y un proceso de auditoría pública año a año.
 
 > **Estado actual:** motor TypeScript completo y validado al céntimo contra los fixtures-oráculo de la implementación Python original (v0.2.0, 2026-04). Fase en curso (v0.3.0): **workflow de auditoría fiscal** con 15 issues abiertos (uno por año fiscal 2012–2026), cada uno con checklist normativo y permalinks al motor. Ver [`docs/auditoria/progreso.md`](docs/auditoria/progreso.md).

--- a/README.md
+++ b/README.md
@@ -3,13 +3,18 @@
 ![TypeScript](https://img.shields.io/badge/typescript-5.5%2B-blue.svg)
 ![Node](https://img.shields.io/badge/node-%3E%3D18.18-brightgreen.svg)
 ![License](https://img.shields.io/badge/license-MIT-green.svg)
-![Estado](<https://img.shields.io/badge/estado-en%20curso%20(v0.3)-yellow.svg>)
+![Estado](<https://img.shields.io/badge/estado-en%20curso%20(v0.4)-yellow.svg>)
+[![Manual](https://img.shields.io/badge/manual-ceballosiker.github.io-blue.svg)](https://ceballosiker.github.io/auditor-irpf-es/)
 
 > **Aviso.** El objetivo de este repositorio es **practicar flujos de trabajo OSS con asistencia de agentes de IA** (Claude Code).
 
 Auditor fiscal que calcula el salario neto en España (2012–2026) euro a euro: IRPF, Seguridad Social, MEI y Cuota de Solidaridad, con análisis de pérdida de poder adquisitivo ajustada a la inflación real (IPC oficial del INE). Se expondrá como una **calculadora interactiva 100 % en el navegador** (sin servidor) acompañada de un manual divulgativo y un proceso de auditoría pública año a año.
 
-> **Estado actual:** motor TypeScript completo y validado al céntimo contra los fixtures-oráculo de la implementación Python original (v0.2.0, 2026-04). Fase en curso (v0.3.0): **workflow de auditoría fiscal** con 15 issues abiertos (uno por año fiscal 2012–2026), cada uno con checklist normativo y permalinks al motor. Ver [`docs/auditoria/progreso.md`](docs/auditoria/progreso.md).
+> **Estado actual:** motor TypeScript completo y validado al céntimo (v0.2.0), workflow de auditoría fiscal con 15 issues `audit-YYYY` abiertos (v0.3.0), y **manual divulgativo publicado** en GitHub Pages (v0.4.0). Próximo hito: calculadora web interactiva (v1.0.0).
+
+## 📖 Manual divulgativo
+
+El manual está publicado en **<https://ceballosiker.github.io/auditor-irpf-es/>**. Contiene siete páginas explicando paso a paso la cadena de cálculo (cotización, SS, MEI/Solidaridad, Art. 19/20, escala IRPF, SMI/tope 43 %), una página dedicada a la **progresividad en frío** con gráficos generados desde el propio motor, y un esqueleto de 15 resúmenes anuales (uno por año entre 2012 y 2026) cuya redacción completa irá llegando en `v1.1.0` en paralelo con la auditoría fiscal.
 
 ---
 
@@ -59,17 +64,18 @@ Para maximizar la precisión antes de ampliar casuística, el motor modela delib
 
 ### Hoja de ruta de desarrollo
 
-| Versión                 | Hito                                                                                                        |
-| ----------------------- | ----------------------------------------------------------------------------------------------------------- |
-| **v0.1.0** ✅           | Infraestructura OSS, tooling TypeScript, fixtures JSON desde el motor Python (oráculo).                     |
-| **v0.2.0** ✅           | Port del motor a TypeScript validado al céntimo contra los fixtures de v0.1.0.                              |
-| **v0.3.0** _(en curso)_ | Workflow de auditoría fiscal: 15 issues (uno por año, 2012–2026) con checklist normativo + referencias BOE. |
-| **v0.4.0**              | Manual divulgativo en MkDocs publicado en GitHub Pages.                                                     |
-| **v1.0.0**              | Calculadora web interactiva: SPA estático, 100 % en el navegador, GitHub Pages.                             |
+| Versión       | Hito                                                                                                        |
+| ------------- | ----------------------------------------------------------------------------------------------------------- |
+| **v0.1.0** ✅ | Infraestructura OSS, tooling TypeScript, fixtures JSON desde el motor Python (oráculo).                     |
+| **v0.2.0** ✅ | Port del motor a TypeScript validado al céntimo contra los fixtures de v0.1.0.                              |
+| **v0.3.0** ✅ | Workflow de auditoría fiscal: 15 issues (uno por año, 2012–2026) con checklist normativo + referencias BOE. |
+| **v0.4.0** ✅ | Manual divulgativo en MkDocs Material publicado en GitHub Pages.                                            |
+| **v1.0.0**    | Calculadora web interactiva: SPA estático, 100 % en el navegador, GitHub Pages.                             |
+| **v1.1.0**    | Redacción completa de los 15 resúmenes anuales con referencias BOE, en paralelo con los `audit-YYYY`.       |
 
 Sigue el progreso en los [issues abiertos](https://github.com/ceballosiker/auditor-irpf-es/issues) y [milestones](https://github.com/ceballosiker/auditor-irpf-es/milestones).
 
-### Hoja de ruta normativa (post-v1.0)
+### Hoja de ruta normativa (post-v1.1)
 
 - Tramos autonómicos específicos por Comunidad Autónoma.
 - Deducciones familiares (hijos, ascendientes, discapacidad).
@@ -137,8 +143,17 @@ Para regenerar los fixtures JSON (operación idempotente):
 ├── test/                         # Vitest (664 cases: fixtures + invariantes + smoke)
 ├── tests/fixtures/               # Golden JSON fixtures: oráculo inmutable
 │   └── golden_YYYY.json          # 10 brutos representativos por año (2012-2026)
+├── docs/                         # Manual MkDocs Material (GitHub Pages)
+│   ├── index.md, contribuir.md
+│   ├── motor/                    # 7 páginas: cadena de cálculo paso a paso
+│   ├── progresividad-en-frio.md  # Concepto + gráficos generados del motor
+│   ├── anual/                    # Stubs 2012-2026 (redacción completa en v1.1.0)
+│   ├── auditoria/progreso.md     # Estado de los 15 audit-YYYY
+│   └── assets/*.svg              # Charts hand-rolled desde src/pipeline.ts
 ├── scripts/
-│   └── generate_fixtures.py      # Regenera fixtures desde el motor Python
+│   ├── generate_fixtures.py      # Regenera fixtures desde el motor Python
+│   ├── render-charts.ts          # `npm run charts` — SVGs para el manual
+│   └── render-anual-stubs.ts     # `npm run anual:stubs` — stubs anuales
 ├── legacy/python-reference/      # Motor Python original (archivado tras v0.2.0)
 │   ├── Calculo_Salario_IRPF.py
 │   └── requirements.txt

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,8 +1,0 @@
-# Política de seguridad
-
-## Versiones soportadas
-
-| Versión | Soporte                   |
-| ------- | ------------------------- |
-| 0.x     | Sí (en desarrollo activo) |
-| < 0.1   | No                        |

--- a/docs/anual/2012.md
+++ b/docs/anual/2012.md
@@ -1,0 +1,30 @@
+# Normativa 2012
+
+> **Pendiente de redacción.** Esta página es un stub. La redacción completa con referencias BOE llegará en Phase 5 (v1.1.0), en paralelo con la validación de [`audit-2012`](https://github.com/ceballosiker/auditor-irpf-es/issues/17).
+
+## Parámetros vigentes
+
+| Parámetro                                | Valor       |
+| ---------------------------------------- | ----------- |
+| Base máxima cotización                   | 39 150,00 € |
+| Tipo SS total empresa                    | 31,40 %     |
+| Tipo SS total trabajador                 | 6,35 %      |
+| MEI                                      | no aplica   |
+| Cuota de Solidaridad                     | no aplica   |
+| Mínimo personal contribuyente            | 5 151,00 €  |
+| Mínimo exento de retención               | 11 162,00 € |
+| Gastos fijos Art. 19                     | 0,00 €      |
+| Tramos IRPF (incl. autonómico = estatal) | 7           |
+| Deducción SMI                            | no aplica   |
+
+Estos valores se generan directamente de `src/normativa.ts`. Para auditarlos contra el BOE, ver el [issue de auditoría](https://github.com/ceballosiker/auditor-irpf-es/issues/17).
+
+## Cómo aportar a esta página
+
+1. Abre el [issue `audit-2012`](https://github.com/ceballosiker/auditor-irpf-es/issues/17) y reclama el slot.
+2. Valida cada elemento del checklist contra el BOE.
+3. Cuando el año esté validado, manda un PR con la redacción completa de esta página: cambios respecto al año anterior, motivación legal, cómo afectan a la curva de neto.
+
+---
+
+[Índice anual](index.md) · [2013 →](2013.md)

--- a/docs/anual/2013.md
+++ b/docs/anual/2013.md
@@ -1,0 +1,30 @@
+# Normativa 2013
+
+> **Pendiente de redacción.** Esta página es un stub. La redacción completa con referencias BOE llegará en Phase 5 (v1.1.0), en paralelo con la validación de [`audit-2013`](https://github.com/ceballosiker/auditor-irpf-es/issues/18).
+
+## Parámetros vigentes
+
+| Parámetro                                | Valor       |
+| ---------------------------------------- | ----------- |
+| Base máxima cotización                   | 41 108,40 € |
+| Tipo SS total empresa                    | 31,40 %     |
+| Tipo SS total trabajador                 | 6,35 %      |
+| MEI                                      | no aplica   |
+| Cuota de Solidaridad                     | no aplica   |
+| Mínimo personal contribuyente            | 5 151,00 €  |
+| Mínimo exento de retención               | 11 162,00 € |
+| Gastos fijos Art. 19                     | 0,00 €      |
+| Tramos IRPF (incl. autonómico = estatal) | 7           |
+| Deducción SMI                            | no aplica   |
+
+Estos valores se generan directamente de `src/normativa.ts`. Para auditarlos contra el BOE, ver el [issue de auditoría](https://github.com/ceballosiker/auditor-irpf-es/issues/18).
+
+## Cómo aportar a esta página
+
+1. Abre el [issue `audit-2013`](https://github.com/ceballosiker/auditor-irpf-es/issues/18) y reclama el slot.
+2. Valida cada elemento del checklist contra el BOE.
+3. Cuando el año esté validado, manda un PR con la redacción completa de esta página: cambios respecto al año anterior, motivación legal, cómo afectan a la curva de neto.
+
+---
+
+[← 2012](2012.md) · [Índice anual](index.md) · [2014 →](2014.md)

--- a/docs/anual/2014.md
+++ b/docs/anual/2014.md
@@ -1,0 +1,30 @@
+# Normativa 2014
+
+> **Pendiente de redacción.** Esta página es un stub. La redacción completa con referencias BOE llegará en Phase 5 (v1.1.0), en paralelo con la validación de [`audit-2014`](https://github.com/ceballosiker/auditor-irpf-es/issues/19).
+
+## Parámetros vigentes
+
+| Parámetro                                | Valor       |
+| ---------------------------------------- | ----------- |
+| Base máxima cotización                   | 43 164,00 € |
+| Tipo SS total empresa                    | 31,40 %     |
+| Tipo SS total trabajador                 | 6,35 %      |
+| MEI                                      | no aplica   |
+| Cuota de Solidaridad                     | no aplica   |
+| Mínimo personal contribuyente            | 5 151,00 €  |
+| Mínimo exento de retención               | 11 162,00 € |
+| Gastos fijos Art. 19                     | 0,00 €      |
+| Tramos IRPF (incl. autonómico = estatal) | 7           |
+| Deducción SMI                            | no aplica   |
+
+Estos valores se generan directamente de `src/normativa.ts`. Para auditarlos contra el BOE, ver el [issue de auditoría](https://github.com/ceballosiker/auditor-irpf-es/issues/19).
+
+## Cómo aportar a esta página
+
+1. Abre el [issue `audit-2014`](https://github.com/ceballosiker/auditor-irpf-es/issues/19) y reclama el slot.
+2. Valida cada elemento del checklist contra el BOE.
+3. Cuando el año esté validado, manda un PR con la redacción completa de esta página: cambios respecto al año anterior, motivación legal, cómo afectan a la curva de neto.
+
+---
+
+[← 2013](2013.md) · [Índice anual](index.md) · [2015 →](2015.md)

--- a/docs/anual/2015.md
+++ b/docs/anual/2015.md
@@ -1,0 +1,30 @@
+# Normativa 2015
+
+> **Pendiente de redacción.** Esta página es un stub. La redacción completa con referencias BOE llegará en Phase 5 (v1.1.0), en paralelo con la validación de [`audit-2015`](https://github.com/ceballosiker/auditor-irpf-es/issues/20).
+
+## Parámetros vigentes
+
+| Parámetro                                | Valor       |
+| ---------------------------------------- | ----------- |
+| Base máxima cotización                   | 43 272,00 € |
+| Tipo SS total empresa                    | 31,40 %     |
+| Tipo SS total trabajador                 | 6,35 %      |
+| MEI                                      | no aplica   |
+| Cuota de Solidaridad                     | no aplica   |
+| Mínimo personal contribuyente            | 5 550,00 €  |
+| Mínimo exento de retención               | 12 000,00 € |
+| Gastos fijos Art. 19                     | 2 000,00 €  |
+| Tramos IRPF (incl. autonómico = estatal) | 5           |
+| Deducción SMI                            | no aplica   |
+
+Estos valores se generan directamente de `src/normativa.ts`. Para auditarlos contra el BOE, ver el [issue de auditoría](https://github.com/ceballosiker/auditor-irpf-es/issues/20).
+
+## Cómo aportar a esta página
+
+1. Abre el [issue `audit-2015`](https://github.com/ceballosiker/auditor-irpf-es/issues/20) y reclama el slot.
+2. Valida cada elemento del checklist contra el BOE.
+3. Cuando el año esté validado, manda un PR con la redacción completa de esta página: cambios respecto al año anterior, motivación legal, cómo afectan a la curva de neto.
+
+---
+
+[← 2014](2014.md) · [Índice anual](index.md) · [2016 →](2016.md)

--- a/docs/anual/2016.md
+++ b/docs/anual/2016.md
@@ -1,0 +1,30 @@
+# Normativa 2016
+
+> **Pendiente de redacción.** Esta página es un stub. La redacción completa con referencias BOE llegará en Phase 5 (v1.1.0), en paralelo con la validación de [`audit-2016`](https://github.com/ceballosiker/auditor-irpf-es/issues/21).
+
+## Parámetros vigentes
+
+| Parámetro                                | Valor       |
+| ---------------------------------------- | ----------- |
+| Base máxima cotización                   | 43 704,00 € |
+| Tipo SS total empresa                    | 31,40 %     |
+| Tipo SS total trabajador                 | 6,35 %      |
+| MEI                                      | no aplica   |
+| Cuota de Solidaridad                     | no aplica   |
+| Mínimo personal contribuyente            | 5 550,00 €  |
+| Mínimo exento de retención               | 12 000,00 € |
+| Gastos fijos Art. 19                     | 2 000,00 €  |
+| Tramos IRPF (incl. autonómico = estatal) | 5           |
+| Deducción SMI                            | no aplica   |
+
+Estos valores se generan directamente de `src/normativa.ts`. Para auditarlos contra el BOE, ver el [issue de auditoría](https://github.com/ceballosiker/auditor-irpf-es/issues/21).
+
+## Cómo aportar a esta página
+
+1. Abre el [issue `audit-2016`](https://github.com/ceballosiker/auditor-irpf-es/issues/21) y reclama el slot.
+2. Valida cada elemento del checklist contra el BOE.
+3. Cuando el año esté validado, manda un PR con la redacción completa de esta página: cambios respecto al año anterior, motivación legal, cómo afectan a la curva de neto.
+
+---
+
+[← 2015](2015.md) · [Índice anual](index.md) · [2017 →](2017.md)

--- a/docs/anual/2017.md
+++ b/docs/anual/2017.md
@@ -1,0 +1,30 @@
+# Normativa 2017
+
+> **Pendiente de redacción.** Esta página es un stub. La redacción completa con referencias BOE llegará en Phase 5 (v1.1.0), en paralelo con la validación de [`audit-2017`](https://github.com/ceballosiker/auditor-irpf-es/issues/22).
+
+## Parámetros vigentes
+
+| Parámetro                                | Valor       |
+| ---------------------------------------- | ----------- |
+| Base máxima cotización                   | 45 014,40 € |
+| Tipo SS total empresa                    | 31,40 %     |
+| Tipo SS total trabajador                 | 6,35 %      |
+| MEI                                      | no aplica   |
+| Cuota de Solidaridad                     | no aplica   |
+| Mínimo personal contribuyente            | 5 550,00 €  |
+| Mínimo exento de retención               | 12 000,00 € |
+| Gastos fijos Art. 19                     | 2 000,00 €  |
+| Tramos IRPF (incl. autonómico = estatal) | 5           |
+| Deducción SMI                            | no aplica   |
+
+Estos valores se generan directamente de `src/normativa.ts`. Para auditarlos contra el BOE, ver el [issue de auditoría](https://github.com/ceballosiker/auditor-irpf-es/issues/22).
+
+## Cómo aportar a esta página
+
+1. Abre el [issue `audit-2017`](https://github.com/ceballosiker/auditor-irpf-es/issues/22) y reclama el slot.
+2. Valida cada elemento del checklist contra el BOE.
+3. Cuando el año esté validado, manda un PR con la redacción completa de esta página: cambios respecto al año anterior, motivación legal, cómo afectan a la curva de neto.
+
+---
+
+[← 2016](2016.md) · [Índice anual](index.md) · [2018 →](2018.md)

--- a/docs/anual/2018.md
+++ b/docs/anual/2018.md
@@ -1,0 +1,30 @@
+# Normativa 2018
+
+> **Pendiente de redacción.** Esta página es un stub. La redacción completa con referencias BOE llegará en Phase 5 (v1.1.0), en paralelo con la validación de [`audit-2018`](https://github.com/ceballosiker/auditor-irpf-es/issues/23).
+
+## Parámetros vigentes
+
+| Parámetro                                | Valor       |
+| ---------------------------------------- | ----------- |
+| Base máxima cotización                   | 45 014,40 € |
+| Tipo SS total empresa                    | 31,40 %     |
+| Tipo SS total trabajador                 | 6,35 %      |
+| MEI                                      | no aplica   |
+| Cuota de Solidaridad                     | no aplica   |
+| Mínimo personal contribuyente            | 5 550,00 €  |
+| Mínimo exento de retención               | 12 643,00 € |
+| Gastos fijos Art. 19                     | 2 000,00 €  |
+| Tramos IRPF (incl. autonómico = estatal) | 5           |
+| Deducción SMI                            | no aplica   |
+
+Estos valores se generan directamente de `src/normativa.ts`. Para auditarlos contra el BOE, ver el [issue de auditoría](https://github.com/ceballosiker/auditor-irpf-es/issues/23).
+
+## Cómo aportar a esta página
+
+1. Abre el [issue `audit-2018`](https://github.com/ceballosiker/auditor-irpf-es/issues/23) y reclama el slot.
+2. Valida cada elemento del checklist contra el BOE.
+3. Cuando el año esté validado, manda un PR con la redacción completa de esta página: cambios respecto al año anterior, motivación legal, cómo afectan a la curva de neto.
+
+---
+
+[← 2017](2017.md) · [Índice anual](index.md) · [2019 →](2019.md)

--- a/docs/anual/2019.md
+++ b/docs/anual/2019.md
@@ -1,0 +1,30 @@
+# Normativa 2019
+
+> **Pendiente de redacción.** Esta página es un stub. La redacción completa con referencias BOE llegará en Phase 5 (v1.1.0), en paralelo con la validación de [`audit-2019`](https://github.com/ceballosiker/auditor-irpf-es/issues/24).
+
+## Parámetros vigentes
+
+| Parámetro                                | Valor       |
+| ---------------------------------------- | ----------- |
+| Base máxima cotización                   | 48 841,20 € |
+| Tipo SS total empresa                    | 31,40 %     |
+| Tipo SS total trabajador                 | 6,35 %      |
+| MEI                                      | no aplica   |
+| Cuota de Solidaridad                     | no aplica   |
+| Mínimo personal contribuyente            | 5 550,00 €  |
+| Mínimo exento de retención               | 14 000,00 € |
+| Gastos fijos Art. 19                     | 2 000,00 €  |
+| Tramos IRPF (incl. autonómico = estatal) | 5           |
+| Deducción SMI                            | no aplica   |
+
+Estos valores se generan directamente de `src/normativa.ts`. Para auditarlos contra el BOE, ver el [issue de auditoría](https://github.com/ceballosiker/auditor-irpf-es/issues/24).
+
+## Cómo aportar a esta página
+
+1. Abre el [issue `audit-2019`](https://github.com/ceballosiker/auditor-irpf-es/issues/24) y reclama el slot.
+2. Valida cada elemento del checklist contra el BOE.
+3. Cuando el año esté validado, manda un PR con la redacción completa de esta página: cambios respecto al año anterior, motivación legal, cómo afectan a la curva de neto.
+
+---
+
+[← 2018](2018.md) · [Índice anual](index.md) · [2020 →](2020.md)

--- a/docs/anual/2020.md
+++ b/docs/anual/2020.md
@@ -1,0 +1,30 @@
+# Normativa 2020
+
+> **Pendiente de redacción.** Esta página es un stub. La redacción completa con referencias BOE llegará en Phase 5 (v1.1.0), en paralelo con la validación de [`audit-2020`](https://github.com/ceballosiker/auditor-irpf-es/issues/25).
+
+## Parámetros vigentes
+
+| Parámetro                                | Valor       |
+| ---------------------------------------- | ----------- |
+| Base máxima cotización                   | 48 841,20 € |
+| Tipo SS total empresa                    | 31,40 %     |
+| Tipo SS total trabajador                 | 6,35 %      |
+| MEI                                      | no aplica   |
+| Cuota de Solidaridad                     | no aplica   |
+| Mínimo personal contribuyente            | 5 550,00 €  |
+| Mínimo exento de retención               | 14 000,00 € |
+| Gastos fijos Art. 19                     | 2 000,00 €  |
+| Tramos IRPF (incl. autonómico = estatal) | 5           |
+| Deducción SMI                            | no aplica   |
+
+Estos valores se generan directamente de `src/normativa.ts`. Para auditarlos contra el BOE, ver el [issue de auditoría](https://github.com/ceballosiker/auditor-irpf-es/issues/25).
+
+## Cómo aportar a esta página
+
+1. Abre el [issue `audit-2020`](https://github.com/ceballosiker/auditor-irpf-es/issues/25) y reclama el slot.
+2. Valida cada elemento del checklist contra el BOE.
+3. Cuando el año esté validado, manda un PR con la redacción completa de esta página: cambios respecto al año anterior, motivación legal, cómo afectan a la curva de neto.
+
+---
+
+[← 2019](2019.md) · [Índice anual](index.md) · [2021 →](2021.md)

--- a/docs/anual/2021.md
+++ b/docs/anual/2021.md
@@ -1,0 +1,30 @@
+# Normativa 2021
+
+> **Pendiente de redacción.** Esta página es un stub. La redacción completa con referencias BOE llegará en Phase 5 (v1.1.0), en paralelo con la validación de [`audit-2021`](https://github.com/ceballosiker/auditor-irpf-es/issues/26).
+
+## Parámetros vigentes
+
+| Parámetro                                | Valor       |
+| ---------------------------------------- | ----------- |
+| Base máxima cotización                   | 48 841,20 € |
+| Tipo SS total empresa                    | 31,40 %     |
+| Tipo SS total trabajador                 | 6,35 %      |
+| MEI                                      | no aplica   |
+| Cuota de Solidaridad                     | no aplica   |
+| Mínimo personal contribuyente            | 5 550,00 €  |
+| Mínimo exento de retención               | 14 000,00 € |
+| Gastos fijos Art. 19                     | 2 000,00 €  |
+| Tramos IRPF (incl. autonómico = estatal) | 6           |
+| Deducción SMI                            | no aplica   |
+
+Estos valores se generan directamente de `src/normativa.ts`. Para auditarlos contra el BOE, ver el [issue de auditoría](https://github.com/ceballosiker/auditor-irpf-es/issues/26).
+
+## Cómo aportar a esta página
+
+1. Abre el [issue `audit-2021`](https://github.com/ceballosiker/auditor-irpf-es/issues/26) y reclama el slot.
+2. Valida cada elemento del checklist contra el BOE.
+3. Cuando el año esté validado, manda un PR con la redacción completa de esta página: cambios respecto al año anterior, motivación legal, cómo afectan a la curva de neto.
+
+---
+
+[← 2020](2020.md) · [Índice anual](index.md) · [2022 →](2022.md)

--- a/docs/anual/2022.md
+++ b/docs/anual/2022.md
@@ -1,0 +1,30 @@
+# Normativa 2022
+
+> **Pendiente de redacción.** Esta página es un stub. La redacción completa con referencias BOE llegará en Phase 5 (v1.1.0), en paralelo con la validación de [`audit-2022`](https://github.com/ceballosiker/auditor-irpf-es/issues/27).
+
+## Parámetros vigentes
+
+| Parámetro                                | Valor       |
+| ---------------------------------------- | ----------- |
+| Base máxima cotización                   | 49 672,80 € |
+| Tipo SS total empresa                    | 31,40 %     |
+| Tipo SS total trabajador                 | 6,35 %      |
+| MEI                                      | no aplica   |
+| Cuota de Solidaridad                     | no aplica   |
+| Mínimo personal contribuyente            | 5 550,00 €  |
+| Mínimo exento de retención               | 14 000,00 € |
+| Gastos fijos Art. 19                     | 2 000,00 €  |
+| Tramos IRPF (incl. autonómico = estatal) | 6           |
+| Deducción SMI                            | no aplica   |
+
+Estos valores se generan directamente de `src/normativa.ts`. Para auditarlos contra el BOE, ver el [issue de auditoría](https://github.com/ceballosiker/auditor-irpf-es/issues/27).
+
+## Cómo aportar a esta página
+
+1. Abre el [issue `audit-2022`](https://github.com/ceballosiker/auditor-irpf-es/issues/27) y reclama el slot.
+2. Valida cada elemento del checklist contra el BOE.
+3. Cuando el año esté validado, manda un PR con la redacción completa de esta página: cambios respecto al año anterior, motivación legal, cómo afectan a la curva de neto.
+
+---
+
+[← 2021](2021.md) · [Índice anual](index.md) · [2023 →](2023.md)

--- a/docs/anual/2023.md
+++ b/docs/anual/2023.md
@@ -1,0 +1,30 @@
+# Normativa 2023
+
+> **Pendiente de redacción.** Esta página es un stub. La redacción completa con referencias BOE llegará en Phase 5 (v1.1.0), en paralelo con la validación de [`audit-2023`](https://github.com/ceballosiker/auditor-irpf-es/issues/28).
+
+## Parámetros vigentes
+
+| Parámetro                                | Valor                                       |
+| ---------------------------------------- | ------------------------------------------- |
+| Base máxima cotización                   | 53 946,00 €                                 |
+| Tipo SS total empresa                    | 31,90 %                                     |
+| Tipo SS total trabajador                 | 6,45 %                                      |
+| MEI                                      | 0,60 % (empresa 0,50 % · trabajador 0,10 %) |
+| Cuota de Solidaridad                     | no aplica                                   |
+| Mínimo personal contribuyente            | 5 550,00 €                                  |
+| Mínimo exento de retención               | 15 000,00 €                                 |
+| Gastos fijos Art. 19                     | 2 000,00 €                                  |
+| Tramos IRPF (incl. autonómico = estatal) | 6                                           |
+| Deducción SMI                            | no aplica                                   |
+
+Estos valores se generan directamente de `src/normativa.ts`. Para auditarlos contra el BOE, ver el [issue de auditoría](https://github.com/ceballosiker/auditor-irpf-es/issues/28).
+
+## Cómo aportar a esta página
+
+1. Abre el [issue `audit-2023`](https://github.com/ceballosiker/auditor-irpf-es/issues/28) y reclama el slot.
+2. Valida cada elemento del checklist contra el BOE.
+3. Cuando el año esté validado, manda un PR con la redacción completa de esta página: cambios respecto al año anterior, motivación legal, cómo afectan a la curva de neto.
+
+---
+
+[← 2022](2022.md) · [Índice anual](index.md) · [2024 →](2024.md)

--- a/docs/anual/2024.md
+++ b/docs/anual/2024.md
@@ -1,0 +1,30 @@
+# Normativa 2024
+
+> **Pendiente de redacción.** Esta página es un stub. La redacción completa con referencias BOE llegará en Phase 5 (v1.1.0), en paralelo con la validación de [`audit-2024`](https://github.com/ceballosiker/auditor-irpf-es/issues/29).
+
+## Parámetros vigentes
+
+| Parámetro                                | Valor                                       |
+| ---------------------------------------- | ------------------------------------------- |
+| Base máxima cotización                   | 56 646,00 €                                 |
+| Tipo SS total empresa                    | 31,98 %                                     |
+| Tipo SS total trabajador                 | 6,47 %                                      |
+| MEI                                      | 0,70 % (empresa 0,58 % · trabajador 0,12 %) |
+| Cuota de Solidaridad                     | no aplica                                   |
+| Mínimo personal contribuyente            | 5 550,00 €                                  |
+| Mínimo exento de retención               | 15 876,00 €                                 |
+| Gastos fijos Art. 19                     | 2 000,00 €                                  |
+| Tramos IRPF (incl. autonómico = estatal) | 6                                           |
+| Deducción SMI                            | no aplica                                   |
+
+Estos valores se generan directamente de `src/normativa.ts`. Para auditarlos contra el BOE, ver el [issue de auditoría](https://github.com/ceballosiker/auditor-irpf-es/issues/29).
+
+## Cómo aportar a esta página
+
+1. Abre el [issue `audit-2024`](https://github.com/ceballosiker/auditor-irpf-es/issues/29) y reclama el slot.
+2. Valida cada elemento del checklist contra el BOE.
+3. Cuando el año esté validado, manda un PR con la redacción completa de esta página: cambios respecto al año anterior, motivación legal, cómo afectan a la curva de neto.
+
+---
+
+[← 2023](2023.md) · [Índice anual](index.md) · [2025 →](2025.md)

--- a/docs/anual/2025.md
+++ b/docs/anual/2025.md
@@ -1,0 +1,30 @@
+# Normativa 2025
+
+> **Pendiente de redacción.** Esta página es un stub. La redacción completa con referencias BOE llegará en Phase 5 (v1.1.0), en paralelo con la validación de [`audit-2025`](https://github.com/ceballosiker/auditor-irpf-es/issues/30).
+
+## Parámetros vigentes
+
+| Parámetro                                | Valor                                       |
+| ---------------------------------------- | ------------------------------------------- |
+| Base máxima cotización                   | 58 914,00 €                                 |
+| Tipo SS total empresa                    | 32,07 %                                     |
+| Tipo SS total trabajador                 | 6,48 %                                      |
+| MEI                                      | 0,80 % (empresa 0,67 % · trabajador 0,13 %) |
+| Cuota de Solidaridad                     | aplica (3 bandas sobre el exceso)           |
+| Mínimo personal contribuyente            | 5 550,00 €                                  |
+| Mínimo exento de retención               | 15 876,00 €                                 |
+| Gastos fijos Art. 19                     | 2 000,00 €                                  |
+| Tramos IRPF (incl. autonómico = estatal) | 6                                           |
+| Deducción SMI                            | aplica                                      |
+
+Estos valores se generan directamente de `src/normativa.ts`. Para auditarlos contra el BOE, ver el [issue de auditoría](https://github.com/ceballosiker/auditor-irpf-es/issues/30).
+
+## Cómo aportar a esta página
+
+1. Abre el [issue `audit-2025`](https://github.com/ceballosiker/auditor-irpf-es/issues/30) y reclama el slot.
+2. Valida cada elemento del checklist contra el BOE.
+3. Cuando el año esté validado, manda un PR con la redacción completa de esta página: cambios respecto al año anterior, motivación legal, cómo afectan a la curva de neto.
+
+---
+
+[← 2024](2024.md) · [Índice anual](index.md) · [2026 →](2026.md)

--- a/docs/anual/2026.md
+++ b/docs/anual/2026.md
@@ -1,0 +1,30 @@
+# Normativa 2026
+
+> **Pendiente de redacción.** Esta página es un stub. La redacción completa con referencias BOE llegará en Phase 5 (v1.1.0), en paralelo con la validación de [`audit-2026`](https://github.com/ceballosiker/auditor-irpf-es/issues/31).
+
+## Parámetros vigentes
+
+| Parámetro                                | Valor                                       |
+| ---------------------------------------- | ------------------------------------------- |
+| Base máxima cotización                   | 61 214,40 €                                 |
+| Tipo SS total empresa                    | 32,15 %                                     |
+| Tipo SS total trabajador                 | 6,50 %                                      |
+| MEI                                      | 0,90 % (empresa 0,75 % · trabajador 0,15 %) |
+| Cuota de Solidaridad                     | aplica (3 bandas sobre el exceso)           |
+| Mínimo personal contribuyente            | 5 550,00 €                                  |
+| Mínimo exento de retención               | 15 876,00 €                                 |
+| Gastos fijos Art. 19                     | 2 000,00 €                                  |
+| Tramos IRPF (incl. autonómico = estatal) | 6                                           |
+| Deducción SMI                            | aplica                                      |
+
+Estos valores se generan directamente de `src/normativa.ts`. Para auditarlos contra el BOE, ver el [issue de auditoría](https://github.com/ceballosiker/auditor-irpf-es/issues/31).
+
+## Cómo aportar a esta página
+
+1. Abre el [issue `audit-2026`](https://github.com/ceballosiker/auditor-irpf-es/issues/31) y reclama el slot.
+2. Valida cada elemento del checklist contra el BOE.
+3. Cuando el año esté validado, manda un PR con la redacción completa de esta página: cambios respecto al año anterior, motivación legal, cómo afectan a la curva de neto.
+
+---
+
+[← 2025](2025.md) · [Índice anual](index.md)

--- a/docs/anual/index.md
+++ b/docs/anual/index.md
@@ -1,0 +1,21 @@
+# Resúmenes anuales 2012–2026
+
+Una página por año entre 2012 y 2026. En la versión `v0.4.0` todas son **stubs**: contienen los parámetros vigentes (extraídos automáticamente de `src/normativa.ts`) y un enlace al `audit-YYYY` correspondiente. La redacción completa, con referencias BOE y análisis de cambios, llegará en Phase 5 (`v1.1.0`).
+
+| Año  | Página                    | Issue de auditoría                                               |
+| ---- | ------------------------- | ---------------------------------------------------------------- |
+| 2012 | [Normativa 2012](2012.md) | [#17](https://github.com/ceballosiker/auditor-irpf-es/issues/17) |
+| 2013 | [Normativa 2013](2013.md) | [#18](https://github.com/ceballosiker/auditor-irpf-es/issues/18) |
+| 2014 | [Normativa 2014](2014.md) | [#19](https://github.com/ceballosiker/auditor-irpf-es/issues/19) |
+| 2015 | [Normativa 2015](2015.md) | [#20](https://github.com/ceballosiker/auditor-irpf-es/issues/20) |
+| 2016 | [Normativa 2016](2016.md) | [#21](https://github.com/ceballosiker/auditor-irpf-es/issues/21) |
+| 2017 | [Normativa 2017](2017.md) | [#22](https://github.com/ceballosiker/auditor-irpf-es/issues/22) |
+| 2018 | [Normativa 2018](2018.md) | [#23](https://github.com/ceballosiker/auditor-irpf-es/issues/23) |
+| 2019 | [Normativa 2019](2019.md) | [#24](https://github.com/ceballosiker/auditor-irpf-es/issues/24) |
+| 2020 | [Normativa 2020](2020.md) | [#25](https://github.com/ceballosiker/auditor-irpf-es/issues/25) |
+| 2021 | [Normativa 2021](2021.md) | [#26](https://github.com/ceballosiker/auditor-irpf-es/issues/26) |
+| 2022 | [Normativa 2022](2022.md) | [#27](https://github.com/ceballosiker/auditor-irpf-es/issues/27) |
+| 2023 | [Normativa 2023](2023.md) | [#28](https://github.com/ceballosiker/auditor-irpf-es/issues/28) |
+| 2024 | [Normativa 2024](2024.md) | [#29](https://github.com/ceballosiker/auditor-irpf-es/issues/29) |
+| 2025 | [Normativa 2025](2025.md) | [#30](https://github.com/ceballosiker/auditor-irpf-es/issues/30) |
+| 2026 | [Normativa 2026](2026.md) | [#31](https://github.com/ceballosiker/auditor-irpf-es/issues/31) |

--- a/docs/assets/neto-real-bruto-real-fijo.svg
+++ b/docs/assets/neto-real-bruto-real-fijo.svg
@@ -1,0 +1,452 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 760 420" width="760" height="420" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif" font-size="13" role="img" aria-labelledby="neto-real-bruto-real-fijo-title neto-real-bruto-real-fijo-desc">
+<title id="neto-real-bruto-real-fijo-title">Neto real por bruto real, fiscalidad de cada año</title>
+<desc id="neto-real-bruto-real-fijo-desc">Para un mismo bruto medido en € constantes de 2026, qué neto real se obtiene aplicando la fiscalidad y SS de cada año. El espaciado vertical entre líneas mide el efecto neto de las reformas más la progresividad en frío.</desc>
+<rect width="760" height="420" fill="#ffffff" />
+<text x="80" y="35" font-size="16" font-weight="600" fill="#222">Neto real por bruto real, fiscalidad de cada año</text>
+<g transform="translate(80,60)">
+<line x1="0" y1="246.59" x2="510" y2="246.59" stroke="#e5e5e5" stroke-width="1" />
+<line x1="0" y1="181.60" x2="510" y2="181.60" stroke="#e5e5e5" stroke-width="1" />
+<line x1="0" y1="116.61" x2="510" y2="116.61" stroke="#e5e5e5" stroke-width="1" />
+<line x1="0" y1="51.62" x2="510" y2="51.62" stroke="#e5e5e5" stroke-width="1" />
+<line x1="0" y1="300" x2="510" y2="300" stroke="#333" stroke-width="1" />
+<line x1="0" y1="0" x2="0" y2="300" stroke="#333" stroke-width="1" />
+<line x1="39.23" y1="300" x2="39.23" y2="305" stroke="#333" stroke-width="1" />
+<text x="39.23" y="322" text-anchor="middle" fill="#444">20k €</text>
+<line x1="117.69" y1="300" x2="117.69" y2="305" stroke="#333" stroke-width="1" />
+<text x="117.69" y="322" text-anchor="middle" fill="#444">30k €</text>
+<line x1="196.15" y1="300" x2="196.15" y2="305" stroke="#333" stroke-width="1" />
+<text x="196.15" y="322" text-anchor="middle" fill="#444">40k €</text>
+<line x1="274.62" y1="300" x2="274.62" y2="305" stroke="#333" stroke-width="1" />
+<text x="274.62" y="322" text-anchor="middle" fill="#444">50k €</text>
+<line x1="353.08" y1="300" x2="353.08" y2="305" stroke="#333" stroke-width="1" />
+<text x="353.08" y="322" text-anchor="middle" fill="#444">60k €</text>
+<line x1="431.54" y1="300" x2="431.54" y2="305" stroke="#333" stroke-width="1" />
+<text x="431.54" y="322" text-anchor="middle" fill="#444">70k €</text>
+<line x1="510.00" y1="300" x2="510.00" y2="305" stroke="#333" stroke-width="1" />
+<text x="510.00" y="322" text-anchor="middle" fill="#444">80k €</text>
+<line x1="-5" y1="246.59" x2="0" y2="246.59" stroke="#333" stroke-width="1" />
+<text x="-10" y="250.59" text-anchor="end" fill="#444">20k €</text>
+<line x1="-5" y1="181.60" x2="0" y2="181.60" stroke="#333" stroke-width="1" />
+<text x="-10" y="185.60" text-anchor="end" fill="#444">30k €</text>
+<line x1="-5" y1="116.61" x2="0" y2="116.61" stroke="#333" stroke-width="1" />
+<text x="-10" y="120.61" text-anchor="end" fill="#444">40k €</text>
+<line x1="-5" y1="51.62" x2="0" y2="51.62" stroke="#333" stroke-width="1" />
+<text x="-10" y="55.62" text-anchor="end" fill="#444">50k €</text>
+<text x="255" y="348" text-anchor="middle" fill="#222" font-size="13">Bruto en € de 2026</text>
+<text transform="translate(-55,150) rotate(-90)" text-anchor="middle" fill="#222" font-size="13">Neto en € de 2026</text>
+<polyline points="0.00,286.36 7.85,283.07 15.69,279.78 23.54,276.49 31.38,273.12 39.23,268.54 47.08,263.96 54.92,259.38 62.77,254.80 70.62,250.22 78.46,245.64 86.31,241.06 94.15,236.48 102.00,231.90 109.85,227.50 117.69,223.24 125.54,218.97 133.38,214.71 141.23,210.45 149.08,206.19 156.92,201.93 164.77,197.67 172.62,193.41 180.46,189.15 188.31,184.89 196.15,180.63 204.00,176.37 211.85,172.11 219.69,167.85 227.54,163.59 235.38,159.33 243.23,155.07 251.08,150.81 258.92,146.54 266.77,142.28 274.62,138.12 282.46,134.47 290.31,130.63 298.15,126.73 306.00,122.83 313.85,118.93 321.69,115.03 329.54,111.13 337.38,107.23 345.23,103.33 353.08,99.43 360.92,95.53 368.77,91.63 376.62,87.73 384.46,83.83 392.31,79.93 400.15,76.03 408.00,72.13 415.85,68.24 423.69,64.34 431.54,60.44 439.38,56.54 447.23,52.64 455.08,48.74 462.92,44.84 470.77,40.94 478.62,37.04 486.46,33.30 494.31,29.86 502.15,26.41 510.00,22.97" fill="none" stroke="#1f77b4" stroke-width="2" stroke-linejoin="round" stroke-linecap="round" />
+<circle cx="0.00" cy="286.36" r="2" fill="#1f77b4" />
+<circle cx="7.85" cy="283.07" r="2" fill="#1f77b4" />
+<circle cx="15.69" cy="279.78" r="2" fill="#1f77b4" />
+<circle cx="23.54" cy="276.49" r="2" fill="#1f77b4" />
+<circle cx="31.38" cy="273.12" r="2" fill="#1f77b4" />
+<circle cx="39.23" cy="268.54" r="2" fill="#1f77b4" />
+<circle cx="47.08" cy="263.96" r="2" fill="#1f77b4" />
+<circle cx="54.92" cy="259.38" r="2" fill="#1f77b4" />
+<circle cx="62.77" cy="254.80" r="2" fill="#1f77b4" />
+<circle cx="70.62" cy="250.22" r="2" fill="#1f77b4" />
+<circle cx="78.46" cy="245.64" r="2" fill="#1f77b4" />
+<circle cx="86.31" cy="241.06" r="2" fill="#1f77b4" />
+<circle cx="94.15" cy="236.48" r="2" fill="#1f77b4" />
+<circle cx="102.00" cy="231.90" r="2" fill="#1f77b4" />
+<circle cx="109.85" cy="227.50" r="2" fill="#1f77b4" />
+<circle cx="117.69" cy="223.24" r="2" fill="#1f77b4" />
+<circle cx="125.54" cy="218.97" r="2" fill="#1f77b4" />
+<circle cx="133.38" cy="214.71" r="2" fill="#1f77b4" />
+<circle cx="141.23" cy="210.45" r="2" fill="#1f77b4" />
+<circle cx="149.08" cy="206.19" r="2" fill="#1f77b4" />
+<circle cx="156.92" cy="201.93" r="2" fill="#1f77b4" />
+<circle cx="164.77" cy="197.67" r="2" fill="#1f77b4" />
+<circle cx="172.62" cy="193.41" r="2" fill="#1f77b4" />
+<circle cx="180.46" cy="189.15" r="2" fill="#1f77b4" />
+<circle cx="188.31" cy="184.89" r="2" fill="#1f77b4" />
+<circle cx="196.15" cy="180.63" r="2" fill="#1f77b4" />
+<circle cx="204.00" cy="176.37" r="2" fill="#1f77b4" />
+<circle cx="211.85" cy="172.11" r="2" fill="#1f77b4" />
+<circle cx="219.69" cy="167.85" r="2" fill="#1f77b4" />
+<circle cx="227.54" cy="163.59" r="2" fill="#1f77b4" />
+<circle cx="235.38" cy="159.33" r="2" fill="#1f77b4" />
+<circle cx="243.23" cy="155.07" r="2" fill="#1f77b4" />
+<circle cx="251.08" cy="150.81" r="2" fill="#1f77b4" />
+<circle cx="258.92" cy="146.54" r="2" fill="#1f77b4" />
+<circle cx="266.77" cy="142.28" r="2" fill="#1f77b4" />
+<circle cx="274.62" cy="138.12" r="2" fill="#1f77b4" />
+<circle cx="282.46" cy="134.47" r="2" fill="#1f77b4" />
+<circle cx="290.31" cy="130.63" r="2" fill="#1f77b4" />
+<circle cx="298.15" cy="126.73" r="2" fill="#1f77b4" />
+<circle cx="306.00" cy="122.83" r="2" fill="#1f77b4" />
+<circle cx="313.85" cy="118.93" r="2" fill="#1f77b4" />
+<circle cx="321.69" cy="115.03" r="2" fill="#1f77b4" />
+<circle cx="329.54" cy="111.13" r="2" fill="#1f77b4" />
+<circle cx="337.38" cy="107.23" r="2" fill="#1f77b4" />
+<circle cx="345.23" cy="103.33" r="2" fill="#1f77b4" />
+<circle cx="353.08" cy="99.43" r="2" fill="#1f77b4" />
+<circle cx="360.92" cy="95.53" r="2" fill="#1f77b4" />
+<circle cx="368.77" cy="91.63" r="2" fill="#1f77b4" />
+<circle cx="376.62" cy="87.73" r="2" fill="#1f77b4" />
+<circle cx="384.46" cy="83.83" r="2" fill="#1f77b4" />
+<circle cx="392.31" cy="79.93" r="2" fill="#1f77b4" />
+<circle cx="400.15" cy="76.03" r="2" fill="#1f77b4" />
+<circle cx="408.00" cy="72.13" r="2" fill="#1f77b4" />
+<circle cx="415.85" cy="68.24" r="2" fill="#1f77b4" />
+<circle cx="423.69" cy="64.34" r="2" fill="#1f77b4" />
+<circle cx="431.54" cy="60.44" r="2" fill="#1f77b4" />
+<circle cx="439.38" cy="56.54" r="2" fill="#1f77b4" />
+<circle cx="447.23" cy="52.64" r="2" fill="#1f77b4" />
+<circle cx="455.08" cy="48.74" r="2" fill="#1f77b4" />
+<circle cx="462.92" cy="44.84" r="2" fill="#1f77b4" />
+<circle cx="470.77" cy="40.94" r="2" fill="#1f77b4" />
+<circle cx="478.62" cy="37.04" r="2" fill="#1f77b4" />
+<circle cx="486.46" cy="33.30" r="2" fill="#1f77b4" />
+<circle cx="494.31" cy="29.86" r="2" fill="#1f77b4" />
+<circle cx="502.15" cy="26.41" r="2" fill="#1f77b4" />
+<circle cx="510.00" cy="22.97" r="2" fill="#1f77b4" />
+<polyline points="0.00,285.28 7.85,279.61 15.69,276.08 23.54,272.55 31.38,269.03 39.23,265.50 47.08,261.27 54.92,256.68 62.77,252.08 70.62,247.48 78.46,242.89 86.31,238.29 94.15,233.70 102.00,229.10 109.85,224.51 117.69,219.91 125.54,215.32 133.38,210.99 141.23,206.76 149.08,202.53 156.92,198.30 164.77,194.07 172.62,189.84 180.46,185.61 188.31,181.38 196.15,177.15 204.00,172.92 211.85,168.69 219.69,164.46 227.54,160.23 235.38,156.00 243.23,151.77 251.08,147.54 258.92,143.31 266.77,139.08 274.62,134.85 282.46,130.77 290.31,126.99 298.15,123.22 306.00,119.45 313.85,115.67 321.69,111.90 329.54,108.13 337.38,104.11 345.23,100.08 353.08,96.05 360.92,92.02 368.77,87.99 376.62,83.96 384.46,79.93 392.31,75.90 400.15,71.87 408.00,67.84 415.85,63.81 423.69,59.78 431.54,55.75 439.38,51.73 447.23,47.70 455.08,43.67 462.92,39.64 470.77,35.61 478.62,31.58 486.46,27.55 494.31,23.52 502.15,19.49 510.00,15.46" fill="none" stroke="#d62728" stroke-width="2" stroke-linejoin="round" stroke-linecap="round" />
+<circle cx="0.00" cy="285.28" r="2" fill="#d62728" />
+<circle cx="7.85" cy="279.61" r="2" fill="#d62728" />
+<circle cx="15.69" cy="276.08" r="2" fill="#d62728" />
+<circle cx="23.54" cy="272.55" r="2" fill="#d62728" />
+<circle cx="31.38" cy="269.03" r="2" fill="#d62728" />
+<circle cx="39.23" cy="265.50" r="2" fill="#d62728" />
+<circle cx="47.08" cy="261.27" r="2" fill="#d62728" />
+<circle cx="54.92" cy="256.68" r="2" fill="#d62728" />
+<circle cx="62.77" cy="252.08" r="2" fill="#d62728" />
+<circle cx="70.62" cy="247.48" r="2" fill="#d62728" />
+<circle cx="78.46" cy="242.89" r="2" fill="#d62728" />
+<circle cx="86.31" cy="238.29" r="2" fill="#d62728" />
+<circle cx="94.15" cy="233.70" r="2" fill="#d62728" />
+<circle cx="102.00" cy="229.10" r="2" fill="#d62728" />
+<circle cx="109.85" cy="224.51" r="2" fill="#d62728" />
+<circle cx="117.69" cy="219.91" r="2" fill="#d62728" />
+<circle cx="125.54" cy="215.32" r="2" fill="#d62728" />
+<circle cx="133.38" cy="210.99" r="2" fill="#d62728" />
+<circle cx="141.23" cy="206.76" r="2" fill="#d62728" />
+<circle cx="149.08" cy="202.53" r="2" fill="#d62728" />
+<circle cx="156.92" cy="198.30" r="2" fill="#d62728" />
+<circle cx="164.77" cy="194.07" r="2" fill="#d62728" />
+<circle cx="172.62" cy="189.84" r="2" fill="#d62728" />
+<circle cx="180.46" cy="185.61" r="2" fill="#d62728" />
+<circle cx="188.31" cy="181.38" r="2" fill="#d62728" />
+<circle cx="196.15" cy="177.15" r="2" fill="#d62728" />
+<circle cx="204.00" cy="172.92" r="2" fill="#d62728" />
+<circle cx="211.85" cy="168.69" r="2" fill="#d62728" />
+<circle cx="219.69" cy="164.46" r="2" fill="#d62728" />
+<circle cx="227.54" cy="160.23" r="2" fill="#d62728" />
+<circle cx="235.38" cy="156.00" r="2" fill="#d62728" />
+<circle cx="243.23" cy="151.77" r="2" fill="#d62728" />
+<circle cx="251.08" cy="147.54" r="2" fill="#d62728" />
+<circle cx="258.92" cy="143.31" r="2" fill="#d62728" />
+<circle cx="266.77" cy="139.08" r="2" fill="#d62728" />
+<circle cx="274.62" cy="134.85" r="2" fill="#d62728" />
+<circle cx="282.46" cy="130.77" r="2" fill="#d62728" />
+<circle cx="290.31" cy="126.99" r="2" fill="#d62728" />
+<circle cx="298.15" cy="123.22" r="2" fill="#d62728" />
+<circle cx="306.00" cy="119.45" r="2" fill="#d62728" />
+<circle cx="313.85" cy="115.67" r="2" fill="#d62728" />
+<circle cx="321.69" cy="111.90" r="2" fill="#d62728" />
+<circle cx="329.54" cy="108.13" r="2" fill="#d62728" />
+<circle cx="337.38" cy="104.11" r="2" fill="#d62728" />
+<circle cx="345.23" cy="100.08" r="2" fill="#d62728" />
+<circle cx="353.08" cy="96.05" r="2" fill="#d62728" />
+<circle cx="360.92" cy="92.02" r="2" fill="#d62728" />
+<circle cx="368.77" cy="87.99" r="2" fill="#d62728" />
+<circle cx="376.62" cy="83.96" r="2" fill="#d62728" />
+<circle cx="384.46" cy="79.93" r="2" fill="#d62728" />
+<circle cx="392.31" cy="75.90" r="2" fill="#d62728" />
+<circle cx="400.15" cy="71.87" r="2" fill="#d62728" />
+<circle cx="408.00" cy="67.84" r="2" fill="#d62728" />
+<circle cx="415.85" cy="63.81" r="2" fill="#d62728" />
+<circle cx="423.69" cy="59.78" r="2" fill="#d62728" />
+<circle cx="431.54" cy="55.75" r="2" fill="#d62728" />
+<circle cx="439.38" cy="51.73" r="2" fill="#d62728" />
+<circle cx="447.23" cy="47.70" r="2" fill="#d62728" />
+<circle cx="455.08" cy="43.67" r="2" fill="#d62728" />
+<circle cx="462.92" cy="39.64" r="2" fill="#d62728" />
+<circle cx="470.77" cy="35.61" r="2" fill="#d62728" />
+<circle cx="478.62" cy="31.58" r="2" fill="#d62728" />
+<circle cx="486.46" cy="27.55" r="2" fill="#d62728" />
+<circle cx="494.31" cy="23.52" r="2" fill="#d62728" />
+<circle cx="502.15" cy="19.49" r="2" fill="#d62728" />
+<circle cx="510.00" cy="15.46" r="2" fill="#d62728" />
+<polyline points="0.00,285.28 7.85,279.19 15.69,274.87 23.54,270.81 31.38,267.42 39.23,263.74 47.08,259.70 54.92,256.17 62.77,252.41 70.62,247.78 78.46,243.15 86.31,238.53 94.15,233.90 102.00,229.28 109.85,224.65 117.69,220.03 125.54,215.74 133.38,211.48 141.23,207.22 149.08,202.96 156.92,198.70 164.77,194.44 172.62,190.18 180.46,185.92 188.31,181.66 196.15,177.40 204.00,173.14 211.85,168.87 219.69,164.61 227.54,160.35 235.38,156.09 243.23,151.83 251.08,147.57 258.92,143.31 266.77,139.05 274.62,134.79 282.46,130.79 290.31,126.96 298.15,123.12 306.00,119.29 313.85,115.46 321.69,111.62 329.54,107.79 337.38,103.72 345.23,99.62 353.08,95.53 360.92,91.43 368.77,87.34 376.62,83.24 384.46,79.15 392.31,75.05 400.15,70.96 408.00,66.87 415.85,62.77 423.69,58.68 431.54,54.58 439.38,50.49 447.23,46.39 455.08,42.30 462.92,38.20 470.77,34.11 478.62,30.01 486.46,25.92 494.31,21.83 502.15,17.73 510.00,13.64" fill="none" stroke="#2ca02c" stroke-width="2" stroke-linejoin="round" stroke-linecap="round" />
+<circle cx="0.00" cy="285.28" r="2" fill="#2ca02c" />
+<circle cx="7.85" cy="279.19" r="2" fill="#2ca02c" />
+<circle cx="15.69" cy="274.87" r="2" fill="#2ca02c" />
+<circle cx="23.54" cy="270.81" r="2" fill="#2ca02c" />
+<circle cx="31.38" cy="267.42" r="2" fill="#2ca02c" />
+<circle cx="39.23" cy="263.74" r="2" fill="#2ca02c" />
+<circle cx="47.08" cy="259.70" r="2" fill="#2ca02c" />
+<circle cx="54.92" cy="256.17" r="2" fill="#2ca02c" />
+<circle cx="62.77" cy="252.41" r="2" fill="#2ca02c" />
+<circle cx="70.62" cy="247.78" r="2" fill="#2ca02c" />
+<circle cx="78.46" cy="243.15" r="2" fill="#2ca02c" />
+<circle cx="86.31" cy="238.53" r="2" fill="#2ca02c" />
+<circle cx="94.15" cy="233.90" r="2" fill="#2ca02c" />
+<circle cx="102.00" cy="229.28" r="2" fill="#2ca02c" />
+<circle cx="109.85" cy="224.65" r="2" fill="#2ca02c" />
+<circle cx="117.69" cy="220.03" r="2" fill="#2ca02c" />
+<circle cx="125.54" cy="215.74" r="2" fill="#2ca02c" />
+<circle cx="133.38" cy="211.48" r="2" fill="#2ca02c" />
+<circle cx="141.23" cy="207.22" r="2" fill="#2ca02c" />
+<circle cx="149.08" cy="202.96" r="2" fill="#2ca02c" />
+<circle cx="156.92" cy="198.70" r="2" fill="#2ca02c" />
+<circle cx="164.77" cy="194.44" r="2" fill="#2ca02c" />
+<circle cx="172.62" cy="190.18" r="2" fill="#2ca02c" />
+<circle cx="180.46" cy="185.92" r="2" fill="#2ca02c" />
+<circle cx="188.31" cy="181.66" r="2" fill="#2ca02c" />
+<circle cx="196.15" cy="177.40" r="2" fill="#2ca02c" />
+<circle cx="204.00" cy="173.14" r="2" fill="#2ca02c" />
+<circle cx="211.85" cy="168.87" r="2" fill="#2ca02c" />
+<circle cx="219.69" cy="164.61" r="2" fill="#2ca02c" />
+<circle cx="227.54" cy="160.35" r="2" fill="#2ca02c" />
+<circle cx="235.38" cy="156.09" r="2" fill="#2ca02c" />
+<circle cx="243.23" cy="151.83" r="2" fill="#2ca02c" />
+<circle cx="251.08" cy="147.57" r="2" fill="#2ca02c" />
+<circle cx="258.92" cy="143.31" r="2" fill="#2ca02c" />
+<circle cx="266.77" cy="139.05" r="2" fill="#2ca02c" />
+<circle cx="274.62" cy="134.79" r="2" fill="#2ca02c" />
+<circle cx="282.46" cy="130.79" r="2" fill="#2ca02c" />
+<circle cx="290.31" cy="126.96" r="2" fill="#2ca02c" />
+<circle cx="298.15" cy="123.12" r="2" fill="#2ca02c" />
+<circle cx="306.00" cy="119.29" r="2" fill="#2ca02c" />
+<circle cx="313.85" cy="115.46" r="2" fill="#2ca02c" />
+<circle cx="321.69" cy="111.62" r="2" fill="#2ca02c" />
+<circle cx="329.54" cy="107.79" r="2" fill="#2ca02c" />
+<circle cx="337.38" cy="103.72" r="2" fill="#2ca02c" />
+<circle cx="345.23" cy="99.62" r="2" fill="#2ca02c" />
+<circle cx="353.08" cy="95.53" r="2" fill="#2ca02c" />
+<circle cx="360.92" cy="91.43" r="2" fill="#2ca02c" />
+<circle cx="368.77" cy="87.34" r="2" fill="#2ca02c" />
+<circle cx="376.62" cy="83.24" r="2" fill="#2ca02c" />
+<circle cx="384.46" cy="79.15" r="2" fill="#2ca02c" />
+<circle cx="392.31" cy="75.05" r="2" fill="#2ca02c" />
+<circle cx="400.15" cy="70.96" r="2" fill="#2ca02c" />
+<circle cx="408.00" cy="66.87" r="2" fill="#2ca02c" />
+<circle cx="415.85" cy="62.77" r="2" fill="#2ca02c" />
+<circle cx="423.69" cy="58.68" r="2" fill="#2ca02c" />
+<circle cx="431.54" cy="54.58" r="2" fill="#2ca02c" />
+<circle cx="439.38" cy="50.49" r="2" fill="#2ca02c" />
+<circle cx="447.23" cy="46.39" r="2" fill="#2ca02c" />
+<circle cx="455.08" cy="42.30" r="2" fill="#2ca02c" />
+<circle cx="462.92" cy="38.20" r="2" fill="#2ca02c" />
+<circle cx="470.77" cy="34.11" r="2" fill="#2ca02c" />
+<circle cx="478.62" cy="30.01" r="2" fill="#2ca02c" />
+<circle cx="486.46" cy="25.92" r="2" fill="#2ca02c" />
+<circle cx="494.31" cy="21.83" r="2" fill="#2ca02c" />
+<circle cx="502.15" cy="17.73" r="2" fill="#2ca02c" />
+<circle cx="510.00" cy="13.64" r="2" fill="#2ca02c" />
+<polyline points="0.00,285.28 7.85,279.96 15.69,276.67 23.54,273.37 31.38,270.08 39.23,266.79 47.08,263.50 54.92,259.06 62.77,254.44 70.62,249.81 78.46,245.19 86.31,240.56 94.15,236.07 102.00,231.81 109.85,227.55 117.69,223.29 125.54,219.03 133.38,214.77 141.23,210.51 149.08,206.25 156.92,201.99 164.77,197.72 172.62,193.46 180.46,189.20 188.31,184.94 196.15,180.68 204.00,176.42 211.85,172.16 219.69,167.90 227.54,163.64 235.38,159.54 243.23,155.71 251.08,151.87 258.92,148.04 266.77,144.20 274.62,140.37 282.46,136.53 290.31,132.70 298.15,128.86 306.00,125.03 313.85,121.20 321.69,117.31 329.54,113.21 337.38,109.12 345.23,105.03 353.08,100.93 360.92,96.84 368.77,92.74 376.62,88.65 384.46,84.55 392.31,80.46 400.15,76.36 408.00,72.27 415.85,68.17 423.69,64.08 431.54,59.99 439.38,55.89 447.23,51.80 455.08,47.70 462.92,44.03 470.77,40.45 478.62,36.88 486.46,33.31 494.31,29.73 502.15,26.16 510.00,22.58" fill="none" stroke="#9467bd" stroke-width="2" stroke-linejoin="round" stroke-linecap="round" />
+<circle cx="0.00" cy="285.28" r="2" fill="#9467bd" />
+<circle cx="7.85" cy="279.96" r="2" fill="#9467bd" />
+<circle cx="15.69" cy="276.67" r="2" fill="#9467bd" />
+<circle cx="23.54" cy="273.37" r="2" fill="#9467bd" />
+<circle cx="31.38" cy="270.08" r="2" fill="#9467bd" />
+<circle cx="39.23" cy="266.79" r="2" fill="#9467bd" />
+<circle cx="47.08" cy="263.50" r="2" fill="#9467bd" />
+<circle cx="54.92" cy="259.06" r="2" fill="#9467bd" />
+<circle cx="62.77" cy="254.44" r="2" fill="#9467bd" />
+<circle cx="70.62" cy="249.81" r="2" fill="#9467bd" />
+<circle cx="78.46" cy="245.19" r="2" fill="#9467bd" />
+<circle cx="86.31" cy="240.56" r="2" fill="#9467bd" />
+<circle cx="94.15" cy="236.07" r="2" fill="#9467bd" />
+<circle cx="102.00" cy="231.81" r="2" fill="#9467bd" />
+<circle cx="109.85" cy="227.55" r="2" fill="#9467bd" />
+<circle cx="117.69" cy="223.29" r="2" fill="#9467bd" />
+<circle cx="125.54" cy="219.03" r="2" fill="#9467bd" />
+<circle cx="133.38" cy="214.77" r="2" fill="#9467bd" />
+<circle cx="141.23" cy="210.51" r="2" fill="#9467bd" />
+<circle cx="149.08" cy="206.25" r="2" fill="#9467bd" />
+<circle cx="156.92" cy="201.99" r="2" fill="#9467bd" />
+<circle cx="164.77" cy="197.72" r="2" fill="#9467bd" />
+<circle cx="172.62" cy="193.46" r="2" fill="#9467bd" />
+<circle cx="180.46" cy="189.20" r="2" fill="#9467bd" />
+<circle cx="188.31" cy="184.94" r="2" fill="#9467bd" />
+<circle cx="196.15" cy="180.68" r="2" fill="#9467bd" />
+<circle cx="204.00" cy="176.42" r="2" fill="#9467bd" />
+<circle cx="211.85" cy="172.16" r="2" fill="#9467bd" />
+<circle cx="219.69" cy="167.90" r="2" fill="#9467bd" />
+<circle cx="227.54" cy="163.64" r="2" fill="#9467bd" />
+<circle cx="235.38" cy="159.54" r="2" fill="#9467bd" />
+<circle cx="243.23" cy="155.71" r="2" fill="#9467bd" />
+<circle cx="251.08" cy="151.87" r="2" fill="#9467bd" />
+<circle cx="258.92" cy="148.04" r="2" fill="#9467bd" />
+<circle cx="266.77" cy="144.20" r="2" fill="#9467bd" />
+<circle cx="274.62" cy="140.37" r="2" fill="#9467bd" />
+<circle cx="282.46" cy="136.53" r="2" fill="#9467bd" />
+<circle cx="290.31" cy="132.70" r="2" fill="#9467bd" />
+<circle cx="298.15" cy="128.86" r="2" fill="#9467bd" />
+<circle cx="306.00" cy="125.03" r="2" fill="#9467bd" />
+<circle cx="313.85" cy="121.20" r="2" fill="#9467bd" />
+<circle cx="321.69" cy="117.31" r="2" fill="#9467bd" />
+<circle cx="329.54" cy="113.21" r="2" fill="#9467bd" />
+<circle cx="337.38" cy="109.12" r="2" fill="#9467bd" />
+<circle cx="345.23" cy="105.03" r="2" fill="#9467bd" />
+<circle cx="353.08" cy="100.93" r="2" fill="#9467bd" />
+<circle cx="360.92" cy="96.84" r="2" fill="#9467bd" />
+<circle cx="368.77" cy="92.74" r="2" fill="#9467bd" />
+<circle cx="376.62" cy="88.65" r="2" fill="#9467bd" />
+<circle cx="384.46" cy="84.55" r="2" fill="#9467bd" />
+<circle cx="392.31" cy="80.46" r="2" fill="#9467bd" />
+<circle cx="400.15" cy="76.36" r="2" fill="#9467bd" />
+<circle cx="408.00" cy="72.27" r="2" fill="#9467bd" />
+<circle cx="415.85" cy="68.17" r="2" fill="#9467bd" />
+<circle cx="423.69" cy="64.08" r="2" fill="#9467bd" />
+<circle cx="431.54" cy="59.99" r="2" fill="#9467bd" />
+<circle cx="439.38" cy="55.89" r="2" fill="#9467bd" />
+<circle cx="447.23" cy="51.80" r="2" fill="#9467bd" />
+<circle cx="455.08" cy="47.70" r="2" fill="#9467bd" />
+<circle cx="462.92" cy="44.03" r="2" fill="#9467bd" />
+<circle cx="470.77" cy="40.45" r="2" fill="#9467bd" />
+<circle cx="478.62" cy="36.88" r="2" fill="#9467bd" />
+<circle cx="486.46" cy="33.31" r="2" fill="#9467bd" />
+<circle cx="494.31" cy="29.73" r="2" fill="#9467bd" />
+<circle cx="502.15" cy="26.16" r="2" fill="#9467bd" />
+<circle cx="510.00" cy="22.58" r="2" fill="#9467bd" />
+<polyline points="0.00,285.40 7.85,279.32 15.69,273.72 23.54,270.44 31.38,267.16 39.23,263.87 47.08,260.59 54.92,257.30 62.77,254.02 70.62,250.74 78.46,246.22 86.31,241.91 94.15,237.66 102.00,233.40 109.85,229.15 117.69,224.89 125.54,220.64 133.38,216.38 141.23,212.13 149.08,207.87 156.92,203.62 164.77,199.36 172.62,195.11 180.46,190.85 188.31,186.59 196.15,182.34 204.00,178.08 211.85,173.83 219.69,169.93 227.54,166.10 235.38,162.27 243.23,158.45 251.08,154.62 258.92,150.79 266.77,146.96 274.62,143.13 282.46,139.30 290.31,135.47 298.15,131.64 306.00,127.81 313.85,123.98 321.69,120.15 329.54,116.32 337.38,112.49 345.23,108.66 353.08,104.83 360.92,100.75 368.77,96.65 376.62,92.56 384.46,88.46 392.31,84.37 400.15,80.27 408.00,76.18 415.85,72.08 423.69,67.99 431.54,64.11 439.38,60.53 447.23,56.96 455.08,53.38 462.92,49.81 470.77,46.23 478.62,42.66 486.46,39.08 494.31,35.51 502.15,31.93 510.00,28.36" fill="none" stroke="#ff7f0e" stroke-width="2" stroke-linejoin="round" stroke-linecap="round" />
+<circle cx="0.00" cy="285.40" r="2" fill="#ff7f0e" />
+<circle cx="7.85" cy="279.32" r="2" fill="#ff7f0e" />
+<circle cx="15.69" cy="273.72" r="2" fill="#ff7f0e" />
+<circle cx="23.54" cy="270.44" r="2" fill="#ff7f0e" />
+<circle cx="31.38" cy="267.16" r="2" fill="#ff7f0e" />
+<circle cx="39.23" cy="263.87" r="2" fill="#ff7f0e" />
+<circle cx="47.08" cy="260.59" r="2" fill="#ff7f0e" />
+<circle cx="54.92" cy="257.30" r="2" fill="#ff7f0e" />
+<circle cx="62.77" cy="254.02" r="2" fill="#ff7f0e" />
+<circle cx="70.62" cy="250.74" r="2" fill="#ff7f0e" />
+<circle cx="78.46" cy="246.22" r="2" fill="#ff7f0e" />
+<circle cx="86.31" cy="241.91" r="2" fill="#ff7f0e" />
+<circle cx="94.15" cy="237.66" r="2" fill="#ff7f0e" />
+<circle cx="102.00" cy="233.40" r="2" fill="#ff7f0e" />
+<circle cx="109.85" cy="229.15" r="2" fill="#ff7f0e" />
+<circle cx="117.69" cy="224.89" r="2" fill="#ff7f0e" />
+<circle cx="125.54" cy="220.64" r="2" fill="#ff7f0e" />
+<circle cx="133.38" cy="216.38" r="2" fill="#ff7f0e" />
+<circle cx="141.23" cy="212.13" r="2" fill="#ff7f0e" />
+<circle cx="149.08" cy="207.87" r="2" fill="#ff7f0e" />
+<circle cx="156.92" cy="203.62" r="2" fill="#ff7f0e" />
+<circle cx="164.77" cy="199.36" r="2" fill="#ff7f0e" />
+<circle cx="172.62" cy="195.11" r="2" fill="#ff7f0e" />
+<circle cx="180.46" cy="190.85" r="2" fill="#ff7f0e" />
+<circle cx="188.31" cy="186.59" r="2" fill="#ff7f0e" />
+<circle cx="196.15" cy="182.34" r="2" fill="#ff7f0e" />
+<circle cx="204.00" cy="178.08" r="2" fill="#ff7f0e" />
+<circle cx="211.85" cy="173.83" r="2" fill="#ff7f0e" />
+<circle cx="219.69" cy="169.93" r="2" fill="#ff7f0e" />
+<circle cx="227.54" cy="166.10" r="2" fill="#ff7f0e" />
+<circle cx="235.38" cy="162.27" r="2" fill="#ff7f0e" />
+<circle cx="243.23" cy="158.45" r="2" fill="#ff7f0e" />
+<circle cx="251.08" cy="154.62" r="2" fill="#ff7f0e" />
+<circle cx="258.92" cy="150.79" r="2" fill="#ff7f0e" />
+<circle cx="266.77" cy="146.96" r="2" fill="#ff7f0e" />
+<circle cx="274.62" cy="143.13" r="2" fill="#ff7f0e" />
+<circle cx="282.46" cy="139.30" r="2" fill="#ff7f0e" />
+<circle cx="290.31" cy="135.47" r="2" fill="#ff7f0e" />
+<circle cx="298.15" cy="131.64" r="2" fill="#ff7f0e" />
+<circle cx="306.00" cy="127.81" r="2" fill="#ff7f0e" />
+<circle cx="313.85" cy="123.98" r="2" fill="#ff7f0e" />
+<circle cx="321.69" cy="120.15" r="2" fill="#ff7f0e" />
+<circle cx="329.54" cy="116.32" r="2" fill="#ff7f0e" />
+<circle cx="337.38" cy="112.49" r="2" fill="#ff7f0e" />
+<circle cx="345.23" cy="108.66" r="2" fill="#ff7f0e" />
+<circle cx="353.08" cy="104.83" r="2" fill="#ff7f0e" />
+<circle cx="360.92" cy="100.75" r="2" fill="#ff7f0e" />
+<circle cx="368.77" cy="96.65" r="2" fill="#ff7f0e" />
+<circle cx="376.62" cy="92.56" r="2" fill="#ff7f0e" />
+<circle cx="384.46" cy="88.46" r="2" fill="#ff7f0e" />
+<circle cx="392.31" cy="84.37" r="2" fill="#ff7f0e" />
+<circle cx="400.15" cy="80.27" r="2" fill="#ff7f0e" />
+<circle cx="408.00" cy="76.18" r="2" fill="#ff7f0e" />
+<circle cx="415.85" cy="72.08" r="2" fill="#ff7f0e" />
+<circle cx="423.69" cy="67.99" r="2" fill="#ff7f0e" />
+<circle cx="431.54" cy="64.11" r="2" fill="#ff7f0e" />
+<circle cx="439.38" cy="60.53" r="2" fill="#ff7f0e" />
+<circle cx="447.23" cy="56.96" r="2" fill="#ff7f0e" />
+<circle cx="455.08" cy="53.38" r="2" fill="#ff7f0e" />
+<circle cx="462.92" cy="49.81" r="2" fill="#ff7f0e" />
+<circle cx="470.77" cy="46.23" r="2" fill="#ff7f0e" />
+<circle cx="478.62" cy="42.66" r="2" fill="#ff7f0e" />
+<circle cx="486.46" cy="39.08" r="2" fill="#ff7f0e" />
+<circle cx="494.31" cy="35.51" r="2" fill="#ff7f0e" />
+<circle cx="502.15" cy="31.93" r="2" fill="#ff7f0e" />
+<circle cx="510.00" cy="28.36" r="2" fill="#ff7f0e" />
+<polyline points="0.00,285.43 7.85,279.35 15.69,273.27 23.54,271.25 31.38,269.85 39.23,266.57 47.08,263.29 54.92,260.00 62.77,256.34 70.62,251.81 78.46,247.56 86.31,243.30 94.15,239.05 102.00,234.80 109.85,230.54 117.69,226.29 125.54,222.04 133.38,217.78 141.23,213.53 149.08,209.27 156.92,205.02 164.77,200.77 172.62,196.51 180.46,192.26 188.31,188.01 196.15,183.84 204.00,180.01 211.85,176.19 219.69,172.36 227.54,168.53 235.38,164.70 243.23,160.87 251.08,157.04 258.92,153.22 266.77,149.39 274.62,145.56 282.46,141.73 290.31,137.90 298.15,134.07 306.00,130.25 313.85,126.42 321.69,122.59 329.54,118.76 337.38,114.93 345.23,111.10 353.08,107.28 360.92,103.45 368.77,99.42 376.62,95.33 384.46,91.24 392.31,87.16 400.15,83.08 408.00,79.51 415.85,75.94 423.69,72.37 431.54,68.81 439.38,65.24 447.23,61.67 455.08,58.10 462.92,54.54 470.77,50.97 478.62,47.40 486.46,43.84 494.31,40.27 502.15,36.70 510.00,33.13" fill="none" stroke="#17becf" stroke-width="2" stroke-linejoin="round" stroke-linecap="round" />
+<circle cx="0.00" cy="285.43" r="2" fill="#17becf" />
+<circle cx="7.85" cy="279.35" r="2" fill="#17becf" />
+<circle cx="15.69" cy="273.27" r="2" fill="#17becf" />
+<circle cx="23.54" cy="271.25" r="2" fill="#17becf" />
+<circle cx="31.38" cy="269.85" r="2" fill="#17becf" />
+<circle cx="39.23" cy="266.57" r="2" fill="#17becf" />
+<circle cx="47.08" cy="263.29" r="2" fill="#17becf" />
+<circle cx="54.92" cy="260.00" r="2" fill="#17becf" />
+<circle cx="62.77" cy="256.34" r="2" fill="#17becf" />
+<circle cx="70.62" cy="251.81" r="2" fill="#17becf" />
+<circle cx="78.46" cy="247.56" r="2" fill="#17becf" />
+<circle cx="86.31" cy="243.30" r="2" fill="#17becf" />
+<circle cx="94.15" cy="239.05" r="2" fill="#17becf" />
+<circle cx="102.00" cy="234.80" r="2" fill="#17becf" />
+<circle cx="109.85" cy="230.54" r="2" fill="#17becf" />
+<circle cx="117.69" cy="226.29" r="2" fill="#17becf" />
+<circle cx="125.54" cy="222.04" r="2" fill="#17becf" />
+<circle cx="133.38" cy="217.78" r="2" fill="#17becf" />
+<circle cx="141.23" cy="213.53" r="2" fill="#17becf" />
+<circle cx="149.08" cy="209.27" r="2" fill="#17becf" />
+<circle cx="156.92" cy="205.02" r="2" fill="#17becf" />
+<circle cx="164.77" cy="200.77" r="2" fill="#17becf" />
+<circle cx="172.62" cy="196.51" r="2" fill="#17becf" />
+<circle cx="180.46" cy="192.26" r="2" fill="#17becf" />
+<circle cx="188.31" cy="188.01" r="2" fill="#17becf" />
+<circle cx="196.15" cy="183.84" r="2" fill="#17becf" />
+<circle cx="204.00" cy="180.01" r="2" fill="#17becf" />
+<circle cx="211.85" cy="176.19" r="2" fill="#17becf" />
+<circle cx="219.69" cy="172.36" r="2" fill="#17becf" />
+<circle cx="227.54" cy="168.53" r="2" fill="#17becf" />
+<circle cx="235.38" cy="164.70" r="2" fill="#17becf" />
+<circle cx="243.23" cy="160.87" r="2" fill="#17becf" />
+<circle cx="251.08" cy="157.04" r="2" fill="#17becf" />
+<circle cx="258.92" cy="153.22" r="2" fill="#17becf" />
+<circle cx="266.77" cy="149.39" r="2" fill="#17becf" />
+<circle cx="274.62" cy="145.56" r="2" fill="#17becf" />
+<circle cx="282.46" cy="141.73" r="2" fill="#17becf" />
+<circle cx="290.31" cy="137.90" r="2" fill="#17becf" />
+<circle cx="298.15" cy="134.07" r="2" fill="#17becf" />
+<circle cx="306.00" cy="130.25" r="2" fill="#17becf" />
+<circle cx="313.85" cy="126.42" r="2" fill="#17becf" />
+<circle cx="321.69" cy="122.59" r="2" fill="#17becf" />
+<circle cx="329.54" cy="118.76" r="2" fill="#17becf" />
+<circle cx="337.38" cy="114.93" r="2" fill="#17becf" />
+<circle cx="345.23" cy="111.10" r="2" fill="#17becf" />
+<circle cx="353.08" cy="107.28" r="2" fill="#17becf" />
+<circle cx="360.92" cy="103.45" r="2" fill="#17becf" />
+<circle cx="368.77" cy="99.42" r="2" fill="#17becf" />
+<circle cx="376.62" cy="95.33" r="2" fill="#17becf" />
+<circle cx="384.46" cy="91.24" r="2" fill="#17becf" />
+<circle cx="392.31" cy="87.16" r="2" fill="#17becf" />
+<circle cx="400.15" cy="83.08" r="2" fill="#17becf" />
+<circle cx="408.00" cy="79.51" r="2" fill="#17becf" />
+<circle cx="415.85" cy="75.94" r="2" fill="#17becf" />
+<circle cx="423.69" cy="72.37" r="2" fill="#17becf" />
+<circle cx="431.54" cy="68.81" r="2" fill="#17becf" />
+<circle cx="439.38" cy="65.24" r="2" fill="#17becf" />
+<circle cx="447.23" cy="61.67" r="2" fill="#17becf" />
+<circle cx="455.08" cy="58.10" r="2" fill="#17becf" />
+<circle cx="462.92" cy="54.54" r="2" fill="#17becf" />
+<circle cx="470.77" cy="50.97" r="2" fill="#17becf" />
+<circle cx="478.62" cy="47.40" r="2" fill="#17becf" />
+<circle cx="486.46" cy="43.84" r="2" fill="#17becf" />
+<circle cx="494.31" cy="40.27" r="2" fill="#17becf" />
+<circle cx="502.15" cy="36.70" r="2" fill="#17becf" />
+<circle cx="510.00" cy="33.13" r="2" fill="#17becf" />
+<rect x="528" y="0" width="14" height="3" fill="#1f77b4" />
+<text x="550" y="6" fill="#222" font-size="12">2012</text>
+<rect x="528" y="22" width="14" height="3" fill="#d62728" />
+<text x="550" y="28" fill="#222" font-size="12">2015</text>
+<rect x="528" y="44" width="14" height="3" fill="#2ca02c" />
+<text x="550" y="50" fill="#222" font-size="12">2018</text>
+<rect x="528" y="66" width="14" height="3" fill="#9467bd" />
+<text x="550" y="72" fill="#222" font-size="12">2022</text>
+<rect x="528" y="88" width="14" height="3" fill="#ff7f0e" />
+<text x="550" y="94" fill="#222" font-size="12">2024</text>
+<rect x="528" y="110" width="14" height="3" fill="#17becf" />
+<text x="550" y="116" fill="#222" font-size="12">2026</text>
+</g>
+</svg>

--- a/docs/assets/neto-real-mismo-nominal.svg
+++ b/docs/assets/neto-real-mismo-nominal.svg
@@ -1,0 +1,70 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 760 420" width="760" height="420" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif" font-size="13" role="img" aria-labelledby="neto-real-mismo-nominal-title neto-real-mismo-nominal-desc">
+<title id="neto-real-mismo-nominal-title">Neto real con bruto nominal fijo en 30 000 €</title>
+<desc id="neto-real-mismo-nominal-desc">Bruto nominal de 30 000 € en cada año entre 2012 y 2026, expresado el neto en € constantes de 2026. Pendiente decreciente: el mismo bruto nominal pierde poder adquisitivo real cada año.</desc>
+<rect width="760" height="420" fill="#ffffff" />
+<text x="80" y="35" font-size="16" font-weight="600" fill="#222">Neto real con bruto nominal fijo en 30 000 €</text>
+<g transform="translate(80,60)">
+<line x1="0" y1="291.02" x2="510" y2="291.02" stroke="#e5e5e5" stroke-width="1" />
+<line x1="0" y1="253.49" x2="510" y2="253.49" stroke="#e5e5e5" stroke-width="1" />
+<line x1="0" y1="215.97" x2="510" y2="215.97" stroke="#e5e5e5" stroke-width="1" />
+<line x1="0" y1="178.45" x2="510" y2="178.45" stroke="#e5e5e5" stroke-width="1" />
+<line x1="0" y1="140.92" x2="510" y2="140.92" stroke="#e5e5e5" stroke-width="1" />
+<line x1="0" y1="103.40" x2="510" y2="103.40" stroke="#e5e5e5" stroke-width="1" />
+<line x1="0" y1="65.87" x2="510" y2="65.87" stroke="#e5e5e5" stroke-width="1" />
+<line x1="0" y1="28.35" x2="510" y2="28.35" stroke="#e5e5e5" stroke-width="1" />
+<line x1="0" y1="300" x2="510" y2="300" stroke="#333" stroke-width="1" />
+<line x1="0" y1="0" x2="0" y2="300" stroke="#333" stroke-width="1" />
+<line x1="0.00" y1="300" x2="0.00" y2="305" stroke="#333" stroke-width="1" />
+<text x="0.00" y="322" text-anchor="middle" fill="#444">2012</text>
+<line x1="72.86" y1="300" x2="72.86" y2="305" stroke="#333" stroke-width="1" />
+<text x="72.86" y="322" text-anchor="middle" fill="#444">2014</text>
+<line x1="145.71" y1="300" x2="145.71" y2="305" stroke="#333" stroke-width="1" />
+<text x="145.71" y="322" text-anchor="middle" fill="#444">2016</text>
+<line x1="218.57" y1="300" x2="218.57" y2="305" stroke="#333" stroke-width="1" />
+<text x="218.57" y="322" text-anchor="middle" fill="#444">2018</text>
+<line x1="291.43" y1="300" x2="291.43" y2="305" stroke="#333" stroke-width="1" />
+<text x="291.43" y="322" text-anchor="middle" fill="#444">2020</text>
+<line x1="364.29" y1="300" x2="364.29" y2="305" stroke="#333" stroke-width="1" />
+<text x="364.29" y="322" text-anchor="middle" fill="#444">2022</text>
+<line x1="437.14" y1="300" x2="437.14" y2="305" stroke="#333" stroke-width="1" />
+<text x="437.14" y="322" text-anchor="middle" fill="#444">2024</text>
+<line x1="510.00" y1="300" x2="510.00" y2="305" stroke="#333" stroke-width="1" />
+<text x="510.00" y="322" text-anchor="middle" fill="#444">2026</text>
+<line x1="-5" y1="291.02" x2="0" y2="291.02" stroke="#333" stroke-width="1" />
+<text x="-10" y="295.02" text-anchor="end" fill="#444">23.000 €</text>
+<line x1="-5" y1="253.49" x2="0" y2="253.49" stroke="#333" stroke-width="1" />
+<text x="-10" y="257.49" text-anchor="end" fill="#444">24.000 €</text>
+<line x1="-5" y1="215.97" x2="0" y2="215.97" stroke="#333" stroke-width="1" />
+<text x="-10" y="219.97" text-anchor="end" fill="#444">25.000 €</text>
+<line x1="-5" y1="178.45" x2="0" y2="178.45" stroke="#333" stroke-width="1" />
+<text x="-10" y="182.45" text-anchor="end" fill="#444">26.000 €</text>
+<line x1="-5" y1="140.92" x2="0" y2="140.92" stroke="#333" stroke-width="1" />
+<text x="-10" y="144.92" text-anchor="end" fill="#444">27.000 €</text>
+<line x1="-5" y1="103.40" x2="0" y2="103.40" stroke="#333" stroke-width="1" />
+<text x="-10" y="107.40" text-anchor="end" fill="#444">28.000 €</text>
+<line x1="-5" y1="65.87" x2="0" y2="65.87" stroke="#333" stroke-width="1" />
+<text x="-10" y="69.87" text-anchor="end" fill="#444">29.000 €</text>
+<line x1="-5" y1="28.35" x2="0" y2="28.35" stroke="#333" stroke-width="1" />
+<text x="-10" y="32.35" text-anchor="end" fill="#444">30.000 €</text>
+<text x="255" y="348" text-anchor="middle" fill="#222" font-size="13">Año</text>
+<text transform="translate(-55,150) rotate(-90)" text-anchor="middle" fill="#222" font-size="13">Neto en € de 2026</text>
+<polyline points="0.00,40.62 36.43,43.95 72.86,32.74 109.29,13.64 145.71,26.59 182.14,38.86 218.57,52.08 255.00,60.83 291.43,55.34 327.86,122.40 364.29,178.03 400.71,208.24 437.14,234.16 473.57,260.17 510.00,286.36" fill="none" stroke="#1f77b4" stroke-width="2" stroke-linejoin="round" stroke-linecap="round" />
+<circle cx="0.00" cy="40.62" r="2" fill="#1f77b4" />
+<circle cx="36.43" cy="43.95" r="2" fill="#1f77b4" />
+<circle cx="72.86" cy="32.74" r="2" fill="#1f77b4" />
+<circle cx="109.29" cy="13.64" r="2" fill="#1f77b4" />
+<circle cx="145.71" cy="26.59" r="2" fill="#1f77b4" />
+<circle cx="182.14" cy="38.86" r="2" fill="#1f77b4" />
+<circle cx="218.57" cy="52.08" r="2" fill="#1f77b4" />
+<circle cx="255.00" cy="60.83" r="2" fill="#1f77b4" />
+<circle cx="291.43" cy="55.34" r="2" fill="#1f77b4" />
+<circle cx="327.86" cy="122.40" r="2" fill="#1f77b4" />
+<circle cx="364.29" cy="178.03" r="2" fill="#1f77b4" />
+<circle cx="400.71" cy="208.24" r="2" fill="#1f77b4" />
+<circle cx="437.14" cy="234.16" r="2" fill="#1f77b4" />
+<circle cx="473.57" cy="260.17" r="2" fill="#1f77b4" />
+<circle cx="510.00" cy="286.36" r="2" fill="#1f77b4" />
+<rect x="528" y="0" width="14" height="3" fill="#1f77b4" />
+<text x="550" y="6" fill="#222" font-size="12">Neto real (€ 2026)</text>
+</g>
+</svg>

--- a/docs/assets/tipo-medio-efectivo.svg
+++ b/docs/assets/tipo-medio-efectivo.svg
@@ -1,0 +1,461 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 760 420" width="760" height="420" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif" font-size="13" role="img" aria-labelledby="tipo-medio-efectivo-title tipo-medio-efectivo-desc">
+<title id="tipo-medio-efectivo-title">Tipo medio efectivo: cotización + IRPF sobre bruto</title>
+<desc id="tipo-medio-efectivo-desc">Cuánto de cada euro bruto se convierte en cotización del trabajador más IRPF, expresado en porcentaje. Eje X en bruto real (€ de 2026) para que años distintos sean comparables a igual poder adquisitivo.</desc>
+<rect width="760" height="420" fill="#ffffff" />
+<text x="80" y="35" font-size="16" font-weight="600" fill="#222">Tipo medio efectivo: cotización + IRPF sobre bruto</text>
+<g transform="translate(80,60)">
+<line x1="0" y1="299.71" x2="510" y2="299.71" stroke="#e5e5e5" stroke-width="1" />
+<line x1="0" y1="250.29" x2="510" y2="250.29" stroke="#e5e5e5" stroke-width="1" />
+<line x1="0" y1="200.88" x2="510" y2="200.88" stroke="#e5e5e5" stroke-width="1" />
+<line x1="0" y1="151.46" x2="510" y2="151.46" stroke="#e5e5e5" stroke-width="1" />
+<line x1="0" y1="102.04" x2="510" y2="102.04" stroke="#e5e5e5" stroke-width="1" />
+<line x1="0" y1="52.63" x2="510" y2="52.63" stroke="#e5e5e5" stroke-width="1" />
+<line x1="0" y1="3.21" x2="510" y2="3.21" stroke="#e5e5e5" stroke-width="1" />
+<line x1="0" y1="300" x2="510" y2="300" stroke="#333" stroke-width="1" />
+<line x1="0" y1="0" x2="0" y2="300" stroke="#333" stroke-width="1" />
+<line x1="39.23" y1="300" x2="39.23" y2="305" stroke="#333" stroke-width="1" />
+<text x="39.23" y="322" text-anchor="middle" fill="#444">20k €</text>
+<line x1="117.69" y1="300" x2="117.69" y2="305" stroke="#333" stroke-width="1" />
+<text x="117.69" y="322" text-anchor="middle" fill="#444">30k €</text>
+<line x1="196.15" y1="300" x2="196.15" y2="305" stroke="#333" stroke-width="1" />
+<text x="196.15" y="322" text-anchor="middle" fill="#444">40k €</text>
+<line x1="274.62" y1="300" x2="274.62" y2="305" stroke="#333" stroke-width="1" />
+<text x="274.62" y="322" text-anchor="middle" fill="#444">50k €</text>
+<line x1="353.08" y1="300" x2="353.08" y2="305" stroke="#333" stroke-width="1" />
+<text x="353.08" y="322" text-anchor="middle" fill="#444">60k €</text>
+<line x1="431.54" y1="300" x2="431.54" y2="305" stroke="#333" stroke-width="1" />
+<text x="431.54" y="322" text-anchor="middle" fill="#444">70k €</text>
+<line x1="510.00" y1="300" x2="510.00" y2="305" stroke="#333" stroke-width="1" />
+<text x="510.00" y="322" text-anchor="middle" fill="#444">80k €</text>
+<line x1="-5" y1="299.71" x2="0" y2="299.71" stroke="#333" stroke-width="1" />
+<text x="-10" y="303.71" text-anchor="end" fill="#444">5.0 %</text>
+<line x1="-5" y1="250.29" x2="0" y2="250.29" stroke="#333" stroke-width="1" />
+<text x="-10" y="254.29" text-anchor="end" fill="#444">10.0 %</text>
+<line x1="-5" y1="200.88" x2="0" y2="200.88" stroke="#333" stroke-width="1" />
+<text x="-10" y="204.88" text-anchor="end" fill="#444">15.0 %</text>
+<line x1="-5" y1="151.46" x2="0" y2="151.46" stroke="#333" stroke-width="1" />
+<text x="-10" y="155.46" text-anchor="end" fill="#444">20.0 %</text>
+<line x1="-5" y1="102.04" x2="0" y2="102.04" stroke="#333" stroke-width="1" />
+<text x="-10" y="106.04" text-anchor="end" fill="#444">25.0 %</text>
+<line x1="-5" y1="52.63" x2="0" y2="52.63" stroke="#333" stroke-width="1" />
+<text x="-10" y="56.63" text-anchor="end" fill="#444">30.0 %</text>
+<line x1="-5" y1="3.21" x2="0" y2="3.21" stroke="#333" stroke-width="1" />
+<text x="-10" y="7.21" text-anchor="end" fill="#444">35.0 %</text>
+<text x="255" y="348" text-anchor="middle" fill="#222" font-size="13">Bruto en € de 2026</text>
+<text transform="translate(-55,150) rotate(-90)" text-anchor="middle" fill="#222" font-size="13">Tipo medio efectivo</text>
+<polyline points="0.00,275.38 7.85,249.50 15.69,226.67 23.54,206.38 31.38,188.80 39.23,182.22 47.08,176.27 54.92,170.86 62.77,165.93 70.62,161.40 78.46,157.24 86.31,153.39 94.15,149.83 102.00,146.53 109.85,142.54 117.69,138.08 125.54,133.91 133.38,130.00 141.23,126.32 149.08,122.86 156.92,119.60 164.77,116.52 172.62,113.60 180.46,110.84 188.31,108.23 196.15,105.74 204.00,103.37 211.85,101.12 219.69,98.97 227.54,96.92 235.38,94.95 243.23,93.08 251.08,91.28 258.92,89.56 266.77,87.91 274.62,86.05 282.46,82.71 290.31,80.05 298.15,77.67 306.00,75.38 313.85,73.17 321.69,71.03 329.54,68.98 337.38,66.99 345.23,65.07 353.08,63.22 360.92,61.43 368.77,59.69 376.62,58.01 384.46,56.38 392.31,54.80 400.15,53.27 408.00,51.79 415.85,50.35 423.69,48.95 431.54,47.59 439.38,46.27 447.23,44.98 455.08,43.73 462.92,42.52 470.77,41.34 478.62,40.18 486.46,38.74 494.31,36.76 502.15,34.84 510.00,32.96" fill="none" stroke="#1f77b4" stroke-width="2" stroke-linejoin="round" stroke-linecap="round" />
+<circle cx="0.00" cy="275.38" r="2" fill="#1f77b4" />
+<circle cx="7.85" cy="249.50" r="2" fill="#1f77b4" />
+<circle cx="15.69" cy="226.67" r="2" fill="#1f77b4" />
+<circle cx="23.54" cy="206.38" r="2" fill="#1f77b4" />
+<circle cx="31.38" cy="188.80" r="2" fill="#1f77b4" />
+<circle cx="39.23" cy="182.22" r="2" fill="#1f77b4" />
+<circle cx="47.08" cy="176.27" r="2" fill="#1f77b4" />
+<circle cx="54.92" cy="170.86" r="2" fill="#1f77b4" />
+<circle cx="62.77" cy="165.93" r="2" fill="#1f77b4" />
+<circle cx="70.62" cy="161.40" r="2" fill="#1f77b4" />
+<circle cx="78.46" cy="157.24" r="2" fill="#1f77b4" />
+<circle cx="86.31" cy="153.39" r="2" fill="#1f77b4" />
+<circle cx="94.15" cy="149.83" r="2" fill="#1f77b4" />
+<circle cx="102.00" cy="146.53" r="2" fill="#1f77b4" />
+<circle cx="109.85" cy="142.54" r="2" fill="#1f77b4" />
+<circle cx="117.69" cy="138.08" r="2" fill="#1f77b4" />
+<circle cx="125.54" cy="133.91" r="2" fill="#1f77b4" />
+<circle cx="133.38" cy="130.00" r="2" fill="#1f77b4" />
+<circle cx="141.23" cy="126.32" r="2" fill="#1f77b4" />
+<circle cx="149.08" cy="122.86" r="2" fill="#1f77b4" />
+<circle cx="156.92" cy="119.60" r="2" fill="#1f77b4" />
+<circle cx="164.77" cy="116.52" r="2" fill="#1f77b4" />
+<circle cx="172.62" cy="113.60" r="2" fill="#1f77b4" />
+<circle cx="180.46" cy="110.84" r="2" fill="#1f77b4" />
+<circle cx="188.31" cy="108.23" r="2" fill="#1f77b4" />
+<circle cx="196.15" cy="105.74" r="2" fill="#1f77b4" />
+<circle cx="204.00" cy="103.37" r="2" fill="#1f77b4" />
+<circle cx="211.85" cy="101.12" r="2" fill="#1f77b4" />
+<circle cx="219.69" cy="98.97" r="2" fill="#1f77b4" />
+<circle cx="227.54" cy="96.92" r="2" fill="#1f77b4" />
+<circle cx="235.38" cy="94.95" r="2" fill="#1f77b4" />
+<circle cx="243.23" cy="93.08" r="2" fill="#1f77b4" />
+<circle cx="251.08" cy="91.28" r="2" fill="#1f77b4" />
+<circle cx="258.92" cy="89.56" r="2" fill="#1f77b4" />
+<circle cx="266.77" cy="87.91" r="2" fill="#1f77b4" />
+<circle cx="274.62" cy="86.05" r="2" fill="#1f77b4" />
+<circle cx="282.46" cy="82.71" r="2" fill="#1f77b4" />
+<circle cx="290.31" cy="80.05" r="2" fill="#1f77b4" />
+<circle cx="298.15" cy="77.67" r="2" fill="#1f77b4" />
+<circle cx="306.00" cy="75.38" r="2" fill="#1f77b4" />
+<circle cx="313.85" cy="73.17" r="2" fill="#1f77b4" />
+<circle cx="321.69" cy="71.03" r="2" fill="#1f77b4" />
+<circle cx="329.54" cy="68.98" r="2" fill="#1f77b4" />
+<circle cx="337.38" cy="66.99" r="2" fill="#1f77b4" />
+<circle cx="345.23" cy="65.07" r="2" fill="#1f77b4" />
+<circle cx="353.08" cy="63.22" r="2" fill="#1f77b4" />
+<circle cx="360.92" cy="61.43" r="2" fill="#1f77b4" />
+<circle cx="368.77" cy="59.69" r="2" fill="#1f77b4" />
+<circle cx="376.62" cy="58.01" r="2" fill="#1f77b4" />
+<circle cx="384.46" cy="56.38" r="2" fill="#1f77b4" />
+<circle cx="392.31" cy="54.80" r="2" fill="#1f77b4" />
+<circle cx="400.15" cy="53.27" r="2" fill="#1f77b4" />
+<circle cx="408.00" cy="51.79" r="2" fill="#1f77b4" />
+<circle cx="415.85" cy="50.35" r="2" fill="#1f77b4" />
+<circle cx="423.69" cy="48.95" r="2" fill="#1f77b4" />
+<circle cx="431.54" cy="47.59" r="2" fill="#1f77b4" />
+<circle cx="439.38" cy="46.27" r="2" fill="#1f77b4" />
+<circle cx="447.23" cy="44.98" r="2" fill="#1f77b4" />
+<circle cx="455.08" cy="43.73" r="2" fill="#1f77b4" />
+<circle cx="462.92" cy="42.52" r="2" fill="#1f77b4" />
+<circle cx="470.77" cy="41.34" r="2" fill="#1f77b4" />
+<circle cx="478.62" cy="40.18" r="2" fill="#1f77b4" />
+<circle cx="486.46" cy="38.74" r="2" fill="#1f77b4" />
+<circle cx="494.31" cy="36.76" r="2" fill="#1f77b4" />
+<circle cx="502.15" cy="34.84" r="2" fill="#1f77b4" />
+<circle cx="510.00" cy="32.96" r="2" fill="#1f77b4" />
+<polyline points="0.00,286.36 7.85,282.41 15.69,259.75 23.54,239.61 31.38,221.59 39.23,205.37 47.08,195.78 54.92,189.59 62.77,183.94 70.62,178.76 78.46,173.99 86.31,169.59 94.15,165.52 102.00,161.74 109.85,158.21 117.69,154.93 125.54,151.85 133.38,147.67 141.23,143.32 149.08,139.22 156.92,135.36 164.77,131.72 172.62,128.27 180.46,125.00 188.31,121.90 196.15,118.95 204.00,116.15 211.85,113.48 219.69,110.94 227.54,108.51 235.38,106.19 243.23,103.97 251.08,101.84 258.92,99.80 266.77,97.85 274.62,95.98 282.46,93.74 290.31,90.68 298.15,87.73 306.00,84.90 313.85,82.17 321.69,79.53 329.54,76.99 337.38,75.18 345.23,73.45 353.08,71.79 360.92,70.18 368.77,68.62 376.62,67.11 384.46,65.65 392.31,64.23 400.15,62.86 408.00,61.53 415.85,60.23 423.69,58.98 431.54,57.76 439.38,56.57 447.23,55.42 455.08,54.30 462.92,53.21 470.77,52.14 478.62,51.11 486.46,50.10 494.31,49.12 502.15,48.17 510.00,47.23" fill="none" stroke="#d62728" stroke-width="2" stroke-linejoin="round" stroke-linecap="round" />
+<circle cx="0.00" cy="286.36" r="2" fill="#d62728" />
+<circle cx="7.85" cy="282.41" r="2" fill="#d62728" />
+<circle cx="15.69" cy="259.75" r="2" fill="#d62728" />
+<circle cx="23.54" cy="239.61" r="2" fill="#d62728" />
+<circle cx="31.38" cy="221.59" r="2" fill="#d62728" />
+<circle cx="39.23" cy="205.37" r="2" fill="#d62728" />
+<circle cx="47.08" cy="195.78" r="2" fill="#d62728" />
+<circle cx="54.92" cy="189.59" r="2" fill="#d62728" />
+<circle cx="62.77" cy="183.94" r="2" fill="#d62728" />
+<circle cx="70.62" cy="178.76" r="2" fill="#d62728" />
+<circle cx="78.46" cy="173.99" r="2" fill="#d62728" />
+<circle cx="86.31" cy="169.59" r="2" fill="#d62728" />
+<circle cx="94.15" cy="165.52" r="2" fill="#d62728" />
+<circle cx="102.00" cy="161.74" r="2" fill="#d62728" />
+<circle cx="109.85" cy="158.21" r="2" fill="#d62728" />
+<circle cx="117.69" cy="154.93" r="2" fill="#d62728" />
+<circle cx="125.54" cy="151.85" r="2" fill="#d62728" />
+<circle cx="133.38" cy="147.67" r="2" fill="#d62728" />
+<circle cx="141.23" cy="143.32" r="2" fill="#d62728" />
+<circle cx="149.08" cy="139.22" r="2" fill="#d62728" />
+<circle cx="156.92" cy="135.36" r="2" fill="#d62728" />
+<circle cx="164.77" cy="131.72" r="2" fill="#d62728" />
+<circle cx="172.62" cy="128.27" r="2" fill="#d62728" />
+<circle cx="180.46" cy="125.00" r="2" fill="#d62728" />
+<circle cx="188.31" cy="121.90" r="2" fill="#d62728" />
+<circle cx="196.15" cy="118.95" r="2" fill="#d62728" />
+<circle cx="204.00" cy="116.15" r="2" fill="#d62728" />
+<circle cx="211.85" cy="113.48" r="2" fill="#d62728" />
+<circle cx="219.69" cy="110.94" r="2" fill="#d62728" />
+<circle cx="227.54" cy="108.51" r="2" fill="#d62728" />
+<circle cx="235.38" cy="106.19" r="2" fill="#d62728" />
+<circle cx="243.23" cy="103.97" r="2" fill="#d62728" />
+<circle cx="251.08" cy="101.84" r="2" fill="#d62728" />
+<circle cx="258.92" cy="99.80" r="2" fill="#d62728" />
+<circle cx="266.77" cy="97.85" r="2" fill="#d62728" />
+<circle cx="274.62" cy="95.98" r="2" fill="#d62728" />
+<circle cx="282.46" cy="93.74" r="2" fill="#d62728" />
+<circle cx="290.31" cy="90.68" r="2" fill="#d62728" />
+<circle cx="298.15" cy="87.73" r="2" fill="#d62728" />
+<circle cx="306.00" cy="84.90" r="2" fill="#d62728" />
+<circle cx="313.85" cy="82.17" r="2" fill="#d62728" />
+<circle cx="321.69" cy="79.53" r="2" fill="#d62728" />
+<circle cx="329.54" cy="76.99" r="2" fill="#d62728" />
+<circle cx="337.38" cy="75.18" r="2" fill="#d62728" />
+<circle cx="345.23" cy="73.45" r="2" fill="#d62728" />
+<circle cx="353.08" cy="71.79" r="2" fill="#d62728" />
+<circle cx="360.92" cy="70.18" r="2" fill="#d62728" />
+<circle cx="368.77" cy="68.62" r="2" fill="#d62728" />
+<circle cx="376.62" cy="67.11" r="2" fill="#d62728" />
+<circle cx="384.46" cy="65.65" r="2" fill="#d62728" />
+<circle cx="392.31" cy="64.23" r="2" fill="#d62728" />
+<circle cx="400.15" cy="62.86" r="2" fill="#d62728" />
+<circle cx="408.00" cy="61.53" r="2" fill="#d62728" />
+<circle cx="415.85" cy="60.23" r="2" fill="#d62728" />
+<circle cx="423.69" cy="58.98" r="2" fill="#d62728" />
+<circle cx="431.54" cy="57.76" r="2" fill="#d62728" />
+<circle cx="439.38" cy="56.57" r="2" fill="#d62728" />
+<circle cx="447.23" cy="55.42" r="2" fill="#d62728" />
+<circle cx="455.08" cy="54.30" r="2" fill="#d62728" />
+<circle cx="462.92" cy="53.21" r="2" fill="#d62728" />
+<circle cx="470.77" cy="52.14" r="2" fill="#d62728" />
+<circle cx="478.62" cy="51.11" r="2" fill="#d62728" />
+<circle cx="486.46" cy="50.10" r="2" fill="#d62728" />
+<circle cx="494.31" cy="49.12" r="2" fill="#d62728" />
+<circle cx="502.15" cy="48.17" r="2" fill="#d62728" />
+<circle cx="510.00" cy="47.23" r="2" fill="#d62728" />
+<polyline points="0.00,286.36 7.85,286.36 15.69,270.62 23.54,254.33 31.38,234.47 39.23,218.78 47.08,207.14 54.92,193.08 62.77,181.78 70.62,176.89 78.46,172.38 86.31,168.22 94.15,164.37 102.00,160.79 109.85,157.46 117.69,154.35 125.54,149.77 133.38,145.36 141.23,141.22 149.08,137.32 156.92,133.65 164.77,130.18 172.62,126.90 180.46,123.79 188.31,120.83 196.15,118.03 204.00,115.36 211.85,112.82 219.69,110.40 227.54,108.09 235.38,105.88 243.23,103.77 251.08,101.75 258.92,99.81 266.77,97.95 274.62,96.16 282.46,93.66 290.31,90.78 298.15,88.01 306.00,85.34 313.85,82.77 321.69,80.29 329.54,77.90 337.38,76.21 345.23,74.63 353.08,73.12 360.92,71.65 368.77,70.22 376.62,68.85 384.46,67.51 392.31,66.22 400.15,64.96 408.00,63.75 415.85,62.57 423.69,61.42 431.54,60.31 439.38,59.22 447.23,58.17 455.08,57.15 462.92,56.15 470.77,55.18 478.62,54.24 486.46,53.32 494.31,52.42 502.15,51.55 510.00,50.70" fill="none" stroke="#2ca02c" stroke-width="2" stroke-linejoin="round" stroke-linecap="round" />
+<circle cx="0.00" cy="286.36" r="2" fill="#2ca02c" />
+<circle cx="7.85" cy="286.36" r="2" fill="#2ca02c" />
+<circle cx="15.69" cy="270.62" r="2" fill="#2ca02c" />
+<circle cx="23.54" cy="254.33" r="2" fill="#2ca02c" />
+<circle cx="31.38" cy="234.47" r="2" fill="#2ca02c" />
+<circle cx="39.23" cy="218.78" r="2" fill="#2ca02c" />
+<circle cx="47.08" cy="207.14" r="2" fill="#2ca02c" />
+<circle cx="54.92" cy="193.08" r="2" fill="#2ca02c" />
+<circle cx="62.77" cy="181.78" r="2" fill="#2ca02c" />
+<circle cx="70.62" cy="176.89" r="2" fill="#2ca02c" />
+<circle cx="78.46" cy="172.38" r="2" fill="#2ca02c" />
+<circle cx="86.31" cy="168.22" r="2" fill="#2ca02c" />
+<circle cx="94.15" cy="164.37" r="2" fill="#2ca02c" />
+<circle cx="102.00" cy="160.79" r="2" fill="#2ca02c" />
+<circle cx="109.85" cy="157.46" r="2" fill="#2ca02c" />
+<circle cx="117.69" cy="154.35" r="2" fill="#2ca02c" />
+<circle cx="125.54" cy="149.77" r="2" fill="#2ca02c" />
+<circle cx="133.38" cy="145.36" r="2" fill="#2ca02c" />
+<circle cx="141.23" cy="141.22" r="2" fill="#2ca02c" />
+<circle cx="149.08" cy="137.32" r="2" fill="#2ca02c" />
+<circle cx="156.92" cy="133.65" r="2" fill="#2ca02c" />
+<circle cx="164.77" cy="130.18" r="2" fill="#2ca02c" />
+<circle cx="172.62" cy="126.90" r="2" fill="#2ca02c" />
+<circle cx="180.46" cy="123.79" r="2" fill="#2ca02c" />
+<circle cx="188.31" cy="120.83" r="2" fill="#2ca02c" />
+<circle cx="196.15" cy="118.03" r="2" fill="#2ca02c" />
+<circle cx="204.00" cy="115.36" r="2" fill="#2ca02c" />
+<circle cx="211.85" cy="112.82" r="2" fill="#2ca02c" />
+<circle cx="219.69" cy="110.40" r="2" fill="#2ca02c" />
+<circle cx="227.54" cy="108.09" r="2" fill="#2ca02c" />
+<circle cx="235.38" cy="105.88" r="2" fill="#2ca02c" />
+<circle cx="243.23" cy="103.77" r="2" fill="#2ca02c" />
+<circle cx="251.08" cy="101.75" r="2" fill="#2ca02c" />
+<circle cx="258.92" cy="99.81" r="2" fill="#2ca02c" />
+<circle cx="266.77" cy="97.95" r="2" fill="#2ca02c" />
+<circle cx="274.62" cy="96.16" r="2" fill="#2ca02c" />
+<circle cx="282.46" cy="93.66" r="2" fill="#2ca02c" />
+<circle cx="290.31" cy="90.78" r="2" fill="#2ca02c" />
+<circle cx="298.15" cy="88.01" r="2" fill="#2ca02c" />
+<circle cx="306.00" cy="85.34" r="2" fill="#2ca02c" />
+<circle cx="313.85" cy="82.77" r="2" fill="#2ca02c" />
+<circle cx="321.69" cy="80.29" r="2" fill="#2ca02c" />
+<circle cx="329.54" cy="77.90" r="2" fill="#2ca02c" />
+<circle cx="337.38" cy="76.21" r="2" fill="#2ca02c" />
+<circle cx="345.23" cy="74.63" r="2" fill="#2ca02c" />
+<circle cx="353.08" cy="73.12" r="2" fill="#2ca02c" />
+<circle cx="360.92" cy="71.65" r="2" fill="#2ca02c" />
+<circle cx="368.77" cy="70.22" r="2" fill="#2ca02c" />
+<circle cx="376.62" cy="68.85" r="2" fill="#2ca02c" />
+<circle cx="384.46" cy="67.51" r="2" fill="#2ca02c" />
+<circle cx="392.31" cy="66.22" r="2" fill="#2ca02c" />
+<circle cx="400.15" cy="64.96" r="2" fill="#2ca02c" />
+<circle cx="408.00" cy="63.75" r="2" fill="#2ca02c" />
+<circle cx="415.85" cy="62.57" r="2" fill="#2ca02c" />
+<circle cx="423.69" cy="61.42" r="2" fill="#2ca02c" />
+<circle cx="431.54" cy="60.31" r="2" fill="#2ca02c" />
+<circle cx="439.38" cy="59.22" r="2" fill="#2ca02c" />
+<circle cx="447.23" cy="58.17" r="2" fill="#2ca02c" />
+<circle cx="455.08" cy="57.15" r="2" fill="#2ca02c" />
+<circle cx="462.92" cy="56.15" r="2" fill="#2ca02c" />
+<circle cx="470.77" cy="55.18" r="2" fill="#2ca02c" />
+<circle cx="478.62" cy="54.24" r="2" fill="#2ca02c" />
+<circle cx="486.46" cy="53.32" r="2" fill="#2ca02c" />
+<circle cx="494.31" cy="52.42" r="2" fill="#2ca02c" />
+<circle cx="502.15" cy="51.55" r="2" fill="#2ca02c" />
+<circle cx="510.00" cy="50.70" r="2" fill="#2ca02c" />
+<polyline points="0.00,286.36 7.85,279.10 15.69,254.53 23.54,232.69 31.38,213.15 39.23,195.56 47.08,179.65 54.92,173.08 62.77,168.35 70.62,164.01 78.46,160.02 86.31,156.33 94.15,152.16 102.00,147.04 109.85,142.27 117.69,137.81 125.54,133.65 133.38,129.74 141.23,126.08 149.08,122.62 156.92,119.37 164.77,116.29 172.62,113.39 180.46,110.63 188.31,108.02 196.15,105.54 204.00,103.17 211.85,100.92 219.69,98.78 227.54,96.73 235.38,94.23 243.23,90.96 251.08,87.83 258.92,84.84 266.77,81.96 274.62,79.20 282.46,76.55 290.31,73.99 298.15,71.54 306.00,69.18 313.85,66.90 321.69,64.85 329.54,63.42 337.38,62.04 345.23,60.71 353.08,59.42 360.92,58.17 368.77,56.97 376.62,55.80 384.46,54.67 392.31,53.58 400.15,52.51 408.00,51.48 415.85,50.48 423.69,49.51 431.54,48.57 439.38,47.65 447.23,46.76 455.08,45.89 462.92,44.18 470.77,42.32 478.62,40.50 486.46,38.73 494.31,37.01 502.15,35.33 510.00,33.70" fill="none" stroke="#9467bd" stroke-width="2" stroke-linejoin="round" stroke-linecap="round" />
+<circle cx="0.00" cy="286.36" r="2" fill="#9467bd" />
+<circle cx="7.85" cy="279.10" r="2" fill="#9467bd" />
+<circle cx="15.69" cy="254.53" r="2" fill="#9467bd" />
+<circle cx="23.54" cy="232.69" r="2" fill="#9467bd" />
+<circle cx="31.38" cy="213.15" r="2" fill="#9467bd" />
+<circle cx="39.23" cy="195.56" r="2" fill="#9467bd" />
+<circle cx="47.08" cy="179.65" r="2" fill="#9467bd" />
+<circle cx="54.92" cy="173.08" r="2" fill="#9467bd" />
+<circle cx="62.77" cy="168.35" r="2" fill="#9467bd" />
+<circle cx="70.62" cy="164.01" r="2" fill="#9467bd" />
+<circle cx="78.46" cy="160.02" r="2" fill="#9467bd" />
+<circle cx="86.31" cy="156.33" r="2" fill="#9467bd" />
+<circle cx="94.15" cy="152.16" r="2" fill="#9467bd" />
+<circle cx="102.00" cy="147.04" r="2" fill="#9467bd" />
+<circle cx="109.85" cy="142.27" r="2" fill="#9467bd" />
+<circle cx="117.69" cy="137.81" r="2" fill="#9467bd" />
+<circle cx="125.54" cy="133.65" r="2" fill="#9467bd" />
+<circle cx="133.38" cy="129.74" r="2" fill="#9467bd" />
+<circle cx="141.23" cy="126.08" r="2" fill="#9467bd" />
+<circle cx="149.08" cy="122.62" r="2" fill="#9467bd" />
+<circle cx="156.92" cy="119.37" r="2" fill="#9467bd" />
+<circle cx="164.77" cy="116.29" r="2" fill="#9467bd" />
+<circle cx="172.62" cy="113.39" r="2" fill="#9467bd" />
+<circle cx="180.46" cy="110.63" r="2" fill="#9467bd" />
+<circle cx="188.31" cy="108.02" r="2" fill="#9467bd" />
+<circle cx="196.15" cy="105.54" r="2" fill="#9467bd" />
+<circle cx="204.00" cy="103.17" r="2" fill="#9467bd" />
+<circle cx="211.85" cy="100.92" r="2" fill="#9467bd" />
+<circle cx="219.69" cy="98.78" r="2" fill="#9467bd" />
+<circle cx="227.54" cy="96.73" r="2" fill="#9467bd" />
+<circle cx="235.38" cy="94.23" r="2" fill="#9467bd" />
+<circle cx="243.23" cy="90.96" r="2" fill="#9467bd" />
+<circle cx="251.08" cy="87.83" r="2" fill="#9467bd" />
+<circle cx="258.92" cy="84.84" r="2" fill="#9467bd" />
+<circle cx="266.77" cy="81.96" r="2" fill="#9467bd" />
+<circle cx="274.62" cy="79.20" r="2" fill="#9467bd" />
+<circle cx="282.46" cy="76.55" r="2" fill="#9467bd" />
+<circle cx="290.31" cy="73.99" r="2" fill="#9467bd" />
+<circle cx="298.15" cy="71.54" r="2" fill="#9467bd" />
+<circle cx="306.00" cy="69.18" r="2" fill="#9467bd" />
+<circle cx="313.85" cy="66.90" r="2" fill="#9467bd" />
+<circle cx="321.69" cy="64.85" r="2" fill="#9467bd" />
+<circle cx="329.54" cy="63.42" r="2" fill="#9467bd" />
+<circle cx="337.38" cy="62.04" r="2" fill="#9467bd" />
+<circle cx="345.23" cy="60.71" r="2" fill="#9467bd" />
+<circle cx="353.08" cy="59.42" r="2" fill="#9467bd" />
+<circle cx="360.92" cy="58.17" r="2" fill="#9467bd" />
+<circle cx="368.77" cy="56.97" r="2" fill="#9467bd" />
+<circle cx="376.62" cy="55.80" r="2" fill="#9467bd" />
+<circle cx="384.46" cy="54.67" r="2" fill="#9467bd" />
+<circle cx="392.31" cy="53.58" r="2" fill="#9467bd" />
+<circle cx="400.15" cy="52.51" r="2" fill="#9467bd" />
+<circle cx="408.00" cy="51.48" r="2" fill="#9467bd" />
+<circle cx="415.85" cy="50.48" r="2" fill="#9467bd" />
+<circle cx="423.69" cy="49.51" r="2" fill="#9467bd" />
+<circle cx="431.54" cy="48.57" r="2" fill="#9467bd" />
+<circle cx="439.38" cy="47.65" r="2" fill="#9467bd" />
+<circle cx="447.23" cy="46.76" r="2" fill="#9467bd" />
+<circle cx="455.08" cy="45.89" r="2" fill="#9467bd" />
+<circle cx="462.92" cy="44.18" r="2" fill="#9467bd" />
+<circle cx="470.77" cy="42.32" r="2" fill="#9467bd" />
+<circle cx="478.62" cy="40.50" r="2" fill="#9467bd" />
+<circle cx="486.46" cy="38.73" r="2" fill="#9467bd" />
+<circle cx="494.31" cy="37.01" r="2" fill="#9467bd" />
+<circle cx="502.15" cy="35.33" r="2" fill="#9467bd" />
+<circle cx="510.00" cy="33.70" r="2" fill="#9467bd" />
+<polyline points="0.00,285.18 7.85,285.18 15.69,280.84 23.54,257.47 31.38,236.56 39.23,217.75 47.08,200.72 54.92,185.24 62.77,171.11 70.62,158.16 78.46,153.71 86.31,148.43 94.15,143.23 102.00,138.39 109.85,133.89 117.69,129.69 125.54,125.76 133.38,122.08 141.23,118.62 149.08,115.36 156.92,112.29 164.77,109.39 172.62,106.64 180.46,104.04 188.31,101.58 196.15,99.24 204.00,97.01 211.85,94.88 219.69,91.59 227.54,88.22 235.38,84.99 243.23,81.91 251.08,78.96 258.92,76.13 266.77,73.41 274.62,70.81 282.46,68.31 290.31,65.90 298.15,63.58 306.00,61.35 313.85,59.21 321.69,57.13 329.54,55.13 337.38,53.20 345.23,51.34 353.08,49.54 360.92,48.43 368.77,47.38 376.62,46.36 384.46,45.38 392.31,44.43 400.15,43.50 408.00,42.61 415.85,41.74 423.69,40.89 431.54,39.62 439.38,37.71 447.23,35.86 455.08,34.06 462.92,32.31 470.77,30.60 478.62,28.94 486.46,27.32 494.31,25.75 502.15,24.21 510.00,22.71" fill="none" stroke="#ff7f0e" stroke-width="2" stroke-linejoin="round" stroke-linecap="round" />
+<circle cx="0.00" cy="285.18" r="2" fill="#ff7f0e" />
+<circle cx="7.85" cy="285.18" r="2" fill="#ff7f0e" />
+<circle cx="15.69" cy="280.84" r="2" fill="#ff7f0e" />
+<circle cx="23.54" cy="257.47" r="2" fill="#ff7f0e" />
+<circle cx="31.38" cy="236.56" r="2" fill="#ff7f0e" />
+<circle cx="39.23" cy="217.75" r="2" fill="#ff7f0e" />
+<circle cx="47.08" cy="200.72" r="2" fill="#ff7f0e" />
+<circle cx="54.92" cy="185.24" r="2" fill="#ff7f0e" />
+<circle cx="62.77" cy="171.11" r="2" fill="#ff7f0e" />
+<circle cx="70.62" cy="158.16" r="2" fill="#ff7f0e" />
+<circle cx="78.46" cy="153.71" r="2" fill="#ff7f0e" />
+<circle cx="86.31" cy="148.43" r="2" fill="#ff7f0e" />
+<circle cx="94.15" cy="143.23" r="2" fill="#ff7f0e" />
+<circle cx="102.00" cy="138.39" r="2" fill="#ff7f0e" />
+<circle cx="109.85" cy="133.89" r="2" fill="#ff7f0e" />
+<circle cx="117.69" cy="129.69" r="2" fill="#ff7f0e" />
+<circle cx="125.54" cy="125.76" r="2" fill="#ff7f0e" />
+<circle cx="133.38" cy="122.08" r="2" fill="#ff7f0e" />
+<circle cx="141.23" cy="118.62" r="2" fill="#ff7f0e" />
+<circle cx="149.08" cy="115.36" r="2" fill="#ff7f0e" />
+<circle cx="156.92" cy="112.29" r="2" fill="#ff7f0e" />
+<circle cx="164.77" cy="109.39" r="2" fill="#ff7f0e" />
+<circle cx="172.62" cy="106.64" r="2" fill="#ff7f0e" />
+<circle cx="180.46" cy="104.04" r="2" fill="#ff7f0e" />
+<circle cx="188.31" cy="101.58" r="2" fill="#ff7f0e" />
+<circle cx="196.15" cy="99.24" r="2" fill="#ff7f0e" />
+<circle cx="204.00" cy="97.01" r="2" fill="#ff7f0e" />
+<circle cx="211.85" cy="94.88" r="2" fill="#ff7f0e" />
+<circle cx="219.69" cy="91.59" r="2" fill="#ff7f0e" />
+<circle cx="227.54" cy="88.22" r="2" fill="#ff7f0e" />
+<circle cx="235.38" cy="84.99" r="2" fill="#ff7f0e" />
+<circle cx="243.23" cy="81.91" r="2" fill="#ff7f0e" />
+<circle cx="251.08" cy="78.96" r="2" fill="#ff7f0e" />
+<circle cx="258.92" cy="76.13" r="2" fill="#ff7f0e" />
+<circle cx="266.77" cy="73.41" r="2" fill="#ff7f0e" />
+<circle cx="274.62" cy="70.81" r="2" fill="#ff7f0e" />
+<circle cx="282.46" cy="68.31" r="2" fill="#ff7f0e" />
+<circle cx="290.31" cy="65.90" r="2" fill="#ff7f0e" />
+<circle cx="298.15" cy="63.58" r="2" fill="#ff7f0e" />
+<circle cx="306.00" cy="61.35" r="2" fill="#ff7f0e" />
+<circle cx="313.85" cy="59.21" r="2" fill="#ff7f0e" />
+<circle cx="321.69" cy="57.13" r="2" fill="#ff7f0e" />
+<circle cx="329.54" cy="55.13" r="2" fill="#ff7f0e" />
+<circle cx="337.38" cy="53.20" r="2" fill="#ff7f0e" />
+<circle cx="345.23" cy="51.34" r="2" fill="#ff7f0e" />
+<circle cx="353.08" cy="49.54" r="2" fill="#ff7f0e" />
+<circle cx="360.92" cy="48.43" r="2" fill="#ff7f0e" />
+<circle cx="368.77" cy="47.38" r="2" fill="#ff7f0e" />
+<circle cx="376.62" cy="46.36" r="2" fill="#ff7f0e" />
+<circle cx="384.46" cy="45.38" r="2" fill="#ff7f0e" />
+<circle cx="392.31" cy="44.43" r="2" fill="#ff7f0e" />
+<circle cx="400.15" cy="43.50" r="2" fill="#ff7f0e" />
+<circle cx="408.00" cy="42.61" r="2" fill="#ff7f0e" />
+<circle cx="415.85" cy="41.74" r="2" fill="#ff7f0e" />
+<circle cx="423.69" cy="40.89" r="2" fill="#ff7f0e" />
+<circle cx="431.54" cy="39.62" r="2" fill="#ff7f0e" />
+<circle cx="439.38" cy="37.71" r="2" fill="#ff7f0e" />
+<circle cx="447.23" cy="35.86" r="2" fill="#ff7f0e" />
+<circle cx="455.08" cy="34.06" r="2" fill="#ff7f0e" />
+<circle cx="462.92" cy="32.31" r="2" fill="#ff7f0e" />
+<circle cx="470.77" cy="30.60" r="2" fill="#ff7f0e" />
+<circle cx="478.62" cy="28.94" r="2" fill="#ff7f0e" />
+<circle cx="486.46" cy="27.32" r="2" fill="#ff7f0e" />
+<circle cx="494.31" cy="25.75" r="2" fill="#ff7f0e" />
+<circle cx="502.15" cy="24.21" r="2" fill="#ff7f0e" />
+<circle cx="510.00" cy="22.71" r="2" fill="#ff7f0e" />
+<polyline points="0.00,284.88 7.85,284.88 15.69,284.88 23.54,250.63 31.38,215.01 39.23,197.25 47.08,181.19 54.92,166.58 62.77,155.79 70.62,151.34 78.46,145.59 86.31,140.28 94.15,135.37 102.00,130.81 109.85,126.57 117.69,122.60 125.54,118.89 133.38,115.42 141.23,112.15 149.08,109.08 156.92,106.18 164.77,103.44 172.62,100.86 180.46,98.40 188.31,96.08 196.15,93.52 204.00,89.85 211.85,86.35 219.69,83.02 227.54,79.83 235.38,76.79 243.23,73.88 251.08,71.10 258.92,68.43 266.77,65.87 274.62,63.41 282.46,61.05 290.31,58.78 298.15,56.59 306.00,54.49 313.85,52.46 321.69,50.51 329.54,48.62 337.38,46.80 345.23,45.04 353.08,43.34 360.92,41.69 368.77,40.60 376.62,39.67 384.46,38.78 392.31,37.91 400.15,37.05 408.00,35.05 415.85,33.12 423.69,31.23 431.54,29.41 439.38,27.63 447.23,25.90 455.08,24.22 462.92,22.59 470.77,21.00 478.62,19.45 486.46,17.94 494.31,16.47 502.15,15.03 510.00,13.64" fill="none" stroke="#17becf" stroke-width="2" stroke-linejoin="round" stroke-linecap="round" />
+<circle cx="0.00" cy="284.88" r="2" fill="#17becf" />
+<circle cx="7.85" cy="284.88" r="2" fill="#17becf" />
+<circle cx="15.69" cy="284.88" r="2" fill="#17becf" />
+<circle cx="23.54" cy="250.63" r="2" fill="#17becf" />
+<circle cx="31.38" cy="215.01" r="2" fill="#17becf" />
+<circle cx="39.23" cy="197.25" r="2" fill="#17becf" />
+<circle cx="47.08" cy="181.19" r="2" fill="#17becf" />
+<circle cx="54.92" cy="166.58" r="2" fill="#17becf" />
+<circle cx="62.77" cy="155.79" r="2" fill="#17becf" />
+<circle cx="70.62" cy="151.34" r="2" fill="#17becf" />
+<circle cx="78.46" cy="145.59" r="2" fill="#17becf" />
+<circle cx="86.31" cy="140.28" r="2" fill="#17becf" />
+<circle cx="94.15" cy="135.37" r="2" fill="#17becf" />
+<circle cx="102.00" cy="130.81" r="2" fill="#17becf" />
+<circle cx="109.85" cy="126.57" r="2" fill="#17becf" />
+<circle cx="117.69" cy="122.60" r="2" fill="#17becf" />
+<circle cx="125.54" cy="118.89" r="2" fill="#17becf" />
+<circle cx="133.38" cy="115.42" r="2" fill="#17becf" />
+<circle cx="141.23" cy="112.15" r="2" fill="#17becf" />
+<circle cx="149.08" cy="109.08" r="2" fill="#17becf" />
+<circle cx="156.92" cy="106.18" r="2" fill="#17becf" />
+<circle cx="164.77" cy="103.44" r="2" fill="#17becf" />
+<circle cx="172.62" cy="100.86" r="2" fill="#17becf" />
+<circle cx="180.46" cy="98.40" r="2" fill="#17becf" />
+<circle cx="188.31" cy="96.08" r="2" fill="#17becf" />
+<circle cx="196.15" cy="93.52" r="2" fill="#17becf" />
+<circle cx="204.00" cy="89.85" r="2" fill="#17becf" />
+<circle cx="211.85" cy="86.35" r="2" fill="#17becf" />
+<circle cx="219.69" cy="83.02" r="2" fill="#17becf" />
+<circle cx="227.54" cy="79.83" r="2" fill="#17becf" />
+<circle cx="235.38" cy="76.79" r="2" fill="#17becf" />
+<circle cx="243.23" cy="73.88" r="2" fill="#17becf" />
+<circle cx="251.08" cy="71.10" r="2" fill="#17becf" />
+<circle cx="258.92" cy="68.43" r="2" fill="#17becf" />
+<circle cx="266.77" cy="65.87" r="2" fill="#17becf" />
+<circle cx="274.62" cy="63.41" r="2" fill="#17becf" />
+<circle cx="282.46" cy="61.05" r="2" fill="#17becf" />
+<circle cx="290.31" cy="58.78" r="2" fill="#17becf" />
+<circle cx="298.15" cy="56.59" r="2" fill="#17becf" />
+<circle cx="306.00" cy="54.49" r="2" fill="#17becf" />
+<circle cx="313.85" cy="52.46" r="2" fill="#17becf" />
+<circle cx="321.69" cy="50.51" r="2" fill="#17becf" />
+<circle cx="329.54" cy="48.62" r="2" fill="#17becf" />
+<circle cx="337.38" cy="46.80" r="2" fill="#17becf" />
+<circle cx="345.23" cy="45.04" r="2" fill="#17becf" />
+<circle cx="353.08" cy="43.34" r="2" fill="#17becf" />
+<circle cx="360.92" cy="41.69" r="2" fill="#17becf" />
+<circle cx="368.77" cy="40.60" r="2" fill="#17becf" />
+<circle cx="376.62" cy="39.67" r="2" fill="#17becf" />
+<circle cx="384.46" cy="38.78" r="2" fill="#17becf" />
+<circle cx="392.31" cy="37.91" r="2" fill="#17becf" />
+<circle cx="400.15" cy="37.05" r="2" fill="#17becf" />
+<circle cx="408.00" cy="35.05" r="2" fill="#17becf" />
+<circle cx="415.85" cy="33.12" r="2" fill="#17becf" />
+<circle cx="423.69" cy="31.23" r="2" fill="#17becf" />
+<circle cx="431.54" cy="29.41" r="2" fill="#17becf" />
+<circle cx="439.38" cy="27.63" r="2" fill="#17becf" />
+<circle cx="447.23" cy="25.90" r="2" fill="#17becf" />
+<circle cx="455.08" cy="24.22" r="2" fill="#17becf" />
+<circle cx="462.92" cy="22.59" r="2" fill="#17becf" />
+<circle cx="470.77" cy="21.00" r="2" fill="#17becf" />
+<circle cx="478.62" cy="19.45" r="2" fill="#17becf" />
+<circle cx="486.46" cy="17.94" r="2" fill="#17becf" />
+<circle cx="494.31" cy="16.47" r="2" fill="#17becf" />
+<circle cx="502.15" cy="15.03" r="2" fill="#17becf" />
+<circle cx="510.00" cy="13.64" r="2" fill="#17becf" />
+<rect x="528" y="0" width="14" height="3" fill="#1f77b4" />
+<text x="550" y="6" fill="#222" font-size="12">2012</text>
+<rect x="528" y="22" width="14" height="3" fill="#d62728" />
+<text x="550" y="28" fill="#222" font-size="12">2015</text>
+<rect x="528" y="44" width="14" height="3" fill="#2ca02c" />
+<text x="550" y="50" fill="#222" font-size="12">2018</text>
+<rect x="528" y="66" width="14" height="3" fill="#9467bd" />
+<text x="550" y="72" fill="#222" font-size="12">2022</text>
+<rect x="528" y="88" width="14" height="3" fill="#ff7f0e" />
+<text x="550" y="94" fill="#222" font-size="12">2024</text>
+<rect x="528" y="110" width="14" height="3" fill="#17becf" />
+<text x="550" y="116" fill="#222" font-size="12">2026</text>
+</g>
+</svg>

--- a/docs/auditoria/progreso.md
+++ b/docs/auditoria/progreso.md
@@ -52,4 +52,4 @@ y `✓` "aplicable, validado".
 4. Si el valor es correcto, marca el ítem y deja la(s) referencia(s) en la sección "Referencias BOE" del issue.
 5. Si encuentras una discrepancia, abre un PR `audit:` con la plantilla `?template=audit.md`: corrige el valor, regenera el fixture afectado y cita la referencia BOE.
 
-Ver [`CONTRIBUTING.md`](../../CONTRIBUTING.md) para el flujo OSS general.
+Ver [`CONTRIBUTING.md`](https://github.com/ceballosiker/auditor-irpf-es/blob/main/CONTRIBUTING.md) para el flujo OSS general.

--- a/docs/auditoria/progreso.md
+++ b/docs/auditoria/progreso.md
@@ -26,23 +26,25 @@ y `✓` "aplicable, validado".
 
 ## Tabla de progreso
 
-| Año  | Issue                                                            | MEI | Solidaridad | SMI | Estado      |
-| ---- | ---------------------------------------------------------------- | --- | ----------- | --- | ----------- |
-| 2012 | [#17](https://github.com/ceballosiker/auditor-irpf-es/issues/17) | —   | —           | —   | no iniciado |
-| 2013 | [#18](https://github.com/ceballosiker/auditor-irpf-es/issues/18) | —   | —           | —   | no iniciado |
-| 2014 | [#19](https://github.com/ceballosiker/auditor-irpf-es/issues/19) | —   | —           | —   | no iniciado |
-| 2015 | [#20](https://github.com/ceballosiker/auditor-irpf-es/issues/20) | —   | —           | —   | no iniciado |
-| 2016 | [#21](https://github.com/ceballosiker/auditor-irpf-es/issues/21) | —   | —           | —   | no iniciado |
-| 2017 | [#22](https://github.com/ceballosiker/auditor-irpf-es/issues/22) | —   | —           | —   | no iniciado |
-| 2018 | [#23](https://github.com/ceballosiker/auditor-irpf-es/issues/23) | —   | —           | —   | no iniciado |
-| 2019 | [#24](https://github.com/ceballosiker/auditor-irpf-es/issues/24) | —   | —           | —   | no iniciado |
-| 2020 | [#25](https://github.com/ceballosiker/auditor-irpf-es/issues/25) | —   | —           | —   | no iniciado |
-| 2021 | [#26](https://github.com/ceballosiker/auditor-irpf-es/issues/26) | —   | —           | —   | no iniciado |
-| 2022 | [#27](https://github.com/ceballosiker/auditor-irpf-es/issues/27) | —   | —           | —   | no iniciado |
-| 2023 | [#28](https://github.com/ceballosiker/auditor-irpf-es/issues/28) | ☐   | —           | —   | no iniciado |
-| 2024 | [#29](https://github.com/ceballosiker/auditor-irpf-es/issues/29) | ☐   | —           | —   | no iniciado |
-| 2025 | [#30](https://github.com/ceballosiker/auditor-irpf-es/issues/30) | ☐   | ☐           | ☐   | no iniciado |
-| 2026 | [#31](https://github.com/ceballosiker/auditor-irpf-es/issues/31) | ☐   | ☐           | ☐   | no iniciado |
+La columna **Manual** indica el estado de la página `docs/anual/YYYY.md`: `stub` significa que sólo contiene los parámetros generados desde `src/normativa.ts`; `redactado` significa que tiene la prosa completa con referencias BOE (entregable de Phase 5 / v1.1.0).
+
+| Año  | Issue                                                            | MEI | Solidaridad | SMI | Manual | Estado      |
+| ---- | ---------------------------------------------------------------- | --- | ----------- | --- | ------ | ----------- |
+| 2012 | [#17](https://github.com/ceballosiker/auditor-irpf-es/issues/17) | —   | —           | —   | stub   | no iniciado |
+| 2013 | [#18](https://github.com/ceballosiker/auditor-irpf-es/issues/18) | —   | —           | —   | stub   | no iniciado |
+| 2014 | [#19](https://github.com/ceballosiker/auditor-irpf-es/issues/19) | —   | —           | —   | stub   | no iniciado |
+| 2015 | [#20](https://github.com/ceballosiker/auditor-irpf-es/issues/20) | —   | —           | —   | stub   | no iniciado |
+| 2016 | [#21](https://github.com/ceballosiker/auditor-irpf-es/issues/21) | —   | —           | —   | stub   | no iniciado |
+| 2017 | [#22](https://github.com/ceballosiker/auditor-irpf-es/issues/22) | —   | —           | —   | stub   | no iniciado |
+| 2018 | [#23](https://github.com/ceballosiker/auditor-irpf-es/issues/23) | —   | —           | —   | stub   | no iniciado |
+| 2019 | [#24](https://github.com/ceballosiker/auditor-irpf-es/issues/24) | —   | —           | —   | stub   | no iniciado |
+| 2020 | [#25](https://github.com/ceballosiker/auditor-irpf-es/issues/25) | —   | —           | —   | stub   | no iniciado |
+| 2021 | [#26](https://github.com/ceballosiker/auditor-irpf-es/issues/26) | —   | —           | —   | stub   | no iniciado |
+| 2022 | [#27](https://github.com/ceballosiker/auditor-irpf-es/issues/27) | —   | —           | —   | stub   | no iniciado |
+| 2023 | [#28](https://github.com/ceballosiker/auditor-irpf-es/issues/28) | ☐   | —           | —   | stub   | no iniciado |
+| 2024 | [#29](https://github.com/ceballosiker/auditor-irpf-es/issues/29) | ☐   | —           | —   | stub   | no iniciado |
+| 2025 | [#30](https://github.com/ceballosiker/auditor-irpf-es/issues/30) | ☐   | ☐           | ☐   | stub   | no iniciado |
+| 2026 | [#31](https://github.com/ceballosiker/auditor-irpf-es/issues/31) | ☐   | ☐           | ☐   | stub   | no iniciado |
 
 ## Cómo participar
 

--- a/docs/contribuir.md
+++ b/docs/contribuir.md
@@ -1,0 +1,32 @@
+# Cómo contribuir
+
+Este proyecto necesita tres tipos de aportación. Elige tu perfil:
+
+## Si eres fiscalista o economista
+
+Tu valor está en **validar la fidelidad normativa** del motor año a año.
+
+El flujo paso a paso —elegir año, reclamar slot, validar contra BOE, reportar discrepancias— vive en la sección «Cómo participar» de la [tabla de progreso de auditoría](auditoria/progreso.md), para mantener una única fuente de verdad.
+
+No necesitas saber programar para auditar; basta con saber leer normativa y citar BOE.
+
+## Si eres developer
+
+Lee [`CONTRIBUTING.md`](https://github.com/ceballosiker/auditor-irpf-es/blob/main/CONTRIBUTING.md) para el flujo OSS completo (branch model, Conventional Commits, pnpm, Vitest, releases).
+
+Áreas con backlog activo:
+
+- `area/engine` — motor de cálculo TypeScript (`src/`).
+- `area/docs` — este manual (MkDocs Material).
+- `area/ui` — futura calculadora web (Phase 4).
+- `area/infra` — CI, releases, GitHub Pages.
+
+Issues etiquetados [`good first issue`](https://github.com/ceballosiker/auditor-irpf-es/labels/good%20first%20issue) son el punto de entrada recomendado.
+
+## Si quieres ayudar con la web
+
+La calculadora interactiva (Phase 4 — v1.0.0) aún no ha empezado. Si quieres aportar diseño o frontend, comenta en el [roadmap pinned issue](https://github.com/ceballosiker/auditor-irpf-es/issues/1) indicando tu perfil.
+
+## Código de conducta
+
+Al participar te adhieres al [Código de conducta](https://github.com/ceballosiker/auditor-irpf-es/blob/main/CODE_OF_CONDUCT.md) (Contributor Covenant v2.1).

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,11 +25,11 @@ Pendiente (Phase 6):
 
 ## Cómo está organizado este manual
 
-- **Motor** — la cadena de cálculo paso a paso (próximamente, Phase 3.2).
+- **[Motor de cálculo](motor/01-cotizacion.md)** — la cadena de cálculo paso a paso, en siete páginas.
 - **Progresividad en frío** — el concepto clave (próximamente, Phase 3.3).
 - **Anual** — un resumen por año entre 2012 y 2026 (stubs en v0.4.0; redacción completa en Phase 5).
-- **Auditoría** — estado vivo de la validación normativa.
-- **Cómo contribuir** — guía corta por perfil.
+- **[Auditoría](auditoria/progreso.md)** — estado vivo de la validación normativa.
+- **[Cómo contribuir](contribuir.md)** — guía corta por perfil.
 
 ## Estado del proyecto
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,7 +27,7 @@ Pendiente (Phase 6):
 
 - **[Motor de cálculo](motor/01-cotizacion.md)** — la cadena de cálculo paso a paso, en siete páginas.
 - **[Progresividad en frío](progresividad-en-frio.md)** — el concepto clave: por qué los impuestos pueden subir sin que el legislador los suba.
-- **Anual** — un resumen por año entre 2012 y 2026 (stubs en v0.4.0; redacción completa en Phase 5).
+- **[Resúmenes anuales](anual/index.md)** — un resumen por año entre 2012 y 2026 (stubs en v0.4.0; redacción completa en Phase 5).
 - **[Auditoría](auditoria/progreso.md)** — estado vivo de la validación normativa.
 - **[Cómo contribuir](contribuir.md)** — guía corta por perfil.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,42 @@
+# Auditor IRPF ES
+
+> **Implementación pública y auditable del cálculo del IRPF y del salario neto en España, 2012–2026.**
+
+Este manual acompaña al [motor de cálculo](https://github.com/ceballosiker/auditor-irpf-es) y traduce su lógica a lenguaje llano. Su objetivo es **democratizar** el conocimiento de cómo se calcula tu nómina y, en particular, qué efecto ha tenido la **progresividad en frío** entre 2012 y 2026.
+
+## A quién va dirigido
+
+- **Fiscalistas y economistas** que quieran auditar la fidelidad normativa año a año. → empieza por la [tabla de progreso](auditoria/progreso.md).
+- **Personas técnicas** que quieran entender el motor o aportar mejoras. → empieza por [Cómo contribuir](contribuir.md).
+- **Cualquier contribuyente** que quiera entender qué se descuenta de su nómina y por qué. → próximamente: la calculadora interactiva (Phase 4 — v1.0.0).
+
+## Alcance actual del motor
+
+Modelado:
+
+- _Soltero / sin hijos / sin discapacidad_.
+- Tramo autonómico = tramo estatal (es decir, escala estatal duplicada; sin variación por CCAA).
+
+Pendiente (Phase 6):
+
+- Escalas autonómicas por CCAA.
+- Deducciones por hijos, ascendientes y discapacidad.
+- Deducciones por edad.
+
+## Cómo está organizado este manual
+
+- **Motor** — la cadena de cálculo paso a paso (próximamente, Phase 3.2).
+- **Progresividad en frío** — el concepto clave (próximamente, Phase 3.3).
+- **Anual** — un resumen por año entre 2012 y 2026 (stubs en v0.4.0; redacción completa en Phase 5).
+- **Auditoría** — estado vivo de la validación normativa.
+- **Cómo contribuir** — guía corta por perfil.
+
+## Estado del proyecto
+
+Este sitio se construye sobre la versión `v0.4.0` del motor. Las versiones publicadas anteriores son:
+
+- **v0.1.0** — base OSS + fixtures-oráculo congelados desde el motor original en Python.
+- **v0.2.0** — port del motor a TypeScript, validado al céntimo contra los fixtures.
+- **v0.3.0** — workflow de auditoría fiscal por años (15 issues `audit-YYYY`).
+
+Ver el [CHANGELOG](https://github.com/ceballosiker/auditor-irpf-es/blob/main/CHANGELOG.md) para el detalle.

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,7 +26,7 @@ Pendiente (Phase 6):
 ## Cómo está organizado este manual
 
 - **[Motor de cálculo](motor/01-cotizacion.md)** — la cadena de cálculo paso a paso, en siete páginas.
-- **Progresividad en frío** — el concepto clave (próximamente, Phase 3.3).
+- **[Progresividad en frío](progresividad-en-frio.md)** — el concepto clave: por qué los impuestos pueden subir sin que el legislador los suba.
 - **Anual** — un resumen por año entre 2012 y 2026 (stubs en v0.4.0; redacción completa en Phase 5).
 - **[Auditoría](auditoria/progreso.md)** — estado vivo de la validación normativa.
 - **[Cómo contribuir](contribuir.md)** — guía corta por perfil.

--- a/docs/motor/01-cotizacion.md
+++ b/docs/motor/01-cotizacion.md
@@ -1,0 +1,61 @@
+# 01. Base de cotización y tope
+
+> Primer paso de la cadena: decidir sobre qué cantidad del salario se cotiza a la Seguridad Social.
+
+## La idea
+
+La **base de cotización** es la cantidad sobre la que se aplican los tipos de Seguridad Social. Para una persona asalariada con un único pagador, en términos prácticos:
+
+- Si el salario bruto anual es **menor o igual** a la base máxima de cotización (`baseMax`), entonces la base de cotización **es** el salario bruto.
+- Si el salario bruto **supera** `baseMax`, la base de cotización se queda **topada** en `baseMax`. El exceso (`bruto − baseMax`) no cotiza por las cuotas ordinarias, pero a partir de 2025 **sí** atrae la [Cuota de Solidaridad](03-mei-solidaridad.md#cuota-de-solidaridad).
+
+En fórmula:
+
+```
+base_cotizacion = min(bruto, baseMax)
+exceso          = max(0, bruto − baseMax)
+```
+
+## La base máxima año a año
+
+La base máxima la fija la Ley de PGE de cada año (o, en su defecto, la prórroga). Estos son los valores anuales que usa el motor:
+
+| Año  | `baseMax` (€) |
+| ---- | ------------: |
+| 2012 |     39 150,00 |
+| 2013 |     41 108,40 |
+| 2014 |     43 164,00 |
+| 2015 |     43 272,00 |
+| 2016 |     43 704,00 |
+| 2017 |     45 014,40 |
+| 2018 |     45 014,40 |
+| 2019 |     48 841,20 |
+| 2020 |     48 841,20 |
+| 2021 |     48 841,20 |
+| 2022 |     49 672,80 |
+| 2023 |     53 946,00 |
+| 2024 |     56 646,00 |
+| 2025 |     58 914,00 |
+| 2026 |     61 214,40 |
+
+Se publica como base mensual; aquí está prorrateada al año (12 mensualidades + 2 pagas extras incluidas en la base, según la práctica habitual).
+
+## Ejemplo (2026)
+
+`baseMax` 2026 = **61 214,40 €**.
+
+| Bruto anual | Base de cotización |      Exceso |
+| ----------: | -----------------: | ----------: |
+|    40 000 € |        40 000,00 € |         0 € |
+|    60 000 € |        60 000,00 € |         0 € |
+|    80 000 € |        61 214,40 € | 18 785,60 € |
+|   150 000 € |        61 214,40 € | 88 785,60 € |
+
+## En el código
+
+- Tabla `BASE_MAX_POR_ANIO`: [`src/normativa.ts` L17–33](https://github.com/ceballosiker/auditor-irpf-es/blob/cd051e2/src/normativa.ts#L17-L33).
+- Cálculo de `base_cotizacion` y `exceso`: [`src/pipeline.ts` L79–80](https://github.com/ceballosiker/auditor-irpf-es/blob/cd051e2/src/pipeline.ts#L79-L80).
+
+---
+
+Siguiente: [02. Tipos de Seguridad Social](02-ss.md).

--- a/docs/motor/02-ss.md
+++ b/docs/motor/02-ss.md
@@ -1,0 +1,49 @@
+# 02. Tipos de Seguridad Social
+
+> Sobre la base de cotización (paso 01) se aplican cinco tipos en paralelo, cada uno con su reparto entre empresa y trabajador.
+
+## Los cinco conceptos
+
+La cuota total de SS es la suma de cinco contingencias. Cada una tiene un tipo aplicado a la base, y un reparto fijo empresa/trabajador:
+
+| Concepto                |     Empresa | Trabajador |       Total |
+| ----------------------- | ----------: | ---------: | ----------: |
+| Contingencias comunes   |     23,60 % |     4,70 % |     28,30 % |
+| Desempleo               |      5,50 % |     1,55 % |      7,05 % |
+| FOGASA                  |      0,20 % |     0,00 % |      0,20 % |
+| Formación profesional   |      0,60 % |     0,10 % |      0,70 % |
+| AT/EP (genérico)        |      1,50 % |     0,00 % |      1,50 % |
+| **Subtotal SS clásica** | **31,40 %** | **6,35 %** | **37,75 %** |
+
+A esto se le suma el [Mecanismo de Equidad Intergeneracional (MEI)](03-mei-solidaridad.md#mecanismo-de-equidad-intergeneracional-mei) desde 2023, que aumenta los tipos totales aplicados sobre la misma base de cotización.
+
+> **Sobre el tipo AT/EP.** El tipo de Accidentes de Trabajo y Enfermedades Profesionales depende de la actividad económica (CNAE). El motor usa **1,5 %** como tipo genérico representativo, aplicable a la mayoría de oficinas y servicios. Para actividades de mayor riesgo, el tipo real puede ser sensiblemente mayor — lo que afecta a la cuota empresa pero no al neto del trabajador.
+
+## Cómo se calculan las cuotas
+
+```
+cot_empresa     = base_cotizacion × tipo_empresa_total
+cot_trabajador  = base_cotizacion × tipo_trabajador_total
+```
+
+Los `tipo_*_total` son la suma de columna de la tabla anterior **más el MEI del año**, si aplica.
+
+## Ejemplo (2026, sin tener aún en cuenta MEI/Solidaridad)
+
+Bruto = 30 000 € → base = 30 000 €.
+
+- Cuota empresa = 30 000 × 31,40 % = **9 420 €**.
+- Cuota trabajador = 30 000 × 6,35 % = **1 905 €**.
+- **Coste laboral** para la empresa = bruto + cot_empresa = **39 420 €**.
+
+(La cuota empresa la paga la empresa por el trabajador; no aparece como descuento en nómina pero sí incrementa el coste de contratación.)
+
+## En el código
+
+- Tipos por concepto: [`src/normativa.ts` L35–41](https://github.com/ceballosiker/auditor-irpf-es/blob/cd051e2/src/normativa.ts#L35-L41).
+- Suma de tipos totales (incluyendo MEI): [`src/normativa.ts` L213–227](https://github.com/ceballosiker/auditor-irpf-es/blob/cd051e2/src/normativa.ts#L213-L227).
+- Aplicación a la base: [`src/pipeline.ts` L82–83](https://github.com/ceballosiker/auditor-irpf-es/blob/cd051e2/src/pipeline.ts#L82-L83).
+
+---
+
+Anterior: [01. Base de cotización](01-cotizacion.md) · Siguiente: [03. MEI y Cuota de Solidaridad](03-mei-solidaridad.md).

--- a/docs/motor/03-mei-solidaridad.md
+++ b/docs/motor/03-mei-solidaridad.md
@@ -1,0 +1,60 @@
+# 03. MEI y Cuota de Solidaridad
+
+> Dos mecanismos relativamente nuevos que se acoplan a la cotización ordinaria: el **MEI** (sobre la misma base, desde 2023) y la **Cuota de Solidaridad** (sólo sobre el exceso por encima de `baseMax`, desde 2025).
+
+## Mecanismo de Equidad Intergeneracional (MEI)
+
+Introducido por la Ley 21/2021 para reforzar el Fondo de Reserva de la SS. Es una **cotización adicional** sobre la **misma base de cotización** que las cuotas ordinarias, con un tipo que escala año a año durante la "década del baby boom":
+
+| Año  | Tipo total MEI | Empresa | Trabajador |
+| ---- | -------------: | ------: | ---------: |
+| 2023 |         0,60 % |  0,50 % |     0,10 % |
+| 2024 |         0,70 % |  0,58 % |     0,12 % |
+| 2025 |         0,80 % |  0,67 % |     0,13 % |
+| 2026 |         0,90 % |  0,75 % |     0,15 % |
+
+Reparto: **5/6 empresa · 1/6 trabajador**.
+
+El motor lo absorbe directamente en `tipo_empresa_total` y `tipo_trabajador_total`, así que en la fórmula del paso 02 no aparece como una línea aparte: ya está sumado.
+
+## Cuota de Solidaridad
+
+Introducida por el RD-ley 2/2023 con efectos desde el **1 de enero de 2025**. La idea es que las rentas que **superan** la base máxima (y que por tanto no pagaban cotización ordinaria sobre el exceso) sí contribuyan, en una franja escalonada, sobre ese exceso.
+
+Sólo aplica al **exceso** = `bruto − baseMax`. Tres bandas, definidas como **multiplicadores de `baseMax`**:
+
+| Banda | Sobre qué se aplica                        | Tipo 2025 | Tipo 2026 |
+| ----- | ------------------------------------------ | --------: | --------: |
+| 1     | Exceso hasta `0,1 × baseMax`               |    0,92 % |    1,15 % |
+| 2     | Exceso entre `0,1·baseMax` y `0,5·baseMax` |    1,00 % |    1,25 % |
+| 3     | Exceso por encima de `0,5·baseMax`         |    1,17 % |    1,46 % |
+
+Reparto: **5/6 empresa · 1/6 trabajador**, igual que el MEI.
+
+## Ejemplo combinado (2026, bruto = 80 000 €)
+
+Datos: `baseMax` = 61 214,40 €, exceso = 18 785,60 €.
+
+**MEI** (sobre la base de 61 214,40 €):
+
+- Empresa: 61 214,40 × 0,75 % = **459,11 €**.
+- Trabajador: 61 214,40 × 0,15 % = **91,82 €**.
+
+**Solidaridad** (sobre el exceso de 18 785,60 €):
+
+- Banda 1 (hasta `0,1·baseMax` = 6 121,44 €): 6 121,44 × 1,15 % = 70,40 €.
+- Banda 2 (entre 6 121,44 y `0,5·baseMax` = 30 607,20 €, pero el exceso sólo llega a 18 785,60): 18 785,60 − 6 121,44 = 12 664,16 € a 1,25 % = 158,30 €.
+- Banda 3 (no aplica: el exceso no supera `0,5·baseMax`).
+- **Cuota total** Solidaridad = 70,40 + 158,30 = **228,70 €**.
+- Empresa (5/6) = **190,58 €** · Trabajador (1/6) = **38,12 €**.
+
+## En el código
+
+- Tipos MEI por año: [`src/normativa.ts` L61–67](https://github.com/ceballosiker/auditor-irpf-es/blob/cd051e2/src/normativa.ts#L61-L67).
+- Bandas Solidaridad por año: [`src/normativa.ts` L69–85](https://github.com/ceballosiker/auditor-irpf-es/blob/cd051e2/src/normativa.ts#L69-L85).
+- Cálculo de la cuota Solidaridad: [`src/pipeline.ts` L19–47](https://github.com/ceballosiker/auditor-irpf-es/blob/cd051e2/src/pipeline.ts#L19-L47).
+- Reparto 5/6 · 1/6: constantes `REPARTO_SOLIDARIDAD_EMPRESA` / `_TRABAJADOR` en [`src/pipeline.ts` L20–21](https://github.com/ceballosiker/auditor-irpf-es/blob/cd051e2/src/pipeline.ts#L20-L21).
+
+---
+
+Anterior: [02. Tipos SS](02-ss.md) · Siguiente: [04. Gastos fijos Art. 19](04-art-19.md).

--- a/docs/motor/04-art-19.md
+++ b/docs/motor/04-art-19.md
@@ -1,0 +1,45 @@
+# 04. Gastos fijos deducibles (Art. 19 LIRPF)
+
+> Una deducción **fija** de los rendimientos del trabajo, en concepto de "otros gastos", introducida en 2015.
+
+## La idea
+
+El Art. 19.2.f de la LIRPF (en su redacción tras la reforma de 2014, vigente desde el ejercicio 2015) permite deducir de los rendimientos íntegros del trabajo una **cantidad fija de 2 000 € anuales** en concepto de "otros gastos distintos de los anteriores", **sin necesidad de justificación**.
+
+Es independiente de la [reducción Art. 20](05-art-20.md) (que se calcula sobre el rendimiento previo a estos 2 000 €) y se aplica **a todo el mundo** que tenga rendimientos del trabajo, con independencia del salario.
+
+## Valor año a año
+
+| Periodo   | Gastos fijos Art. 19 |
+| --------- | -------------------: |
+| 2012–2014 |                  0 € |
+| 2015–2026 |              2 000 € |
+
+Antes de 2015 esta deducción fija no existía; los gastos por cotización social ya se deducían (y siguen haciéndolo) con su propio mecanismo, pero no había un "comodín" fijo de 2 000 €.
+
+## Posición en la cadena
+
+```
+rendimiento_previo  = bruto − cot_trabajador
+reducción_Art_20    = f(rendimiento_previo)        ← se calcula ANTES (paso 05)
+rendimiento_neto    = max(0, rendimiento_previo − gastos_fijos)
+base_imponible      = max(0, rendimiento_neto − reducción_Art_20)
+```
+
+El orden es importante: la reducción Art. 20 toma como entrada el rendimiento **previo** a restar gastos Art. 19, no después. Esa elección legal (no "doblamos descuentos") está fijada en el motor y no debe reordenarse.
+
+## Ejemplo (2026, bruto = 30 000 €)
+
+- Cot. trabajador (incluyendo MEI 2026, sin Solidaridad porque no hay exceso): 30 000 × 6,50 % = 1 950 €.
+- Rendimiento previo = 30 000 − 1 950 = 28 050 €.
+- Reducción Art. 20 (sobre 28 050) = 0 € (estamos por encima del tramo de aplicación).
+- Rendimiento neto = 28 050 − 2 000 = **26 050 €**.
+
+## En el código
+
+- Valor de `gastosFijos` por año: [`src/normativa.ts` L238](https://github.com/ceballosiker/auditor-irpf-es/blob/cd051e2/src/normativa.ts#L238).
+- Aplicación en la cadena: [`src/pipeline.ts` L91–94](https://github.com/ceballosiker/auditor-irpf-es/blob/cd051e2/src/pipeline.ts#L91-L94).
+
+---
+
+Anterior: [03. MEI y Solidaridad](03-mei-solidaridad.md) · Siguiente: [05. Reducción Art. 20](05-art-20.md).

--- a/docs/motor/05-art-20.md
+++ b/docs/motor/05-art-20.md
@@ -1,0 +1,97 @@
+# 05. Reducción por rendimientos del trabajo (Art. 20 LIRPF)
+
+> El elemento más cambiante de la cadena. Es una reducción **decreciente con el salario**, diseñada para aliviar la fiscalidad de las rentas bajas y medias del trabajo.
+
+## La idea
+
+Sobre el **rendimiento previo** (bruto menos cotización del trabajador), el Art. 20 aplica una reducción que tiene **forma de pieza decreciente**:
+
+- Hasta un umbral inferior `uInf`: la reducción está en su valor máximo `rMax`.
+- Entre `uInf` y `uSup`: decrece linealmente hasta `rMin` (típicamente 0).
+- A partir de `uSup`: la reducción ya no aplica.
+
+El motor evalúa la reducción **antes** de restar [gastos Art. 19](04-art-19.md), sobre el rendimiento previo a esa deducción. Es decisión legal explícita.
+
+## Evolución año a año
+
+### 2012–2014 (régimen pre-reforma 2014)
+
+| Variable |    Valor |
+| -------- | -------: |
+| `uInf`   |  9 180 € |
+| `rMax`   |  4 080 € |
+| `uSup`   | 13 260 € |
+| `rMin`   |  2 652 € |
+
+Pendiente de la rampa decreciente: 0,35.
+
+### 2015–2017 (reforma Montoro)
+
+| Variable |    Valor |
+| -------- | -------: |
+| `uInf`   | 11 250 € |
+| `rMax`   |  3 700 € |
+| `uSup`   | 14 450 € |
+| `rMin`   |      0 € |
+
+Pendiente: 1,15625.
+
+### 2018 — régimen transitorio
+
+La Ley 6/2018, de PGE 2018, eleva la reducción **a partir del 5 de julio de 2018**. Para no aplicar dos reglas en el mismo ejercicio fiscal, la Disposición Adicional 47ª LIRPF establece un **régimen transitorio**: la reducción del ejercicio 2018 se calcula como **media de la regla previa (2015–2017) y la nueva (2019+)**.
+
+```
+reducción_2018(rn) = 0,5 × reducción_2017(rn) + 0,5 × reducción_2019(rn)
+```
+
+Esto es un detalle de precisión que no aparece en la mayoría de calculadoras del mercado. El motor lo modela explícitamente.
+
+### 2019–2022
+
+| Variable |    Valor |
+| -------- | -------: |
+| `uInf`   | 13 115 € |
+| `rMax`   |  5 565 € |
+| `uSup`   | 16 825 € |
+| `rMin`   |      0 € |
+
+Pendiente: 1,5.
+
+### 2023
+
+| Variable |      Valor |
+| -------- | ---------: |
+| `uInf`   | 14 047,5 € |
+| `rMax`   |    6 498 € |
+| `uSup`   | 19 747,5 € |
+| `rMin`   |        0 € |
+
+Pendiente: 1,14.
+
+### 2024–2026 — tres segmentos
+
+A partir de 2024 la pieza no es bilineal sino **trilineal**: el tramo decreciente cambia de pendiente a mitad de camino.
+
+```
+si rn ≤ 14 852          →  reducción = 7 302
+si rn ≤ 17 673,52       →  reducción = 7 302 − 1,75 × (rn − 14 852)
+si rn ≤ 19 747,5        →  reducción = 2 364,34 − 1,14 × (rn − 17 673,52)
+si rn > 19 747,5        →  reducción = 0
+```
+
+El primer tramo decreciente (pendiente 1,75) baja rápido para concentrar el ahorro fiscal en el tramo SMI; el segundo tramo (pendiente 1,14) suaviza la transición hasta el corte definitivo.
+
+## Por qué importa el orden
+
+Al aplicarse **antes** de los 2 000 € fijos del Art. 19, el resultado de la reducción Art. 20 puede ser distinto al que daría aplicarla después. Para alguien justo en el codo `uSup`, los 2 000 € lo sitúan más bajo en la curva si se aplicaran primero — y haría diferencia. La doctrina y la práctica administrativa fijan este orden.
+
+## En el código
+
+- Tabla `art20MetaDe` (los `uInf`/`rMax`/`uSup`/`rMin` que muestran las hojas de control del Excel): [`src/normativa.ts` L87–96](https://github.com/ceballosiker/auditor-irpf-es/blob/cd051e2/src/normativa.ts#L87-L96).
+- Función `reduccionTrabajoDe` (lógica completa, por año): [`src/normativa.ts` L98–142](https://github.com/ceballosiker/auditor-irpf-es/blob/cd051e2/src/normativa.ts#L98-L142).
+- Régimen transitorio 2018: [`src/normativa.ts` L113–120](https://github.com/ceballosiker/auditor-irpf-es/blob/cd051e2/src/normativa.ts#L113-L120).
+- Aplicación en la cadena, antes de gastos Art. 19: [`src/pipeline.ts` L91–94](https://github.com/ceballosiker/auditor-irpf-es/blob/cd051e2/src/pipeline.ts#L91-L94).
+
+---
+
+Anterior: [04. Gastos Art. 19](04-art-19.md) · Siguiente: [06. Tramos IRPF y mínimo personal](06-tramos-irpf.md).

--- a/docs/motor/06-tramos-irpf.md
+++ b/docs/motor/06-tramos-irpf.md
@@ -1,0 +1,107 @@
+# 06. Escala progresiva y mínimo personal
+
+> Sobre la base imponible se aplica la **escala IRPF progresiva**. El mínimo personal se descuenta **como cuota** al tipo del primer tramo, no como deducción de la base — un detalle conceptualmente importante que ya estaba en la reforma Montoro de 2015.
+
+## La escala progresiva
+
+La base imponible se divide en tramos. Cada tramo tributa a su tipo, y la cuota íntegra es la suma:
+
+```
+cuota_íntegra = Σ (base_en_tramo_i × tipo_i)
+```
+
+El motor modela los tramos **estatales** y, bajo el supuesto del proyecto (_tramo autonómico = tramo estatal_), los duplica. Así, los porcentajes que ves a continuación son los **totales aplicables** (estatal × 2).
+
+### Tramos por periodo
+
+#### 2012–2014
+
+| Hasta (€) | Tipo total |
+| --------: | ---------: |
+|    17 707 |    24,75 % |
+|    33 007 |    30,00 % |
+|    53 407 |    40,00 % |
+|   120 000 |    47,00 % |
+|   175 000 |    49,00 % |
+|   300 000 |    51,00 % |
+|         ∞ |    52,00 % |
+
+Periodo de "complementos transitorios" del IRPF (mucha progresividad y un tipo marginal alto del 52 %).
+
+#### 2015 (reforma Montoro, año 1)
+
+| Hasta (€) | Tipo total |
+| --------: | ---------: |
+|    12 450 |    19,50 % |
+|    20 200 |    24,50 % |
+|    34 000 |    30,50 % |
+|    60 000 |    38,00 % |
+|         ∞ |    46,00 % |
+
+Reducción notable de tramos (de 7 a 5) y del tipo marginal (52 → 46 %).
+
+#### 2016–2020
+
+| Hasta (€) | Tipo total |
+| --------: | ---------: |
+|    12 450 |    19,00 % |
+|    20 200 |    24,00 % |
+|    35 200 |    30,00 % |
+|    60 000 |    37,00 % |
+|         ∞ |    45,00 % |
+
+Ligera bajada respecto a 2015.
+
+#### 2021–2026
+
+| Hasta (€) | Tipo total |
+| --------: | ---------: |
+|    12 450 |    19,00 % |
+|    20 200 |    24,00 % |
+|    35 200 |    30,00 % |
+|    60 000 |    37,00 % |
+|   300 000 |    45,00 % |
+|         ∞ |    47,00 % |
+
+Reintroducción de un tramo alto del 47 % a partir de 300 000 €.
+
+## El mínimo personal: cuota, no base
+
+A diferencia de muchos otros impuestos, el IRPF español **no resta el mínimo personal de la base** antes de aplicar la escala. En su lugar:
+
+1. Se calcula la cuota íntegra sobre la base imponible completa.
+2. Se calcula una "cuota equivalente" del mínimo personal, multiplicándolo por el **tipo del primer tramo**.
+3. La cuota teórica es `max(0, cuota_íntegra − cuota_mínimo_personal)`.
+
+```
+cuota_mínimo_personal = mínimo_personal × tipo_primer_tramo
+cuota_teórica         = max(0, cuota_íntegra − cuota_mínimo_personal)
+```
+
+Valores del **mínimo personal del contribuyente** (soltero, sin hijos, sin discapacidad, < 65 años):
+
+| Periodo   | Mínimo personal |
+| --------- | --------------: |
+| 2012–2014 |         5 151 € |
+| 2015–2026 |         5 550 € |
+
+> **¿Por qué cuota y no base?** Aplicar el mínimo como cuota al tipo más bajo es **más equitativo**: si se restara de la base, las rentas altas obtendrían un ahorro mayor (porque "esquivarían" el último tramo, no el primero). Aplicado como cuota, el ahorro es el mismo en valor absoluto para todos los contribuyentes con la misma situación personal.
+
+## Posición en la cadena
+
+```
+base_imponible  = max(0, ren_neto − reducción_Art_20)        ← paso 05/06
+cuota_íntegra   = Σ tramos × base_en_cada_tramo              ← este paso
+cuota_teórica   = max(0, cuota_íntegra − mín_personal × t1)  ← este paso
+```
+
+## En el código
+
+- Tabla `tramosIRPFDe` por periodo: [`src/normativa.ts` L144–182](https://github.com/ceballosiker/auditor-irpf-es/blob/cd051e2/src/normativa.ts#L144-L182).
+- Mínimo personal por periodo (`irpfMinimo`): [`src/normativa.ts` L236](https://github.com/ceballosiker/auditor-irpf-es/blob/cd051e2/src/normativa.ts#L236).
+- Cálculo `calcularCuotasPorTramo`: [`src/pipeline.ts` L49–71](https://github.com/ceballosiker/auditor-irpf-es/blob/cd051e2/src/pipeline.ts#L49-L71).
+- Mínimo personal aplicado al tipo del primer tramo: [`src/pipeline.ts` L96–99](https://github.com/ceballosiker/auditor-irpf-es/blob/cd051e2/src/pipeline.ts#L96-L99).
+
+---
+
+Anterior: [05. Reducción Art. 20](05-art-20.md) · Siguiente: [07. Deducción SMI y tope 43 %](07-smi-y-43.md).

--- a/docs/motor/07-smi-y-43.md
+++ b/docs/motor/07-smi-y-43.md
@@ -1,0 +1,90 @@
+# 07. Deducción SMI y tope del 43 %
+
+> Dos correcciones que se aplican al final de la cadena: una deducción específica para rentas próximas al SMI (sólo 2025+) y un **tope** sobre la retención efectiva.
+
+## Deducción SMI
+
+Aplicable únicamente a partir de 2025. Es una deducción que reduce la cuota cuando el bruto está cerca del Salario Mínimo Interprofesional, y se desvanece linealmente más allá del umbral.
+
+### 2025
+
+```
+si bruto ≤ 16 576 €    →  deducción = 340 €
+si bruto ≤ 18 276 €    →  deducción = max(0, 340 − 0,2 × (bruto − 16 576))
+en otro caso           →  deducción = 0
+```
+
+### 2026
+
+```
+si bruto ≤ 17 094 €    →  deducción = 590,89 €
+en otro caso           →  deducción = max(0, 590,89 − 0,2 × (bruto − 17 094))
+```
+
+A diferencia de la regla 2025, en 2026 la deducción decrece sin **corte abrupto** a cero — sólo cuando el descuento llega a 0 deja de aplicarse, de forma natural por el `max(0, …)`.
+
+La deducción se resta **después** de aplicar el mínimo personal y **antes** del tope del 43 %.
+
+## El tope del 43 % (Art. 85.3 RIRPF)
+
+El Reglamento del IRPF impone un techo a la **retención efectiva** de IRPF: la cantidad efectivamente retenida no puede superar el **43 %** de la diferencia entre el bruto y el **mínimo exento de retención**.
+
+```
+límite_43 = max(0, (bruto − mínimo_exento) × 0,43)
+IRPF_final = min(cuota_tras_SMI, límite_43)
+```
+
+### Mínimo exento año a año
+
+Atención: este es **distinto** del mínimo personal. Es una cantidad **a partir de la cual existe obligación de retener**; aplicada en el cálculo del tope se interpreta como "no se retiene sobre la franja exenta".
+
+| Año  | Mínimo exento (€) |
+| ---- | ----------------: |
+| 2012 |            11 162 |
+| 2013 |            11 162 |
+| 2014 |            11 162 |
+| 2015 |            12 000 |
+| 2016 |            12 000 |
+| 2017 |            12 000 |
+| 2018 |            12 643 |
+| 2019 |            14 000 |
+| 2020 |            14 000 |
+| 2021 |            14 000 |
+| 2022 |            14 000 |
+| 2023 |            15 000 |
+| 2024 |            15 876 |
+| 2025 |            15 876 |
+| 2026 |            15 876 |
+
+El umbral de 14 000 € de 2019 fue una elevación importante destinada a alinear el mínimo exento con el SMI de la época. El salto a 15 876 € en 2024 mantiene la equivalencia con el SMI vigente desde entonces.
+
+## Posición en la cadena
+
+```
+cuota_tras_minimo_personal  ← paso 06
+   − deducción_SMI(bruto)               ← este paso (2025+)
+   = cuota_tras_SMI
+   limit  max(0, (bruto − mín_exento) × 43 %)
+   = IRPF_final
+```
+
+`IRPF_final` es la línea final del cálculo. El **salario neto** sale entonces de:
+
+```
+neto = bruto − cot_trabajador − IRPF_final
+```
+
+## Cuándo se activa el tope
+
+El tope del 43 % se activa típicamente para brutos en una **franja relativamente estrecha** justo por encima del mínimo exento, donde la cuota teórica todavía es alta en relación al exceso sobre el mínimo. Para brutos mucho mayores, la cuota teórica crece menos que el 43 % del exceso, y el tope deja de morder. El motor reporta tanto la cuota teórica como el `límite_43` para que se vea cuándo ha actuado.
+
+## En el código
+
+- Función `deduccionSMIDe` por año: [`src/normativa.ts` L184–198](https://github.com/ceballosiker/auditor-irpf-es/blob/cd051e2/src/normativa.ts#L184-L198).
+- Constante `TIPO_43`: [`src/pipeline.ts` L19](https://github.com/ceballosiker/auditor-irpf-es/blob/cd051e2/src/pipeline.ts#L19).
+- Tabla `MINIMO_EXENTO_POR_ANIO`: [`src/normativa.ts` L43–59](https://github.com/ceballosiker/auditor-irpf-es/blob/cd051e2/src/normativa.ts#L43-L59).
+- Aplicación del tope y cálculo de `irpfFinal`: [`src/pipeline.ts` L101–106](https://github.com/ceballosiker/auditor-irpf-es/blob/cd051e2/src/pipeline.ts#L101-L106).
+
+---
+
+Anterior: [06. Tramos IRPF](06-tramos-irpf.md) · Volver al [inicio del manual](../index.md).

--- a/docs/progresividad-en-frio.md
+++ b/docs/progresividad-en-frio.md
@@ -61,7 +61,8 @@ Lo más llamativo no es la columna del **tipo medio efectivo** —que de hecho h
 
 Una parte de esa caída es por inflación pura (su salario perdió valor). La otra parte es lo que la **progresividad en frío** habría agravado de no ser por reformas puntuales que recortaron tramos y subieron reducciones.
 
-<!-- CHART: "neto-real-mismo-nominal" — eje X: año (2012–2026); eje Y: neto en € de 2026; serie única (bruto nominal = 30 000 €). Pendiente decreciente que ilustra el ejemplo de la tabla anterior. -->
+![Neto real con bruto nominal fijo en 30 000 €](assets/neto-real-mismo-nominal.svg)
+{ .img-chart }
 
 ## Otra mirada: mismo poder de compra a través del tiempo
 
@@ -69,9 +70,11 @@ Otra forma de ver el efecto es preguntarse: si yo gano hoy lo equivalente a un p
 
 Esta vez **fijamos el bruto real**, no el nominal — el sueldo se actualiza año a año en línea con el IPC.
 
-<!-- CHART: "neto-real-bruto-real-fijo" — eje X: bruto en € de 2026 (15 000–80 000 €); eje Y: neto en € de 2026; una serie por año (2012, 2015, 2018, 2022, 2024, 2026). El espaciado vertical entre líneas mide el efecto neto de las reformas + progresividad en frío. -->
+![Neto real por bruto real, fiscalidad de cada año](assets/neto-real-bruto-real-fijo.svg)
+{ .img-chart }
 
-<!-- CHART: "tipo-medio-efectivo" — eje X: bruto en € de 2026 (15 000–80 000 €); eje Y: tipo medio efectivo (cot. trabajador + IRPF) / bruto, en %; una serie por año (2012, 2015, 2018, 2022, 2024, 2026). Permite ver dónde tributa hoy más quien antes tributaba menos. -->
+![Tipo medio efectivo: cotización + IRPF sobre bruto](assets/tipo-medio-efectivo.svg)
+{ .img-chart }
 
 ## Cuándo se nota más
 

--- a/docs/progresividad-en-frio.md
+++ b/docs/progresividad-en-frio.md
@@ -1,0 +1,91 @@
+# Progresividad en frío
+
+> Cuando los **tramos** y las **deducciones** del IRPF están fijados en valores nominales (€) y el **salario nominal sube** —aunque solo sea para compensar inflación—, el contribuyente sube de tramo o pierde reducciones **sin que el legislador haya cambiado nada**. El efecto neto es una subida de impuestos no votada.
+
+## La idea
+
+Imagínate una escala fiscal sencilla: hasta 12 450 € se paga el 19 %, a partir de ahí el 24 %. Estos dos tramos no se han movido en España desde 2016.
+
+Si en 2016 ganas 12 000 € y en 2026 ganas 14 000 €, has subido **en términos nominales**. Pero si la inflación entre 2016 y 2026 ha sido del 30 % (aproximadamente el caso real), tu **poder adquisitivo real** ha **bajado**: 14 000 € de 2026 valen aproximadamente 10 800 € de 2016.
+
+Y como los tramos no se han movido, ahora estás pagando una parte de tu salario al 24 %, mientras que en 2016 todo lo pagabas al 19 %. **Tu fiscalidad real ha subido sin que nadie haya cambiado la ley.**
+
+A esto se le llama **progresividad en frío** (_bracket creep_ en inglés): la progresividad fiscal funciona "en frío" sobre un salario que solo ha crecido en frío (nominal), no en términos de poder de compra.
+
+## Por qué es importante
+
+- Es una **subida de impuestos automática**, no debatida en parlamento.
+- Afecta más a las **rentas medias y bajas**, donde los tramos cambian con más frecuencia y el salto entre uno y otro tiene más peso relativo.
+- En periodos de inflación alta (2021–2023 en España, con IPC acumulado >15 %), el efecto se acelera dramáticamente.
+- Algunos países lo combaten **deflactando los tramos** automáticamente cada año (Alemania desde 2010, Francia indiciariamente, Estados Unidos vía CPI desde 1985). España **no lo hace**: las actualizaciones de tramos cuando ocurren son políticas, ad hoc y rara vez compensan la inflación.
+
+## Cómo lo modela este motor
+
+El motor incluye una serie histórica de **IPC anual de diciembre a diciembre** (fuente: INE):
+
+| Año  | IPC anual (Dic/Dic) | Multiplicador acumulado a 2026 |
+| ---- | ------------------: | -----------------------------: |
+| 2013 |              +0,3 % |                         1,3052 |
+| 2014 |              −1,0 % |                         1,3184 |
+| 2015 |               0,0 % |                         1,3184 |
+| 2016 |              +1,6 % |                         1,2976 |
+| 2017 |              +1,1 % |                         1,2835 |
+| 2018 |              +1,2 % |                         1,2683 |
+| 2019 |              +0,8 % |                         1,2582 |
+| 2020 |              −0,5 % |                         1,2645 |
+| 2021 |              +6,5 % |                         1,1874 |
+| 2022 |              +5,7 % |                         1,1233 |
+| 2023 |              +3,1 % |                         1,0895 |
+| 2024 |              +2,8 % |                         1,0599 |
+| 2025 |              +2,9 % |                         1,0300 |
+| 2026 |              +3,0 % |                         1,0000 |
+
+El **multiplicador acumulado a 2026** se calcula encadenando `(1 + IPC[a])` desde el año siguiente al año base hasta 2026. Un euro de 2012 son 1,3091 € de 2026; un euro de 2020 son 1,2645 € de 2026.
+
+La **pestaña `COMPARATIVA_INFLACION`** del Excel auditor (y los gráficos de las páginas siguientes) usan esta serie para deflactar e inflactar netos entre años, midiendo así la pérdida (o ganancia) de poder adquisitivo real con la fiscalidad de cada año.
+
+## Un ejemplo concreto: 30 000 € nominales sin subida
+
+Una persona que gana **30 000 € nominales** en cada año entre 2012 y 2026 — sin subidas, ni siquiera para compensar inflación — vive en términos reales una **caída sostenida** de poder adquisitivo:
+
+| Año  | Bruto nominal | **Bruto en € de 2026** | Neto nominal | **Neto en € de 2026** | Tipo medio efectivo |
+| ---- | ------------: | ---------------------: | -----------: | --------------------: | ------------------: |
+| 2012 |        30 000 |             **39 273** |       22 667 |            **29 673** |             24,44 % |
+| 2015 |        30 000 |             **39 551** |       23 053 |            **30 392** |             23,16 % |
+| 2018 |        30 000 |             **38 048** |       23 156 |            **29 367** |             22,81 % |
+| 2022 |        30 000 |             **33 700** |       23 156 |            **26 011** |             22,81 % |
+| 2024 |        30 000 |             **31 796** |       23 130 |            **24 515** |             22,90 % |
+| 2026 |        30 000 |             **30 000** |       23 124 |            **23 124** |             22,92 % |
+
+Lo más llamativo no es la columna del **tipo medio efectivo** —que de hecho ha bajado ligeramente gracias a algunas reformas—, sino la última columna numérica: **el neto en € de 2026 cae de 29 673 € a 23 124 €** entre 2012 y 2026. Eso son **6 549 € reales menos** de poder adquisitivo, **un 22 % menos**, sin que el contribuyente haya cambiado de empleo, ni de bruto.
+
+Una parte de esa caída es por inflación pura (su salario perdió valor). La otra parte es lo que la **progresividad en frío** habría agravado de no ser por reformas puntuales que recortaron tramos y subieron reducciones.
+
+<!-- CHART: "neto-real-mismo-nominal" — eje X: año (2012–2026); eje Y: neto en € de 2026; serie única (bruto nominal = 30 000 €). Pendiente decreciente que ilustra el ejemplo de la tabla anterior. -->
+
+## Otra mirada: mismo poder de compra a través del tiempo
+
+Otra forma de ver el efecto es preguntarse: si yo gano hoy lo equivalente a un poder adquisitivo X (medido en € de 2026), ¿qué neto real me habría quedado con la fiscalidad de cada año?
+
+Esta vez **fijamos el bruto real**, no el nominal — el sueldo se actualiza año a año en línea con el IPC.
+
+<!-- CHART: "neto-real-bruto-real-fijo" — eje X: bruto en € de 2026 (15 000–80 000 €); eje Y: neto en € de 2026; una serie por año (2012, 2015, 2018, 2022, 2024, 2026). El espaciado vertical entre líneas mide el efecto neto de las reformas + progresividad en frío. -->
+
+<!-- CHART: "tipo-medio-efectivo" — eje X: bruto en € de 2026 (15 000–80 000 €); eje Y: tipo medio efectivo (cot. trabajador + IRPF) / bruto, en %; una serie por año (2012, 2015, 2018, 2022, 2024, 2026). Permite ver dónde tributa hoy más quien antes tributaba menos. -->
+
+## Cuándo se nota más
+
+- **Brutos justo por encima de un salto de tramo**: una pequeña subida nominal te puede empujar al siguiente tramo, donde el tipo marginal es notablemente mayor.
+- **En la zona del Art. 20** (la reducción por rendimientos del trabajo, ver página [05. Reducción Art. 20](motor/05-art-20.md)): si tu rendimiento previo cae cerca del codo `uSup`, una subida nominal pequeña puede hacer que pierdas reducción rápidamente.
+- **Cerca del mínimo exento de retención** (ver [07. SMI y tope 43 %](motor/07-smi-y-43.md)): subir nominalmente por encima del umbral introduce retención donde antes no la había.
+
+## En el código
+
+- Tabla `IPC_ANUAL_DIC` (IPC INE de Dic/Dic, 2013–2026): [`src/inflacion.ts` L7–22](https://github.com/ceballosiker/auditor-irpf-es/blob/5b70e47/src/inflacion.ts#L7-L22).
+- Función `inflacionAcumulada(anioBase, anioDestino=2026)`: [`src/inflacion.ts` L24–39](https://github.com/ceballosiker/auditor-irpf-es/blob/5b70e47/src/inflacion.ts#L24-L39).
+- Cache `INFLACION_A_2026` precomputada: [`src/inflacion.ts` L42–48](https://github.com/ceballosiker/auditor-irpf-es/blob/5b70e47/src/inflacion.ts#L42-L48).
+- En el Excel: pestaña `COMPARATIVA_INFLACION` (función `buildComparativaInflacion` en [`src/excel.ts` L66](https://github.com/ceballosiker/auditor-irpf-es/blob/5b70e47/src/excel.ts#L66); barre brutos de 15 000 a 100 000 € en pasos de 1 000 €, en € de 2026 — ver [`src/excel.ts` L13–17](https://github.com/ceballosiker/auditor-irpf-es/blob/5b70e47/src/excel.ts#L13-L17)).
+
+---
+
+Volver al [inicio del manual](index.md) · Ver el [motor de cálculo](motor/01-cotizacion.md) paso a paso.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -4,7 +4,15 @@ import prettier from 'eslint-config-prettier';
 
 export default tseslint.config(
   {
-    ignores: ['dist/', 'node_modules/', 'coverage/', '.venv/', 'tests/fixtures/**'],
+    ignores: [
+      'dist/',
+      'node_modules/',
+      'coverage/',
+      '.venv/',
+      '.venv-*/',
+      'site/',
+      'tests/fixtures/**',
+    ],
   },
   js.configs.recommended,
   ...tseslint.configs.recommended,

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -41,6 +41,14 @@ theme:
 
 nav:
   - Inicio: index.md
+  - Motor de cálculo:
+      - 1. Base de cotización: motor/01-cotizacion.md
+      - 2. Tipos SS: motor/02-ss.md
+      - 3. MEI y Solidaridad: motor/03-mei-solidaridad.md
+      - 4. Gastos Art. 19: motor/04-art-19.md
+      - 5. Reducción Art. 20: motor/05-art-20.md
+      - 6. Tramos IRPF: motor/06-tramos-irpf.md
+      - 7. SMI y tope 43 %: motor/07-smi-y-43.md
   - Cómo contribuir: contribuir.md
   - Auditoría:
       - Progreso 2012–2026: auditoria/progreso.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,69 @@
+site_name: Auditor IRPF ES
+site_description: Implementación pública y auditable del cálculo del IRPF y del salario neto en España, 2012–2026.
+site_url: https://ceballosiker.github.io/auditor-irpf-es/
+site_author: ceballosiker
+
+repo_url: https://github.com/ceballosiker/auditor-irpf-es
+repo_name: ceballosiker/auditor-irpf-es
+edit_uri: edit/develop/docs/
+
+docs_dir: docs
+site_dir: site
+
+theme:
+  name: material
+  language: es
+  features:
+    - navigation.sections
+    - navigation.top
+    - navigation.tracking
+    - content.code.copy
+    - content.action.edit
+    - search.highlight
+    - search.suggest
+  palette:
+    - media: '(prefers-color-scheme: light)'
+      scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-7
+        name: Cambiar a modo oscuro
+    - media: '(prefers-color-scheme: dark)'
+      scheme: slate
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-4
+        name: Cambiar a modo claro
+  icon:
+    repo: fontawesome/brands/github
+
+nav:
+  - Inicio: index.md
+  - Cómo contribuir: contribuir.md
+  - Auditoría:
+      - Progreso 2012–2026: auditoria/progreso.md
+
+markdown_extensions:
+  - admonition
+  - attr_list
+  - md_in_html
+  - tables
+  - toc:
+      permalink: true
+  - pymdownx.details
+  - pymdownx.superfences
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.tabbed:
+      alternate_style: true
+
+plugins:
+  - search:
+      lang: es
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/ceballosiker/auditor-irpf-es

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,6 +50,23 @@ nav:
       - 6. Tramos IRPF: motor/06-tramos-irpf.md
       - 7. SMI y tope 43 %: motor/07-smi-y-43.md
   - Progresividad en frío: progresividad-en-frio.md
+  - Resúmenes anuales:
+      - Índice 2012–2026: anual/index.md
+      - 2012: anual/2012.md
+      - 2013: anual/2013.md
+      - 2014: anual/2014.md
+      - 2015: anual/2015.md
+      - 2016: anual/2016.md
+      - 2017: anual/2017.md
+      - 2018: anual/2018.md
+      - 2019: anual/2019.md
+      - 2020: anual/2020.md
+      - 2021: anual/2021.md
+      - 2022: anual/2022.md
+      - 2023: anual/2023.md
+      - 2024: anual/2024.md
+      - 2025: anual/2025.md
+      - 2026: anual/2026.md
   - Cómo contribuir: contribuir.md
   - Auditoría:
       - Progreso 2012–2026: auditoria/progreso.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -49,6 +49,7 @@ nav:
       - 5. Reducción Art. 20: motor/05-art-20.md
       - 6. Tramos IRPF: motor/06-tramos-irpf.md
       - 7. SMI y tope 43 %: motor/07-smi-y-43.md
+  - Progresividad en frío: progresividad-en-frio.md
   - Cómo contribuir: contribuir.md
   - Auditoría:
       - Progreso 2012–2026: auditoria/progreso.md

--- a/package.json
+++ b/package.json
@@ -30,6 +30,8 @@
     "dev": "vite",
     "preview": "vite preview",
     "build:excel": "tsx src/cli.ts",
+    "charts": "tsx scripts/render-charts.ts",
+    "anual:stubs": "tsx scripts/render-anual-stubs.ts && prettier --write \"docs/anual/**/*.md\"",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auditor-irpf-es",
-  "version": "0.2.0",
+  "version": "0.4.0",
   "private": true,
   "description": "Auditor histórico de nóminas e IRPF en España (2012-2026) con ajuste de inflación.",
   "license": "MIT",

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,0 +1,3 @@
+mkdocs==1.6.1
+mkdocs-material==9.5.49
+pymdown-extensions==10.12

--- a/scripts/render-anual-stubs.ts
+++ b/scripts/render-anual-stubs.ts
@@ -1,0 +1,149 @@
+// Generate the 15 docs/anual/YYYY.md stubs + docs/anual/index.md from
+// obtenerParametros(). Values come straight from src/normativa.ts so the
+// stubs cannot drift from the engine's source of truth.
+//
+// Run: `npm run anual:stubs` (from repo root). Idempotent.
+
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { obtenerParametros, ANIO_MIN, ANIO_MAX } from '../src/normativa.ts';
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const OUT_DIR = join(REPO_ROOT, 'docs', 'anual');
+
+// audit-YYYY GitHub issue numbers (created in Phase 2, v0.3.0).
+const AUDIT_ISSUE: Readonly<Record<number, number>> = {
+  2012: 17,
+  2013: 18,
+  2014: 19,
+  2015: 20,
+  2016: 21,
+  2017: 22,
+  2018: 23,
+  2019: 24,
+  2020: 25,
+  2021: 26,
+  2022: 27,
+  2023: 28,
+  2024: 29,
+  2025: 30,
+  2026: 31,
+};
+
+const REPO_URL = 'https://github.com/ceballosiker/auditor-irpf-es';
+
+function fmtPct(v: number): string {
+  return (v * 100).toFixed(2).replace('.', ',') + ' %';
+}
+
+function fmtEuro(v: number): string {
+  const abs = Math.abs(v);
+  const intPart = Math.floor(abs);
+  const cents = Math.round((abs - intPart) * 100);
+  const intStr = intPart.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ' ');
+  const sign = v < 0 ? '-' : '';
+  return `${sign}${intStr},${cents.toString().padStart(2, '0')} €`;
+}
+
+function nav(anio: number): string {
+  const parts: string[] = [];
+  if (anio > ANIO_MIN) {
+    parts.push(`[← ${String(anio - 1)}](${String(anio - 1)}.md)`);
+  }
+  parts.push(`[Índice anual](index.md)`);
+  if (anio < ANIO_MAX) {
+    parts.push(`[${String(anio + 1)} →](${String(anio + 1)}.md)`);
+  }
+  return parts.join(' · ');
+}
+
+function renderStub(anio: number): string {
+  const p = obtenerParametros(anio);
+  const issue = AUDIT_ISSUE[anio];
+  const meiAplica = p.mei[0] > 0 || p.mei[1] > 0;
+  const solidaridadAplica = p.solidaridad.length > 0;
+  const smiAplica = p.deduccionSMI(0) > 0;
+
+  const lines: string[] = [];
+  lines.push(`# Normativa ${String(anio)}`);
+  lines.push('');
+  lines.push(
+    `> **Pendiente de redacción.** Esta página es un stub. La redacción completa con referencias BOE llegará en Phase 5 (v1.1.0), en paralelo con la validación de [\`audit-${String(anio)}\`](${REPO_URL}/issues/${String(issue)}).`,
+  );
+  lines.push('');
+  lines.push('## Parámetros vigentes');
+  lines.push('');
+  lines.push(`| Parámetro                       | Valor                  |`);
+  lines.push(`| ------------------------------- | ---------------------- |`);
+  lines.push(`| Base máxima cotización          | ${fmtEuro(p.baseMax)}  |`);
+  lines.push(`| Tipo SS total empresa           | ${fmtPct(p.tipoEmpresaTotal)} |`);
+  lines.push(`| Tipo SS total trabajador        | ${fmtPct(p.tipoTrabajadorTotal)} |`);
+  lines.push(
+    `| MEI                             | ${meiAplica ? `${fmtPct(p.mei[0] + p.mei[1])} (empresa ${fmtPct(p.mei[0])} · trabajador ${fmtPct(p.mei[1])})` : 'no aplica'} |`,
+  );
+  lines.push(
+    `| Cuota de Solidaridad            | ${solidaridadAplica ? 'aplica (3 bandas sobre el exceso)' : 'no aplica'} |`,
+  );
+  lines.push(`| Mínimo personal contribuyente   | ${fmtEuro(p.irpfMinimo)} |`);
+  lines.push(`| Mínimo exento de retención      | ${fmtEuro(p.minimoExento)} |`);
+  lines.push(`| Gastos fijos Art. 19            | ${fmtEuro(p.gastosFijos)} |`);
+  lines.push(`| Tramos IRPF (incl. autonómico = estatal) | ${String(p.tramosIRPF.length)} |`);
+  lines.push(`| Deducción SMI                   | ${smiAplica ? 'aplica' : 'no aplica'} |`);
+  lines.push('');
+  lines.push(
+    'Estos valores se generan directamente de `src/normativa.ts`. Para auditarlos contra el BOE, ver el [issue de auditoría](' +
+      REPO_URL +
+      '/issues/' +
+      String(issue) +
+      ').',
+  );
+  lines.push('');
+  lines.push('## Cómo aportar a esta página');
+  lines.push('');
+  lines.push(
+    `1. Abre el [issue \`audit-${String(anio)}\`](${REPO_URL}/issues/${String(issue)}) y reclama el slot.`,
+  );
+  lines.push('2. Valida cada elemento del checklist contra el BOE.');
+  lines.push(
+    '3. Cuando el año esté validado, manda un PR con la redacción completa de esta página: cambios respecto al año anterior, motivación legal, cómo afectan a la curva de neto.',
+  );
+  lines.push('');
+  lines.push('---');
+  lines.push('');
+  lines.push(nav(anio));
+  lines.push('');
+  return lines.join('\n');
+}
+
+function renderIndex(): string {
+  const lines: string[] = [];
+  lines.push('# Resúmenes anuales 2012–2026');
+  lines.push('');
+  lines.push(
+    'Una página por año entre 2012 y 2026. En la versión `v0.4.0` todas son **stubs**: contienen los parámetros vigentes (extraídos automáticamente de `src/normativa.ts`) y un enlace al `audit-YYYY` correspondiente. La redacción completa, con referencias BOE y análisis de cambios, llegará en Phase 5 (`v1.1.0`).',
+  );
+  lines.push('');
+  lines.push(`| Año  | Página                       | Issue de auditoría |`);
+  lines.push(`| ---- | ---------------------------- | ------------------ |`);
+  for (let a = ANIO_MIN; a <= ANIO_MAX; a++) {
+    const issue = AUDIT_ISSUE[a];
+    lines.push(
+      `| ${String(a)} | [Normativa ${String(a)}](${String(a)}.md) | [#${String(issue)}](${REPO_URL}/issues/${String(issue)}) |`,
+    );
+  }
+  lines.push('');
+  return lines.join('\n');
+}
+
+mkdirSync(OUT_DIR, { recursive: true });
+
+for (let a = ANIO_MIN; a <= ANIO_MAX; a++) {
+  const out = join(OUT_DIR, `${String(a)}.md`);
+  writeFileSync(out, renderStub(a), 'utf8');
+  console.log(`[anual] wrote ${out}`);
+}
+
+const idxOut = join(OUT_DIR, 'index.md');
+writeFileSync(idxOut, renderIndex(), 'utf8');
+console.log(`[anual] wrote ${idxOut}`);

--- a/scripts/render-charts.ts
+++ b/scripts/render-charts.ts
@@ -1,0 +1,275 @@
+// Render SVG charts for the manual.
+//
+// Output: docs/assets/<slug>.svg, one per chart referenced in
+// docs/progresividad-en-frio.md.
+//
+// Run: `npm run charts` (from repo root). Idempotent.
+
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { calcularNomina } from '../src/pipeline.ts';
+import { INFLACION_A_2026 } from '../src/inflacion.ts';
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const OUT_DIR = join(REPO_ROOT, 'docs', 'assets');
+
+const PALETTE = ['#1f77b4', '#d62728', '#2ca02c', '#9467bd', '#ff7f0e', '#17becf'] as const;
+
+interface Series {
+  label: string;
+  color: string;
+  points: [number, number][];
+}
+
+interface ChartSpec {
+  slug: string;
+  title: string;
+  xLabel: string;
+  yLabel: string;
+  xFormat: (v: number) => string;
+  yFormat: (v: number) => string;
+  series: Series[];
+  desc: string;
+  width?: number;
+  height?: number;
+}
+
+const linearScale =
+  (d0: number, d1: number, r0: number, r1: number) =>
+  (v: number): number =>
+    r0 + ((v - d0) / (d1 - d0)) * (r1 - r0);
+
+function niceTicks(min: number, max: number, count = 6): number[] {
+  const span = max - min;
+  if (span <= 0) return [min];
+  const rough = span / count;
+  const mag = Math.pow(10, Math.floor(Math.log10(rough)));
+  const norm = rough / mag;
+  let step: number;
+  if (norm < 1.5) step = mag;
+  else if (norm < 3) step = 2 * mag;
+  else if (norm < 7) step = 5 * mag;
+  else step = 10 * mag;
+  const start = Math.ceil(min / step) * step;
+  const out: number[] = [];
+  for (let v = start; v <= max + 1e-9; v += step) {
+    out.push(Number(v.toFixed(10)));
+  }
+  return out;
+}
+
+function escapeXml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function renderChart(spec: ChartSpec): string {
+  const W = spec.width ?? 760;
+  const H = spec.height ?? 420;
+  const M = { top: 60, right: 170, bottom: 60, left: 80 };
+  const innerW = W - M.left - M.right;
+  const innerH = H - M.top - M.bottom;
+
+  const allX = spec.series.flatMap((s) => s.points.map((p) => p[0]));
+  const allY = spec.series.flatMap((s) => s.points.map((p) => p[1]));
+  const xMin = Math.min(...allX);
+  const xMax = Math.max(...allX);
+  const yMinRaw = Math.min(...allY);
+  const yMaxRaw = Math.max(...allY);
+  const yPad = (yMaxRaw - yMinRaw) * 0.05;
+  const yMin = Math.max(0, yMinRaw - yPad);
+  const yMax = yMaxRaw + yPad;
+
+  const x = linearScale(xMin, xMax, 0, innerW);
+  const y = linearScale(yMin, yMax, innerH, 0);
+
+  const xTicks = niceTicks(xMin, xMax, 8);
+  const yTicks = niceTicks(yMin, yMax, 6);
+
+  const parts: string[] = [];
+  parts.push(
+    `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${String(W)} ${String(H)}" width="${String(W)}" height="${String(H)}" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif" font-size="13" role="img" aria-labelledby="${spec.slug}-title ${spec.slug}-desc">`,
+  );
+  parts.push(`<title id="${spec.slug}-title">${escapeXml(spec.title)}</title>`);
+  parts.push(`<desc id="${spec.slug}-desc">${escapeXml(spec.desc)}</desc>`);
+  parts.push(`<rect width="${String(W)}" height="${String(H)}" fill="#ffffff" />`);
+
+  // Title
+  parts.push(
+    `<text x="${String(M.left)}" y="${String(M.top - 25)}" font-size="16" font-weight="600" fill="#222">${escapeXml(spec.title)}</text>`,
+  );
+
+  // Plot area transform
+  parts.push(`<g transform="translate(${String(M.left)},${String(M.top)})">`);
+
+  // Gridlines (horizontal)
+  for (const t of yTicks) {
+    const yp = y(t);
+    parts.push(
+      `<line x1="0" y1="${yp.toFixed(2)}" x2="${String(innerW)}" y2="${yp.toFixed(2)}" stroke="#e5e5e5" stroke-width="1" />`,
+    );
+  }
+
+  // Axes
+  parts.push(
+    `<line x1="0" y1="${String(innerH)}" x2="${String(innerW)}" y2="${String(innerH)}" stroke="#333" stroke-width="1" />`,
+  );
+  parts.push(`<line x1="0" y1="0" x2="0" y2="${String(innerH)}" stroke="#333" stroke-width="1" />`);
+
+  // X ticks + labels
+  for (const t of xTicks) {
+    const xp = x(t);
+    parts.push(
+      `<line x1="${xp.toFixed(2)}" y1="${String(innerH)}" x2="${xp.toFixed(2)}" y2="${String(innerH + 5)}" stroke="#333" stroke-width="1" />`,
+    );
+    parts.push(
+      `<text x="${xp.toFixed(2)}" y="${String(innerH + 22)}" text-anchor="middle" fill="#444">${escapeXml(spec.xFormat(t))}</text>`,
+    );
+  }
+
+  // Y ticks + labels
+  for (const t of yTicks) {
+    const yp = y(t);
+    parts.push(
+      `<line x1="-5" y1="${yp.toFixed(2)}" x2="0" y2="${yp.toFixed(2)}" stroke="#333" stroke-width="1" />`,
+    );
+    parts.push(
+      `<text x="-10" y="${(yp + 4).toFixed(2)}" text-anchor="end" fill="#444">${escapeXml(spec.yFormat(t))}</text>`,
+    );
+  }
+
+  // Axis labels
+  parts.push(
+    `<text x="${String(innerW / 2)}" y="${String(innerH + 48)}" text-anchor="middle" fill="#222" font-size="13">${escapeXml(spec.xLabel)}</text>`,
+  );
+  parts.push(
+    `<text transform="translate(-55,${String(innerH / 2)}) rotate(-90)" text-anchor="middle" fill="#222" font-size="13">${escapeXml(spec.yLabel)}</text>`,
+  );
+
+  // Series
+  for (const s of spec.series) {
+    const points = s.points.map(([px, py]) => `${x(px).toFixed(2)},${y(py).toFixed(2)}`).join(' ');
+    parts.push(
+      `<polyline points="${points}" fill="none" stroke="${s.color}" stroke-width="2" stroke-linejoin="round" stroke-linecap="round" />`,
+    );
+    // dots
+    for (const [px, py] of s.points) {
+      parts.push(
+        `<circle cx="${x(px).toFixed(2)}" cy="${y(py).toFixed(2)}" r="2" fill="${s.color}" />`,
+      );
+    }
+  }
+
+  // Legend
+  if (spec.series.length > 1 || spec.series[0]?.label) {
+    const lx = innerW + 18;
+    let ly = 0;
+    for (const s of spec.series) {
+      parts.push(
+        `<rect x="${String(lx)}" y="${String(ly)}" width="14" height="3" fill="${s.color}" />`,
+      );
+      parts.push(
+        `<text x="${String(lx + 22)}" y="${String(ly + 6)}" fill="#222" font-size="12">${escapeXml(s.label)}</text>`,
+      );
+      ly += 22;
+    }
+  }
+
+  parts.push(`</g>`);
+  parts.push(`</svg>`);
+  return parts.join('\n');
+}
+
+// ---- Chart specs ----
+
+function chartNetoRealMismoNominal(): ChartSpec {
+  const points: [number, number][] = [];
+  for (let a = 2012; a <= 2026; a++) {
+    const n = calcularNomina(30000, a);
+    points.push([a, n.salarioNeto * INFLACION_A_2026[a]]);
+  }
+  return {
+    slug: 'neto-real-mismo-nominal',
+    title: 'Neto real con bruto nominal fijo en 30 000 €',
+    desc: 'Bruto nominal de 30 000 € en cada año entre 2012 y 2026, expresado el neto en € constantes de 2026. Pendiente decreciente: el mismo bruto nominal pierde poder adquisitivo real cada año.',
+    xLabel: 'Año',
+    yLabel: 'Neto en € de 2026',
+    xFormat: (v) => String(Math.round(v)),
+    yFormat: (v) => Math.round(v).toLocaleString('es-ES') + ' €',
+    series: [{ label: 'Neto real (€ 2026)', color: PALETTE[0], points }],
+  };
+}
+
+function brutoSeriesByYear(years: number[]): Series[] {
+  const series: Series[] = [];
+  let i = 0;
+  for (const a of years) {
+    const points: [number, number][] = [];
+    const mult = INFLACION_A_2026[a];
+    for (let b = 15000; b <= 80000; b += 1000) {
+      const n = calcularNomina(b / mult, a);
+      points.push([b, n.salarioNeto * mult]);
+    }
+    series.push({ label: String(a), color: PALETTE[i++ % PALETTE.length], points });
+  }
+  return series;
+}
+
+function chartNetoRealBrutoRealFijo(): ChartSpec {
+  return {
+    slug: 'neto-real-bruto-real-fijo',
+    title: 'Neto real por bruto real, fiscalidad de cada año',
+    desc: 'Para un mismo bruto medido en € constantes de 2026, qué neto real se obtiene aplicando la fiscalidad y SS de cada año. El espaciado vertical entre líneas mide el efecto neto de las reformas más la progresividad en frío.',
+    xLabel: 'Bruto en € de 2026',
+    yLabel: 'Neto en € de 2026',
+    xFormat: (v) => Math.round(v / 1000) + 'k €',
+    yFormat: (v) => Math.round(v / 1000) + 'k €',
+    series: brutoSeriesByYear([2012, 2015, 2018, 2022, 2024, 2026]),
+  };
+}
+
+function chartTipoMedioEfectivo(): ChartSpec {
+  const series: Series[] = [];
+  let i = 0;
+  for (const a of [2012, 2015, 2018, 2022, 2024, 2026]) {
+    const points: [number, number][] = [];
+    const mult = INFLACION_A_2026[a];
+    for (let b = 15000; b <= 80000; b += 1000) {
+      const brutoNominal = b / mult;
+      const n = calcularNomina(brutoNominal, a);
+      const tipo = ((n.cotSocTrabajador + n.irpfFinal) / brutoNominal) * 100;
+      points.push([b, tipo]);
+    }
+    series.push({ label: String(a), color: PALETTE[i++ % PALETTE.length], points });
+  }
+  return {
+    slug: 'tipo-medio-efectivo',
+    title: 'Tipo medio efectivo: cotización + IRPF sobre bruto',
+    desc: 'Cuánto de cada euro bruto se convierte en cotización del trabajador más IRPF, expresado en porcentaje. Eje X en bruto real (€ de 2026) para que años distintos sean comparables a igual poder adquisitivo.',
+    xLabel: 'Bruto en € de 2026',
+    yLabel: 'Tipo medio efectivo',
+    xFormat: (v) => Math.round(v / 1000) + 'k €',
+    yFormat: (v) => v.toFixed(1) + ' %',
+    series,
+  };
+}
+
+// ---- Run ----
+
+mkdirSync(OUT_DIR, { recursive: true });
+
+const charts: ChartSpec[] = [
+  chartNetoRealMismoNominal(),
+  chartNetoRealBrutoRealFijo(),
+  chartTipoMedioEfectivo(),
+];
+
+for (const c of charts) {
+  const out = join(OUT_DIR, `${c.slug}.svg`);
+  writeFileSync(out, renderChart(c) + '\n', 'utf8');
+  console.log(`[charts] wrote ${out}`);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 // Public API barrel for the auditor-irpf-es engine.
 
-export const VERSION = '0.2.0';
+export const VERSION = '0.4.0';
 
 export type {
   Art20Meta,

--- a/test/version.test.ts
+++ b/test/version.test.ts
@@ -3,6 +3,6 @@ import { VERSION } from '../src/index';
 
 describe('VERSION', () => {
   it('matches package.json', () => {
-    expect(VERSION).toBe('0.2.0');
+    expect(VERSION).toBe('0.4.0');
   });
 });


### PR DESCRIPTION
## Release v0.4.0

Promueve a `main` toda la Phase 3 (manual divulgativo en MkDocs Material publicado en GitHub Pages). Sin commits nuevos: este PR es puramente la promoción de `develop` (`974a6c9`) a `main`.

## Highlights del release

- **Manual divulgativo en GitHub Pages** — siete páginas explicando la cadena fiscal paso a paso, una página dedicada a la **progresividad en frío** con gráficos generados desde el propio motor, y 15 stubs anuales auto-generados desde `obtenerParametros()` (la redacción completa con prosa BOE llegará en `v1.1.0`).
- **Workflow de docs** (`.github/workflows/docs.yml`) — `mkdocs build --strict` en cada PR; deploy a GitHub Pages vía `actions/deploy-pages@v4` en push a `main`. Tras este merge, el sitio quedará live en `https://ceballosiker.github.io/auditor-irpf-es/`.
- **Dos scripts nuevos**: `npm run charts` (renderiza 3 SVGs hand-rolled desde `src/pipeline.ts` + `src/inflacion.ts`, sin Vega/Chart.js) y `npm run anual:stubs` (regenera los 15 stubs desde el motor; encadena `prettier --write`).
- **Housekeeping**: `SECURITY.md` removido (era un stub sin valor), `eslint.config.js` ignora `.venv-*/` y `site/`, README incluye aviso de una línea sobre el doble propósito del repo (proyecto + práctica de flujos OSS asistidos por agente de IA).
- **Bumps**: `package.json`, `src/index.ts` (`VERSION`) y `test/version.test.ts` a `0.4.0`.
- **CHANGELOG**: nueva entrada `[0.4.0] - 2026-04-29` + backfill de `[0.3.0] - 2026-04-27` (la entrada de v0.3.0 nunca se documentó en su release).

Detalle completo en [`CHANGELOG.md`](https://github.com/ceballosiker/auditor-irpf-es/blob/develop/CHANGELOG.md#040---2026-04-29).

## Sub-tasks cerradas en Phase 3

- #34 — Phase 3.1: MkDocs Material scaffold (PR #41).
- #35 — Phase 3.2: 7 motor pages (PR #43).
- #36 — Phase 3.3: progresividad-en-frio (PR #44).
- #37 — Phase 3.4: chart rendering (PR #45, bundle).
- #38 — Phase 3.5: yearly stubs (PR #45, bundle).
- #39 — Phase 3.6: GitHub Pages workflow (PR #42).
- #40 — Phase 3.7: README + CHANGELOG + version bump (PR #46).

## Acción requerida antes/después del merge

> **Settings → Pages → Build and deployment → Source = \"GitHub Actions\"**
>
> Sin este ajuste, el job `Deploy to GitHub Pages` del workflow `Docs` fallará en el primer push a `main`. Es one-off, se puede hacer ahora o justo antes de mergear este PR.

## Test plan

- [x] Phase 3 aterrizó verde en cada sub-task PR; `develop` tiene CI verde acumulado.
- [ ] CI de este PR (`Docs` build + `CI` TS checks) verde.
- [ ] Tras merge: el job `Deploy to GitHub Pages` corre con éxito y el sitio queda accesible en `https://ceballosiker.github.io/auditor-irpf-es/`.
- [ ] Tras deploy: tag `v0.4.0` sobre el merge commit + GitHub Release con notas extraídas del CHANGELOG.

Refs #4