### PR TITLE
feat(ui): comparativa frente a inflación con Chart.js (Phase 4.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ El formato sigue [Keep a Changelog](https://keepachangelog.com/es-ES/1.1.0/) y e
 
 ### Added
 
+- **Comparativa frente a inflación** (Phase 4.3) — gráfico Chart.js que ilustra la pérdida de poder adquisitivo: para el bruto introducido (interpretado como € de 2026), deflacta al equivalente nominal de cada año entre 2012 y 2026, calcula `salarioNeto` e `irpfFinal` con la fiscalidad de ese año y reinflacta los tres números a € de 2026. Tres series en línea: bruto real (constante, dashed), neto real (creciente luego decreciente vía progresividad en frío), IRPF real (creciente). Tooltips en español con `Intl.NumberFormat`. Re-render del chart en cada cambio de bruto destruyendo la instancia previa para evitar fugas.
 - **Calculadora interactiva** (Phase 4.2) — el SPA pasa de placeholder a calculadora funcional:
   - `src/ui/form.ts` — formulario con bruto (€, `step=100`), año (2012–2026, default 2026 ordenado descendente) y CCAA (deshabilitado, "Estatal" fijo). Etiquetas semánticas `<label>` con texto de ayuda en `<small>` para cada campo.
   - `src/ui/results.ts` — panel de resultados en tres `<article>`s (cotización social, IRPF, neto). Detalla tope de cotización, MEI/Solidaridad trabajador (cuando aplican), reducción Art. 20, gastos Art. 19, base imponible, mínimo personal aplicado como cuota, tope 43 % con etiqueta "aplica/no aplica", y neto anual + mensual (×14). Tabla de tramos IRPF muestra solo los tramos con cuota > 0 (o un mensaje si no hay IRPF a pagar).

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@picocss/pico": "^2.1.1",
+        "chart.js": "^4.5.1",
         "xlsx": "^0.18.5"
       },
       "devDependencies": {
@@ -759,6 +760,11 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w=="
     },
     "node_modules/@picocss/pico": {
       "version": "2.1.1",
@@ -1672,6 +1678,17 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chart.js": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
+      "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
       }
     },
     "node_modules/check-error": {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
   },
   "dependencies": {
     "@picocss/pico": "^2.1.1",
+    "chart.js": "^4.5.1",
     "xlsx": "^0.18.5"
   }
 }

