### PR TITLE
feat(ui): scaffold static SPA (Phase 4.1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,3 +41,6 @@ jobs:
 
       - name: Test
         run: npm test
+
+      - name: Build (Vite static bundle)
+        run: npm run build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ El formato sigue [Keep a Changelog](https://keepachangelog.com/es-ES/1.1.0/) y e
 
 ## [Unreleased]
 
+### Added
+
+- **Esqueleto SPA estático** (Phase 4.1) — primer paso hacia la calculadora interactiva (`v1.0.0`):
+  - `index.html` en la raíz como entrypoint Vite (lang `es`, viewport, meta description, mount point `<main id="app">`).
+  - `src/ui/main.ts` — bootstrap mínimo que importa Pico.css y renderiza un placeholder en `#app`.
+  - `src/ui/render.ts` — helper `render(target, html)` para usar template strings sin reaching directo a `innerHTML` desde toda la app.
+  - `@picocss/pico` añadido como dependencia (CSS clásico, sin runtime, ~12 KB gzip), bundleado por Vite — sin CDN externo.
+- `.github/workflows/ci.yml` — añadido paso `npm run build` para que CI cace cualquier rotura del bundle Vite a partir de ahora.
+
 ### Changed
 
 - Manual MkDocs reubicado bajo el subpath `/manual/` (antes en la raíz). La raíz de GitHub Pages queda reservada para la calculadora interactiva (Phase 4 / `v1.0.0`); hasta entonces, una página estática redirige automáticamente a `/manual/`. `mkdocs.yml` actualiza `site_url` para que canonical URLs y sitemap reflejen la nueva ruta. `.github/workflows/docs.yml` reestructura el artefacto antes del upload (mueve `site/` a `public/manual/` y emite un `public/index.html` con `meta refresh`). README + badge apuntan a la nueva URL.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Calculadora IRPF España 2012–2026</title>
+    <meta
+      name="description"
+      content="Calculadora interactiva del salario neto en España (2012–2026): IRPF, Seguridad Social, MEI y Cuota de Solidaridad, con análisis de pérdida de poder adquisitivo. 100 % en el navegador, sin servidor."
+    />
+    <meta name="color-scheme" content="light dark" />
+  </head>
+  <body>
+    <main id="app" class="container"></main>
+    <script type="module" src="/src/ui/main.ts"></script>
+  </body>
+</html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "auditor-irpf-es",
-  "version": "0.1.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "auditor-irpf-es",
-      "version": "0.1.0",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
+        "@picocss/pico": "^2.1.1",
         "xlsx": "^0.18.5"
       },
       "devDependencies": {
@@ -758,6 +759,11 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@picocss/pico": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@picocss/pico/-/pico-2.1.1.tgz",
+      "integrity": "sha512-kIDugA7Ps4U+2BHxiNHmvgPIQDWPDU4IeU6TNRdvXQM1uZX+FibqDQT2xUOnnO2yq/LUHcwnGlu1hvf4KfXnMg=="
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.60.2",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "vitest": "^1.6.0"
   },
   "dependencies": {
+    "@picocss/pico": "^2.1.1",
     "xlsx": "^0.18.5"
   }
 }

--- a/src/ui/main.ts
+++ b/src/ui/main.ts
@@ -1,0 +1,22 @@
+import '@picocss/pico/css/pico.min.css';
+import { render } from './render.js';
+
+const app = document.getElementById('app');
+if (!app) {
+  throw new Error('Mount point #app not found in index.html');
+}
+
+render(
+  app,
+  `
+    <header>
+      <hgroup>
+        <h1>Calculadora IRPF España</h1>
+        <p>Salario neto, IRPF y cotización social entre 2012 y 2026.</p>
+      </hgroup>
+    </header>
+    <section>
+      <p>Hola, IRPF — el formulario aterriza en <a href="https://github.com/ceballosiker/auditor-irpf-es/issues/49">#49</a>.</p>
+    </section>
+  `,
+);

--- a/src/ui/render.ts
+++ b/src/ui/render.ts
@@ -1,0 +1,3 @@
+export function render(target: HTMLElement, html: string): void {
+  target.innerHTML = html;
+}


