### PR TITLE
ci(docs): publish manual under /manual/ subpath

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,11 +34,38 @@ jobs:
       - name: Build with strict mode
         run: mkdocs build --strict
 
+      # Pages layout: manual under /manual/, root reserved for the SPA (Phase 4 / #53).
+      # `actions/deploy-pages` replaces the entire deployment per upload, so we publish
+      # both the manual and a placeholder root redirect from a single artifact here.
+      # When #53 lands, the root index.html will be replaced by the SPA bundle in a
+      # unified workflow (see #53 for the merge plan).
+      - name: Restructure artifact (manual under /manual/, redirect at root)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: |
+          mkdir -p public/manual
+          mv site/* public/manual/
+          cat > public/index.html <<'HTML'
+          <!doctype html>
+          <html lang="es">
+          <head>
+            <meta charset="utf-8">
+            <title>Auditor IRPF ES</title>
+            <meta http-equiv="refresh" content="0; url=./manual/">
+            <link rel="canonical" href="./manual/">
+            <meta name="robots" content="noindex">
+          </head>
+          <body>
+            <p>Redirigiendo al <a href="./manual/">manual</a>…</p>
+            <p>La calculadora interactiva (v1.0.0) sustituirá esta página próximamente.</p>
+          </body>
+          </html>
+          HTML
+
       - name: Upload Pages artifact
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: actions/upload-pages-artifact@v3
         with:
-          path: site
+          path: public
 
   deploy:
     name: Deploy to GitHub Pages

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ El formato sigue [Keep a Changelog](https://keepachangelog.com/es-ES/1.1.0/) y e
 
 ## [Unreleased]
 
+### Changed
+
+- Manual MkDocs reubicado bajo el subpath `/manual/` (antes en la raíz). La raíz de GitHub Pages queda reservada para la calculadora interactiva (Phase 4 / `v1.0.0`); hasta entonces, una página estática redirige automáticamente a `/manual/`. `mkdocs.yml` actualiza `site_url` para que canonical URLs y sitemap reflejen la nueva ruta. `.github/workflows/docs.yml` reestructura el artefacto antes del upload (mueve `site/` a `public/manual/` y emite un `public/index.html` con `meta refresh`). README + badge apuntan a la nueva URL.
+
 ## [0.4.0] - 2026-04-29
 
 Manual divulgativo del motor publicado en GitHub Pages: explica la cadena de cálculo paso a paso y la **progresividad en frío** en lenguaje llano, con gráficos generados desde el propio motor.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ![Node](https://img.shields.io/badge/node-%3E%3D18.18-brightgreen.svg)
 ![License](https://img.shields.io/badge/license-MIT-green.svg)
 ![Estado](<https://img.shields.io/badge/estado-en%20curso%20(v0.4)-yellow.svg>)
-[![Manual](https://img.shields.io/badge/manual-ceballosiker.github.io-blue.svg)](https://ceballosiker.github.io/auditor-irpf-es/)
+[![Manual](https://img.shields.io/badge/manual-ceballosiker.github.io-blue.svg)](https://ceballosiker.github.io/auditor-irpf-es/manual/)
 
 > **Aviso.** El objetivo de este repositorio es **practicar flujos de trabajo OSS con asistencia de agentes de IA** (Claude Code).
 
@@ -14,7 +14,9 @@ Auditor fiscal que calcula el salario neto en España (2012–2026) euro a euro:
 
 ## 📖 Manual divulgativo
 
-El manual está publicado en **<https://ceballosiker.github.io/auditor-irpf-es/>**. Contiene siete páginas explicando paso a paso la cadena de cálculo (cotización, SS, MEI/Solidaridad, Art. 19/20, escala IRPF, SMI/tope 43 %), una página dedicada a la **progresividad en frío** con gráficos generados desde el propio motor, y un esqueleto de 15 resúmenes anuales (uno por año entre 2012 y 2026) cuya redacción completa irá llegando en `v1.1.0` en paralelo con la auditoría fiscal.
+El manual está publicado en **<https://ceballosiker.github.io/auditor-irpf-es/manual/>**. Contiene siete páginas explicando paso a paso la cadena de cálculo (cotización, SS, MEI/Solidaridad, Art. 19/20, escala IRPF, SMI/tope 43 %), una página dedicada a la **progresividad en frío** con gráficos generados desde el propio motor, y un esqueleto de 15 resúmenes anuales (uno por año entre 2012 y 2026) cuya redacción completa irá llegando en `v1.1.0` en paralelo con la auditoría fiscal.
+
+> La raíz del sitio (`https://ceballosiker.github.io/auditor-irpf-es/`) está reservada para la **calculadora interactiva** que aterrizará en `v1.0.0`; mientras tanto redirige al manual.
 
 ---
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: Auditor IRPF ES
 site_description: Implementación pública y auditable del cálculo del IRPF y del salario neto en España, 2012–2026.
-site_url: https://ceballosiker.github.io/auditor-irpf-es/
+site_url: https://ceballosiker.github.io/auditor-irpf-es/manual/
 site_author: ceballosiker
 
 repo_url: https://github.com/ceballosiker/auditor-irpf-es


### PR DESCRIPTION
## Resumen

Reubica el sitio MkDocs (publicado en v0.4.0 en la raíz de GitHub Pages) bajo el subpath `/manual/`. La raíz queda libre para la calculadora interactiva que aterrizará en `v1.0.0` (Phase 4 / #53). Hasta entonces, una página estática mínima en la raíz redirige automáticamente a `/manual/` para no romper enlaces externos.

## Issue relacionado

Closes #55
Refs #5

## Tipo de cambio

- [x] `ci` / `build` — infra de tests, CI, builds

## Auto-review

- [x] He pasado `mkdocs build --strict` en local — 0 warnings.
- [ ] No aplica `npm run` (este PR no toca código TS).
- [x] He actualizado `CHANGELOG.md` (sección `[Unreleased]`).

## Notas para el revisor

**Cambios** (37 líneas, 4 ficheros):

- `mkdocs.yml` — `site_url` → `…/manual/`. Afecta canonical URLs (`<link rel="canonical">`) y sitemap; verificado que el sitemap y los canonical de cada página ya emiten URLs bajo `/manual/`.
- `.github/workflows/docs.yml` — nuevo paso "Restructure artifact" entre `mkdocs build` y `upload-pages-artifact@v3`: mueve `site/*` a `public/manual/` y emite `public/index.html` con `meta http-equiv="refresh"` apuntando a `./manual/`. El upload pasa de `path: site` a `path: public`.
- `README.md` — badge "Manual" y enlace en prosa apuntan a `/manual/`. Nota nueva avisando que la raíz queda reservada para la calculadora.
- `CHANGELOG.md` — entrada en `[Unreleased]`.

**Verificación local** (simula el workflow):

```
$ rm -rf site/ public/ && .venv-docs/bin/mkdocs build --strict
INFO    -  Documentation built in 1.54 seconds
$ mkdir -p public/manual && mv site/* public/manual/ && cat > public/index.html <<…>
$ ls public/
index.html  manual
$ grep -o 'rel="canonical"[^>]*' public/manual/index.html
rel="canonical" href="https://ceballosiker.github.io/auditor-irpf-es/manual/"
```

**Coordinación con #53 (deploy SPA)**: ambos workflows escribirán sobre el mismo Pages deployment (`actions/deploy-pages` reemplaza el deployment entero por upload). El PR de #53 deberá decidir entre (a) un único workflow que construya manual + SPA y suba un solo artifact, o (b) cambiar a `peaceiris/actions-gh-pages` con `keep_files: true`. Documentado en el comentario al inicio del paso "Restructure artifact" para que quien aterrice #53 lo encuentre.

**Ruptura aceptada**: enlaces externos a `https://ceballosiker.github.io/auditor-irpf-es/<página>` (sin `/manual/`) seguirán funcionando solo desde la raíz (`/`) gracias al redirect; rutas profundas (p.ej. `/motor/01-cotizacion/`) sí 404. El manual se publicó hace pocos días, riesgo bajo; no se invierte tiempo en redirects HTML por página.