--- a/src/ui/chart.ts
+++ b/src/ui/chart.ts
@@ -1,0 +1,98 @@
+import { Chart } from 'chart.js/auto';
+import { ANIO_MAX, ANIO_MIN, INFLACION_A_2026, calcularNomina } from '../index.js';
+import { eur } from './format.js';
+
+const PALETTE = {
+  bruto: '#1f4e79',
+  neto: '#2ca02c',
+  irpf: '#d62728',
+} as const;
+
+interface Series {
+  readonly bruto: number[];
+  readonly neto: number[];
+  readonly irpf: number[];
+  readonly years: number[];
+}
+
+function comparativaSeries(bruto2026: number): Series {
+  const years: number[] = [];
+  const brutoR: number[] = [];
+  const netoR: number[] = [];
+  const irpfR: number[] = [];
+
+  for (let a = ANIO_MIN; a <= ANIO_MAX; a++) {
+    const mult = INFLACION_A_2026[a] ?? 1;
+    const brutoNominal = bruto2026 / mult;
+    const n = calcularNomina(brutoNominal, a);
+    years.push(a);
+    brutoR.push(bruto2026);
+    netoR.push(n.salarioNeto * mult);
+    irpfR.push(n.irpfFinal * mult);
+  }
+  return { years, bruto: brutoR, neto: netoR, irpf: irpfR };
+}
+
+let current: Chart | undefined;
+
+export function renderComparativaInflacion(canvas: HTMLCanvasElement, bruto: number): void {
+  const data = comparativaSeries(bruto);
+
+  current?.destroy();
+  current = new Chart(canvas, {
+    type: 'line',
+    data: {
+      labels: data.years.map(String),
+      datasets: [
+        {
+          label: 'Bruto real (€ 2026)',
+          data: data.bruto,
+          borderColor: PALETTE.bruto,
+          backgroundColor: PALETTE.bruto,
+          borderDash: [6, 4],
+          tension: 0,
+          pointRadius: 0,
+        },
+        {
+          label: 'Neto real (€ 2026)',
+          data: data.neto,
+          borderColor: PALETTE.neto,
+          backgroundColor: PALETTE.neto,
+          tension: 0.15,
+        },
+        {
+          label: 'IRPF real (€ 2026)',
+          data: data.irpf,
+          borderColor: PALETTE.irpf,
+          backgroundColor: PALETTE.irpf,
+          tension: 0.15,
+        },
+      ],
+    },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      interaction: { mode: 'index', intersect: false },
+      plugins: {
+        legend: { position: 'bottom' },
+        tooltip: {
+          callbacks: {
+            label: (ctx) => `${ctx.dataset.label ?? ''}: ${eur(Number(ctx.parsed.y))}`,
+          },
+        },
+        title: {
+          display: true,
+          text: 'Poder adquisitivo: bruto fijo en € de 2026, fiscalidad de cada año',
+        },
+      },
+      scales: {
+        y: {
+          beginAtZero: true,
+          ticks: {
+            callback: (v) => eur(Number(v)),
+          },
+        },
+      },
+    },
+  });
+}

--- a/src/ui/main.ts
+++ b/src/ui/main.ts
@@ -1,5 +1,6 @@
 import '@picocss/pico/css/pico.min.css';
 import { ANIO_MAX } from '../normativa.js';
+import { renderComparativaInflacion } from './chart.js';
 import { mountForm } from './form.js';
 import type { FormState } from './form.js';
 import { render } from './render.js';