### PR DESCRIPTION
## Resumen

Primer paso de la calculadora interactiva (v1.0.0): esqueleto SPA estático con vanilla TS + template strings (decisión tomada en el kickoff de Phase 4 — sin React/Svelte/Lit/Solid). Levanta el entrypoint HTML, la carpeta `src/ui/`, y verifica que `npm run dev` y `npm run build` funcionan extremo a extremo. El form, los resultados, el chart y el botón de Excel aterrizan en #49–#51.

## Issue relacionado

Closes #48
Refs #5

## Tipo de cambio

- [x] `feat` — nueva funcionalidad

## Auto-review

- [x] He pasado `npm run format:check`, `npm run lint`, `npm run typecheck` y `npm test` en local — todo verde, 664/664 tests del motor sin regresión.
- [x] He pasado también `npm run build` (nuevo paso en CI introducido en este PR) — produce `dist/` con bundle Vite limpio.
- [ ] No hay tests UI todavía (smoke test = build verde + dev server boot). Tests con axe + Playwright llegan en #52.
- [x] He actualizado `CHANGELOG.md` (sección `[Unreleased]`).

## Notas para el revisor

**Cambios** (63 líneas, 7 ficheros):

- `index.html` — entrypoint Vite en la raíz: `lang="es"`, viewport, meta description, `color-scheme: light dark`, `<main id="app" class="container">` y `<script type="module" src="/src/ui/main.ts">`.
- `src/ui/main.ts` — bootstrap: importa `@picocss/pico/css/pico.min.css` (Vite procesa el CSS al bundle), recupera `#app`, lanza si no existe, y renderiza un placeholder mínimo ("Hola, IRPF") con un link a #49.
- `src/ui/render.ts` — helper `render(target: HTMLElement, html: string): void`. Centraliza el único `innerHTML` de la app para que en #52 (a11y) o #49 (form) podamos sustituirlo por algo más seguro (sanitización / DOM construction) sin tocar callsites.
- `package.json` + `package-lock.json` — `@picocss/pico ^2.1.1` como dependencia. CSS-only, ~12 KB gzip, bundled — **no CDN externo en runtime** (alineado con "no telemetry, no cookies, no fetch externo" de #52).
- `.github/workflows/ci.yml` — añade `npm run build` después del step Test. Pequeño extra fuera del scope literal del issue, pero a partir de ahora cualquier rotura del bundle Vite la caza CI; el coste es una llamada más a Vite (~250 ms en local) por job.
- `CHANGELOG.md` — entrada en `[Unreleased] / Added`.

**Smoke verificado en local**:

```
$ npm run build
dist/index.html                  0.75 kB │ gzip:  0.46 kB
dist/assets/index-DxCYN04u.css  83.00 kB │ gzip: 11.68 kB
dist/assets/index--vwHbfQ1.js    1.19 kB │ gzip:  0.69 kB
✓ built in 218ms

$ npx vite --port 5180
  VITE v5.4.21  ready in 367 ms

$ curl -s -o /dev/null -w "%{http_code}\n" http://127.0.0.1:5180/
200
```

**Decisiones notables**:

- **Pico.css bundleado, no CDN**: añade ~12 KB gzip al bundle pero elimina latencia de CDN, evita SRI hashes en el HTML, y deja el sitio 100 % offline-friendly. Si Lighthouse en #52 marca el CSS como bloqueante de render, lo migraremos a `?inline` o critical-CSS extraction en ese momento.
- **`render()` helper trivial**: hoy son 3 líneas y se podría inline `innerHTML`. La razón de extraerlo es que el form (#49) y el panel de resultados re-renderizan en cada `input`/`change`; centralizar el punto de entrada simplifica la migración futura a una abstracción más segura (template literal con escape, lit-html opcional, etc.) sin tocar 5+ callsites.
- **Sin tests UI todavía**: Vitest + Playwright + axe-core entra en #52. Para este PR, build verde + dev server arrancando es suficiente acceptance.