### PR TITLE
feat(ui): wire form + results panel to calcularNomina (Phase 4.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ El formato sigue [Keep a Changelog](https://keepachangelog.com/es-ES/1.1.0/) y e
 
 ### Added
 
+- **Calculadora interactiva** (Phase 4.2) — el SPA pasa de placeholder a calculadora funcional:
+  - `src/ui/form.ts` — formulario con bruto (€, `step=100`), año (2012–2026, default 2026 ordenado descendente) y CCAA (deshabilitado, "Estatal" fijo). Etiquetas semánticas `<label>` con texto de ayuda en `<small>` para cada campo.
+  - `src/ui/results.ts` — panel de resultados en tres `<article>`s (cotización social, IRPF, neto). Detalla tope de cotización, MEI/Solidaridad trabajador (cuando aplican), reducción Art. 20, gastos Art. 19, base imponible, mínimo personal aplicado como cuota, tope 43 % con etiqueta "aplica/no aplica", y neto anual + mensual (×14). Tabla de tramos IRPF muestra solo los tramos con cuota > 0 (o un mensaje si no hay IRPF a pagar).
+  - `src/ui/format.ts` — helpers `eur()` y `percent()` con `Intl.NumberFormat('es-ES', …)` para que todos los importes y porcentajes usen el formato español de forma consistente.
+  - `src/ui/main.ts` — wiring reactivo: cada `input`/`change` del formulario re-renderiza la sección de resultados (sin debouncing). Sección con `aria-live="polite"` para que lectores de pantalla anuncien las actualizaciones.
 - **Esqueleto SPA estático** (Phase 4.1) — primer paso hacia la calculadora interactiva (`v1.0.0`):
   - `index.html` en la raíz como entrypoint Vite (lang `es`, viewport, meta description, mount point `<main id="app">`).
   - `src/ui/main.ts` — bootstrap mínimo que importa Pico.css y renderiza un placeholder en `#app`.

--- a/src/ui/form.ts
+++ b/src/ui/form.ts
@@ -1,0 +1,83 @@
+import { ANIOS_SOPORTADOS } from '../normativa.js';
+import { render } from './render.js';
+
+export interface FormState {
+  readonly bruto: number;
+  readonly anio: number;
+}
+
+export interface FormOptions {
+  readonly initial: FormState;
+  readonly onChange: (state: FormState) => void;
+}
+
+export function mountForm(target: HTMLElement, opts: FormOptions): void {
+  const { initial, onChange } = opts;
+
+  const yearOptions = [...ANIOS_SOPORTADOS]
+    .reverse()
+    .map(
+      (y) =>
+        `<option value="${String(y)}"${y === initial.anio ? ' selected' : ''}>${String(y)}</option>`,
+    )
+    .join('');
+
+  render(
+    target,
+    `
+      <form id="calc-form" autocomplete="off" novalidate>
+        <div class="grid">
+          <label>
+            Salario bruto anual (€)
+            <input
+              type="number"
+              id="input-bruto"
+              name="bruto"
+              min="0"
+              step="100"
+              value="${String(initial.bruto)}"
+              inputmode="numeric"
+              required
+            />
+            <small>Importe íntegro antes de cotización social y retención.</small>
+          </label>
+          <label>
+            Año fiscal
+            <select id="input-anio" name="anio">${yearOptions}</select>
+            <small>Normativa aplicable a 31 de diciembre.</small>
+          </label>
+          <label>
+            Comunidad Autónoma
+            <select id="input-ccaa" name="ccaa" disabled>
+              <option value="estatal" selected>Estatal (escala duplicada)</option>
+            </select>
+            <small>Las escalas autonómicas llegan en una versión posterior.</small>
+          </label>
+        </div>
+      </form>
+    `,
+  );
+
+  const form = target.querySelector<HTMLFormElement>('#calc-form');
+  const brutoInput = target.querySelector<HTMLInputElement>('#input-bruto');
+  const anioSelect = target.querySelector<HTMLSelectElement>('#input-anio');
+  if (!form || !brutoInput || !anioSelect) {
+    throw new Error('Form mount: expected fields not found in DOM');
+  }
+
+  function readState(): FormState {
+    const bruto = Number.parseFloat(brutoInput?.value ?? '0');
+    const anio = Number.parseInt(anioSelect?.value ?? '0', 10);
+    return {
+      bruto: Number.isFinite(bruto) && bruto >= 0 ? bruto : 0,
+      anio,
+    };
+  }
+
+  function emit(): void {
+    onChange(readState());
+  }
+
+  brutoInput.addEventListener('input', emit);
+  anioSelect.addEventListener('change', emit);
+}

--- a/src/ui/format.ts
+++ b/src/ui/format.ts
@@ -1,0 +1,20 @@
+const eurFormatter = new Intl.NumberFormat('es-ES', {
+  style: 'currency',
+  currency: 'EUR',
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+});
+
+const percentFormatter = new Intl.NumberFormat('es-ES', {
+  style: 'percent',
+  minimumFractionDigits: 1,
+  maximumFractionDigits: 2,
+});
+
+export function eur(value: number): string {
+  return eurFormatter.format(value);
+}
+
+export function percent(value: number): string {
+  return percentFormatter.format(value);
+}

--- a/src/ui/main.ts
+++ b/src/ui/main.ts
@@ -1,5 +1,9 @@
 import '@picocss/pico/css/pico.min.css';
+import { ANIO_MAX } from '../normativa.js';
+import { mountForm } from './form.js';
+import type { FormState } from './form.js';
 import { render } from './render.js';
+import { renderResults } from './results.js';
 
 const app = document.getElementById('app');
 if (!app) {
@@ -12,11 +16,30 @@ render(
     <header>
       <hgroup>
         <h1>Calculadora IRPF España</h1>
-        <p>Salario neto, IRPF y cotización social entre 2012 y 2026.</p>
+        <p>Salario neto, IRPF y cotización social entre 2012 y ${String(ANIO_MAX)}.</p>
       </hgroup>
     </header>
-    <section>
-      <p>Hola, IRPF — el formulario aterriza en <a href="https://github.com/ceballosiker/auditor-irpf-es/issues/49">#49</a>.</p>
-    </section>
+    <section id="form-section"></section>
+    <section id="results-section" aria-live="polite"></section>
   `,
 );
+
+const formSection = app.querySelector<HTMLElement>('#form-section');
+const resultsSection = app.querySelector<HTMLElement>('#results-section');
+if (!formSection || !resultsSection) {
+  throw new Error('Layout sections not found after initial render');
+}
+
+const initial: FormState = { bruto: 30000, anio: ANIO_MAX };
+
+function update(state: FormState): void {
+  if (!resultsSection) return;
+  if (!Number.isInteger(state.anio)) {
+    render(resultsSection, '<p role="alert">Año no válido.</p>');
+    return;
+  }
+  renderResults(resultsSection, state.bruto, state.anio);
+}
+
+mountForm(formSection, { initial, onChange: update });
+update(initial);

--- a/src/ui/results.ts
+++ b/src/ui/results.ts
@@ -1,0 +1,138 @@
+import { calcularNomina, obtenerParametros } from '../index.js';
+import type { Nomina, Parametros } from '../index.js';
+import { eur, percent } from './format.js';
+import { render } from './render.js';
+
+interface Breakdown {
+  readonly baseCotizacion: number;
+  readonly topeAlcanzado: boolean;
+  readonly meiTrabajador: number;
+  readonly solidaridadTrabajador: number;
+  readonly tope43Aplica: boolean;
+}
+
+function breakdown(nomina: Nomina, p: Parametros): Breakdown {
+  const baseCotizacion = Math.min(nomina.bruto, p.baseMax);
+  const meiTrabajador = baseCotizacion * p.mei[1];
+  const solidaridadTrabajador = nomina.cotSocTrabajador - baseCotizacion * p.tipoTrabajadorTotal;
+  return {
+    baseCotizacion,
+    topeAlcanzado: nomina.bruto > p.baseMax,
+    meiTrabajador,
+    solidaridadTrabajador: Math.max(0, solidaridadTrabajador),
+    tope43Aplica: nomina.cuotaTrasSMI > nomina.limite43 + 1e-6,
+  };
+}
+
+function row(label: string, value: string, hint?: string): string {
+  const hintHtml = hint ? `<br><small>${hint}</small>` : '';
+  return `<tr><th scope="row">${label}${hintHtml}</th><td>${value}</td></tr>`;
+}
+
+function tramosTable(nomina: Nomina): string {
+  const activos = nomina.cuotasPorTramo
+    .map((t, i) => ({ ...t, idx: i + 1 }))
+    .filter((t) => t.cuota > 0);
+
+  if (activos.length === 0) {
+    return `<p><em>Sin cuota a pagar en ningún tramo (base imponible nula o cubierta por el mínimo personal).</em></p>`;
+  }
+
+  const rows = activos
+    .map((t) => {
+      const baseAplicada = t.tipo > 0 ? t.cuota / t.tipo : 0;
+      return `
+        <tr>
+          <td>T${String(t.idx)}</td>
+          <td>${percent(t.tipo)}</td>
+          <td>${eur(baseAplicada)}</td>
+          <td>${eur(t.cuota)}</td>
+        </tr>
+      `;
+    })
+    .join('');
+
+  return `
+    <table>
+      <thead>
+        <tr><th>Tramo</th><th>Tipo</th><th>Base aplicada</th><th>Cuota</th></tr>
+      </thead>
+      <tbody>${rows}</tbody>
+    </table>
+  `;
+}
+
+export function renderResults(target: HTMLElement, bruto: number, anio: number): void {
+  const params = obtenerParametros(anio);
+  const nomina = calcularNomina(bruto, anio);
+  const b = breakdown(nomina, params);
+
+  const netoMensual = nomina.salarioNeto / 14;
+
+  const cotizacionRows = [
+    row('Bruto anual', eur(nomina.bruto)),
+    row(
+      'Base de cotización',
+      `${eur(b.baseCotizacion)}${b.topeAlcanzado ? ' <mark>tope alcanzado</mark>' : ''}`,
+      b.topeAlcanzado
+        ? `Bruto excede el tope (${eur(params.baseMax)}); el exceso solo cotiza por Solidaridad.`
+        : undefined,
+    ),
+    row('Cotización empresa', eur(nomina.cotSocEmpresa)),
+    row('Cotización trabajador', eur(nomina.cotSocTrabajador)),
+    ...(b.meiTrabajador > 0 ? [row('— de la cual, MEI trabajador', eur(b.meiTrabajador))] : []),
+    ...(b.solidaridadTrabajador > 0
+      ? [row('— de la cual, Solidaridad trabajador', eur(b.solidaridadTrabajador))]
+      : []),
+    row('Coste laboral total', eur(nomina.costeLaboral)),
+  ].join('');
+
+  const irpfRows = [
+    row('Rendimiento previo (bruto − cot. trabajador)', eur(nomina.renPrevio)),
+    row('Reducción Art. 20 (rendimientos del trabajo)', eur(nomina.redRenTrabajo)),
+    row('Gastos fijos Art. 19', eur(nomina.gastosFijos)),
+    row('Base imponible', eur(nomina.baseImponible)),
+    row('Cuota íntegra (suma tramos)', eur(nomina.cuotaIntegra)),
+    row(
+      'Cuota mínimo personal',
+      eur(nomina.cuotaMinimoPersonal),
+      `Mínimo aplicado al tipo del primer tramo (${percent(params.tramosIRPF[0]?.tipo ?? 0)}).`,
+    ),
+    row('Cuota teórica (íntegra − mínimo)', eur(nomina.cuotaTeorica)),
+    ...(nomina.deduccionSMI > 0 ? [row('Deducción SMI', eur(nomina.deduccionSMI))] : []),
+    row('Cuota tras SMI', eur(nomina.cuotaTrasSMI)),
+    row(
+      'Tope 43 % sobre (bruto − mínimo exento)',
+      `${eur(nomina.limite43)} <small>(${b.tope43Aplica ? 'aplica' : 'no aplica'})</small>`,
+      b.tope43Aplica
+        ? `La cuota teórica supera el tope; el IRPF final se recorta a ${eur(nomina.limite43)}.`
+        : undefined,
+    ),
+    row('IRPF final', `<strong>${eur(nomina.irpfFinal)}</strong>`),
+  ].join('');
+
+  render(
+    target,
+    `
+      <article>
+        <header><strong>Cotización social</strong></header>
+        <table>${cotizacionRows}</table>
+      </article>
+
+      <article>
+        <header><strong>IRPF</strong></header>
+        <table>${irpfRows}</table>
+        <h6>Tramos aplicados</h6>
+        ${tramosTable(nomina)}
+      </article>
+
+      <article>
+        <header><strong>Resultado: salario neto</strong></header>
+        <table>
+          ${row('Neto anual', `<strong>${eur(nomina.salarioNeto)}</strong>`)}
+          ${row('Neto mensual (×14 pagas)', `<strong>${eur(netoMensual)}</strong>`)}
+        </table>
+      </article>
+    `,
+  );
+}


### PR DESCRIPTION
## Resumen

Convierte el placeholder de #48 en una calculadora funcional de un único año: el usuario teclea un bruto y elige un año (2012–2026), la UI llama a `calcularNomina(bruto, anio)` y renderiza el desglose completo (cotización social, IRPF tramo a tramo, neto anual y mensual). Reactivo, sin red, sin debouncing.

## Issue relacionado

Closes #49
Refs #5

## Tipo de cambio

- [x] `feat` — nueva funcionalidad

## Auto-review

- [x] He pasado `npm run format:check`, `npm run lint`, `npm run typecheck`, `npm test` (664/664) y `npm run build` en local — todo verde.
- [ ] Sin tests UI (entran en #52 con axe + Playwright); cobertura indirecta vía spot-check de fixture (ver más abajo).
- [x] He actualizado `CHANGELOG.md` (sección `[Unreleased]`).

## Notas para el revisor

**Cambios** (273 líneas, 5 ficheros, todos bajo `src/ui/`):

- `form.ts` — formulario controlado en una `<form>` con tres campos: bruto (`<input type="number" min=0 step=100>`, default 30 000 €), año (`<select>` 2012–2026 ordenado desc, default 2026), y CCAA (`<select>` disabled, valor único "Estatal"). Cada campo lleva `<label>` semántica + texto de ayuda en `<small>`. Emite `FormState` vía callback en cada `input`/`change`. Sin debouncing — el motor calcula 0–100 000 € en milisegundos, no hay latencia que esconder.
- `results.ts` — panel en tres `<article>`s:
  1. **Cotización social** — bruto, base de cotización (con `<mark>tope alcanzado</mark>` si `bruto > baseMax`, hint citando `params.baseMax`), cot. empresa, cot. trabajador, MEI trabajador (solo si > 0, i.e. desde 2023), Solidaridad trabajador (solo si > 0, i.e. desde 2025), coste laboral.
  2. **IRPF** — rendimiento previo, reducción Art. 20, gastos Art. 19, base imponible, cuota íntegra, cuota mínimo personal (con hint mostrando el tipo del primer tramo), cuota teórica, deducción SMI (solo si > 0), cuota tras SMI, tope 43 % con etiqueta `aplica` / `no aplica` y hint explicando el recorte cuando aplica, IRPF final destacado. Tabla de tramos filtrada a los que tienen `cuota > 0`; mensaje "sin IRPF a pagar" si la base queda cubierta por el mínimo.
  3. **Resultado** — neto anual y neto mensual (×14 pagas) destacados.
- `format.ts` — `eur()` y `percent()` con `Intl.NumberFormat('es-ES', …)`. Centraliza el formato monetario y porcentual para que cualquier futuro componente (chart en #50, panel de Excel en #51) lo reutilice.
- `main.ts` — sustituye el placeholder de #48 por un layout `header + form-section + results-section`. La sección de resultados lleva `aria-live="polite"` para que lectores de pantalla anuncien las actualizaciones sin interrumpir. La función `update()` se invoca una vez al montar y luego en cada cambio del form.

**Spot-check vs fixture** (`tests/fixtures/golden_2024.json`, bruto=30 000):

```
$ npx tsx -e "import { calcularNomina } from './src/index'; const n = calcularNomina(30000, 2024); console.log(n.irpfFinal, n.salarioNeto, n.costeLaboral)"
4928.7 23130.3 39594
```

Coincide exacto con la fila del fixture (IRPF 4928.70, Neto 23130.30, Coste 39594.00). La UI invoca la misma función pura del motor que ya pasa 664 tests, así que la confianza en los números renderizados se hereda directamente del motor.

**Decisiones notables**:

- **MEI y Solidaridad recomputados en el UI** desde `(nomina, params)` en lugar de añadir campos al tipo `Nomina`. Razón: el tipo público está congelado por los fixtures dorados; tocar su shape obligaría a reconstruir el oráculo. La descomposición es trivial (`baseCotizacion × mei[1]`, `cotSocTrabajador − baseCotizacion × tipoTrabajadorTotal`) y vive en una función `breakdown()` aislada en `results.ts`.
- **Tabla de tramos filtra `cuota > 0`** en lugar de mostrar siempre los 6 tramos. Para brutos bajos en años con escala larga (2026 tiene 6 tramos) eso evita 4 filas de ceros visualmente ruidosas. El mensaje "sin IRPF a pagar" cubre el caso bruto < cobertura del mínimo personal.
- **`renderResults` re-llama a `obtenerParametros` y `calcularNomina` en cada update**. No hay caché. Coste: una llamada al motor por keystroke. El motor está en TypeScript puro y procesa en microsegundos; no merece la complejidad de un cache LRU. Si en #50/#52 esto se nota en Lighthouse, se introduce entonces.
- **Sección `aria-live="polite"` desde ya** para no requerir un PR aparte cuando llegue #52. La auditoría completa de a11y (`axe-core`) sigue siendo parte de #52, pero los hooks básicos (`<label>`, `<small>` de ayuda, `aria-live`) entran limpios aquí.