@@ -21,24 +22,42 @@ render(
     </header>
     <section id="form-section"></section>
     <section id="results-section" aria-live="polite"></section>
+    <section id="chart-section">
+      <h2>Comparativa frente a inflación</h2>
+      <p>
+        Manteniendo el bruto constante en euros de ${String(ANIO_MAX)}, este gráfico
+        muestra qué neto e IRPF reales obtendría el mismo poder adquisitivo en
+        cada año entre ${String(2012)} y ${String(ANIO_MAX)}.
+      </p>
+      <div class="chart-container" style="position: relative; height: clamp(240px, 40vh, 360px);">
+        <canvas id="chart-comparativa" role="img" aria-label="Bruto, neto e IRPF reales (€ de 2026) entre 2012 y 2026"></canvas>
+      </div>
+    </section>
   `,
 );
 
 const formSection = app.querySelector<HTMLElement>('#form-section');
 const resultsSection = app.querySelector<HTMLElement>('#results-section');
-if (!formSection || !resultsSection) {
+const chartCanvas = app.querySelector<HTMLCanvasElement>('#chart-comparativa');
+if (!formSection || !resultsSection || !chartCanvas) {
   throw new Error('Layout sections not found after initial render');
 }
 
 const initial: FormState = { bruto: 30000, anio: ANIO_MAX };
 
+let lastBruto: number | undefined;
+
 function update(state: FormState): void {
-  if (!resultsSection) return;
+  if (!resultsSection || !chartCanvas) return;
   if (!Number.isInteger(state.anio)) {
     render(resultsSection, '<p role="alert">Año no válido.</p>');
     return;
   }
   renderResults(resultsSection, state.bruto, state.anio);
+  if (state.bruto !== lastBruto) {
+    renderComparativaInflacion(chartCanvas, state.bruto);
+    lastBruto = state.bruto;
+  }
 }
 
 mountForm(formSection, { initial, onChange: update });


### PR DESCRIPTION
## Resumen

Añade el gráfico de pérdida de poder adquisitivo: para el bruto introducido (interpretado como € de 2026), deflacta al equivalente nominal de cada año entre 2012 y 2026, calcula la nómina con la normativa de ese año y reinflacta neto e IRPF a € de 2026. Tres series: bruto real (constante, dashed, ancla visual), neto real (curva descendente vía progresividad en frío), IRPF real (curva ascendente). Reactivo al cambio de bruto, sin red.

## Issue relacionado

Closes #50
Refs #5

## Tipo de cambio

- [x] `feat` — nueva funcionalidad

## Auto-review

- [x] `format:check` / `lint` / `typecheck` / `test` (664/664) / `build` verdes en local.
- [x] `CHANGELOG.md` actualizado en `[Unreleased] / Added`.
- [ ] Sin tests UI (entran en #52 con axe + Playwright).

## Notas para el revisor

**Cambios** (138 líneas, 5 ficheros):

- `src/ui/chart.ts` — `renderComparativaInflacion(canvas, bruto)` itera `ANIO_MIN..ANIO_MAX`, llama a `calcularNomina(brutoNominal, año)` y arma 3 datasets Chart.js. Bruto en línea discontinua para señalar que es el ancla; neto e IRPF con `tension: 0.15`. Tooltips formateados con `eur()`. El módulo conserva la instancia activa en `let current` y la destruye antes de re-renderizar para evitar fugas.
- `src/ui/main.ts` — nueva `<section>` con `<canvas>` envuelto en un contenedor de altura responsive (`clamp(240px, 40vh, 360px)`) y `aria-label` describiendo la curva. El chart solo se re-renderiza cuando cambia el bruto (no en cambio de año), porque el chart agrupa todos los años por diseño — añadí un `lastBruto` para evitar re-renders redundantes en cada keystroke de año.
- `chart.js ^4.5.1` — vanilla, no `react-chartjs-2`. Usa `chart.js/auto` (registra todas las controllers/scales/plugins) por simplicidad inicial.

**Bundle**:

```
Antes:  index.js  11.21 kB raw │  4.53 kB gzip
Ahora:  index.js 220.08 kB raw │ 75.92 kB gzip
```

El salto viene casi todo de `chart.js/auto`. Si #52 (Lighthouse) marca el bundle como bloqueante, se tree-shakea registrando solo `LineController`, `LineElement`, `PointElement`, `LinearScale`, `CategoryScale`, `Tooltip`, `Legend`, `Title` (esperado: ~30–40 KB gzip). Lo dejo para entonces para no preoptimizar contra una métrica que aún no medimos.

**Decisiones notables**:

- **No comparto código con `scripts/render-charts.ts`** (Phase 3.4). La aritmética de defle/inflate es 5 líneas; el SVG renderer maneja tipos diferentes (`ChartSpec` vs Chart.js datasets), así que extraer un módulo común forzaría un tipo intermedio incómodo. Si en el futuro queremos que ambos renderers coman de la misma fuente, refactor cuando aparezca un tercer renderer o cuando la lógica supere las ~10 líneas; YAGNI hoy.
- **Chart no depende del año seleccionado**: el chart es global a 2012–2026 por construcción. Cambiar año actualiza el panel de resultados pero no el chart. Documentado en el comentario sobre `lastBruto`.
- **Colores accesibles**: paleta `#1f4e79` / `#2ca02c` / `#d62728` (azul oscuro / verde / rojo). Funciona también en daltónicos rojo-verde porque el bruto está en azul oscuro discontinuo y el contraste tonal es suficiente; #52 confirmará con axe.

**Conflicto previsto con #51**: ambas ramas tocan `src/ui/main.ts` (sección distinta) y `CHANGELOG.md` (bullet distinto en `[Unreleased] / Added`). El segundo merge necesitará un rebase trivial.