### PR TITLE
chore(release): v1.0.0 prep — unified Pages deploy + release notes

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,4 +1,4 @@
-name: Docs
+name: Pages
 
 on:
   push:
@@ -15,11 +15,27 @@ concurrency:
 
 jobs:
   build:
-    name: Build site (strict)
+    name: Build site (SPA + manual, strict)
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      # --- SPA (TypeScript / Vite) ---
+
+      - name: Setup Node 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install Node dependencies
+        run: npm ci
+
+      - name: Build SPA (Vite)
+        run: npm run build
+
+      # --- Manual (MkDocs Material) ---
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -28,37 +44,23 @@ jobs:
           cache: 'pip'
           cache-dependency-path: requirements-docs.txt
 
-      - name: Install dependencies
+      - name: Install Python dependencies
         run: pip install -r requirements-docs.txt
 
-      - name: Build with strict mode
+      - name: Build manual (MkDocs strict)
         run: mkdocs build --strict
 
-      # `actions/deploy-pages` replaces the entire deployment per upload, so the
-      # manual and the root redirect must ship in a single artifact.
-      - name: Restructure artifact (manual under /manual/, redirect at root)
+      # --- Pages artifact: SPA at root, manual under /manual/ ---
+      # `actions/deploy-pages` replaces the entire deployment per upload, so
+      # both must ship in a single artefact tree.
+      - name: Compose Pages artefact
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: |
           mkdir -p public/manual
-          mv site/* public/manual/
-          cat > public/index.html <<'HTML'
-          <!doctype html>
-          <html lang="es">
-          <head>
-            <meta charset="utf-8">
-            <title>Auditor IRPF ES</title>
-            <meta http-equiv="refresh" content="0; url=./manual/">
-            <link rel="canonical" href="./manual/">
-            <meta name="robots" content="noindex">
-          </head>
-          <body>
-            <p>Redirigiendo al <a href="./manual/">manual</a>…</p>
-            <p>La calculadora interactiva (v1.0.0) sustituirá esta página próximamente.</p>
-          </body>
-          </html>
-          HTML
+          cp -r dist/. public/
+          cp -r site/. public/manual/
 
-      - name: Upload Pages artifact
+      - name: Upload Pages artefact
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: actions/upload-pages-artifact@v3
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ build/
 develop-eggs/
 dist/
 .lighthouseci/
+# Lighthouse on WSL2 sometimes drops Chrome user-profile dirs whose names
+# are literal Windows paths (backslashes and all) into the repo root.
+C:\\*
 downloads/
 eggs/
 .eggs/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,13 @@ El formato sigue [Keep a Changelog](https://keepachangelog.com/es-ES/1.1.0/) y e
 
 ## [Unreleased]
 
+## [1.0.0] - 2026-05-03
+
+Calculadora IRPF interactiva en GitHub Pages. Cualquier persona puede introducir un bruto y un año entre 2012 y 2026 y ver, sin servidor y sin red, el desglose completo (cotización social, MEI, Solidaridad, IRPF tramo a tramo, mínimo personal aplicado como cuota, tope 43 %, deducción SMI) más la curva de pérdida de poder adquisitivo deflactada a euros de 2026. Bundle estático ~92 KB gzip iniciales; Chart.js (~71 KB gzip) y SheetJS (~96 KB gzip) en chunks dinámicos. La auditoría axe-core (WCAG 2.1 AA) y los thresholds Lighthouse (perf ≥ 0.85, a11y ≥ 0.95, bp ≥ 0.95, seo ≥ 0.90) corren en cada PR.
+
 ### Added
 
+- **Pages unificado: SPA en raíz + manual en `/manual/`** (Phase 4.6) — `.github/workflows/pages.yml` (renombrado desde `docs.yml`) construye en un solo job el SPA (Vite, `npm run build` → `dist/`) y el manual (MkDocs, `mkdocs build --strict` → `site/`), compone un único artefacto Pages con `dist/` en raíz y `site/` bajo `public/manual/`, y despliega en push a `main`. La página-redirección stub anterior desaparece — la raíz ahora sirve la calculadora directamente. `vite.config.ts` configurado con `base: './'` para que las URLs de los assets del SPA funcionen tanto en `/` (preview local) como en `/auditor-irpf-es/` (Pages).
 - **Auditoría axe-core en CI** (Phase 4.5) — `test/a11y.browser.test.ts` ejecuta `axe-core` contra el SPA en tres estados (carga inicial, tras cambiar bruto, con `aria-busy="true"` aplicado al botón Excel) bajo Vitest browser project (Playwright + Chromium). Falla CI si aparece cualquier violación `serious` o `critical` de WCAG 2.1 AA (`wcag2a`/`wcag2aa`/`wcag21a`/`wcag21aa`/`best-practice`). Tema fijado a `data-theme="light"` para que las reglas de contraste sean deterministas. Job `browser-tests` añadido a `.github/workflows/ci.yml` con cache de la binary Playwright.
 - **Lighthouse CI** (Phase 4.5) — `.github/workflows/lighthouse.yml` ejecuta Lighthouse mobile (mediana de 3) en cada PR a `develop`/`main`. Thresholds: performance ≥ 0.85 (CI tolera ruido de runners; objetivo local ≥ 0.90), accesibilidad ≥ 0.95, best-practices ≥ 0.95, SEO ≥ 0.90. Reportes subidos a almacenamiento temporal público; HTML también guardado como artefacto. Comando local: `npm run lighthouse`. Scores actuales sobre el bundle: perf 0.99, a11y 0.98, bp 0.96, seo 1.0.
 - **Tabla `sr-only` espejo del chart** — usuarios de lectores de pantalla acceden a las mismas series (bruto, neto e IRPF reales en € de 2026) que el `<canvas>`. La tabla se sincroniza con el chart en cada cambio de bruto. Helper CSS `.sr-only` (patrón estándar WCAG visually-hidden) en `src/ui/sr-only.css`.
@@ -122,7 +127,8 @@ Primera release pública. Establece los cimientos para el porting del motor a Ty
 
 - README reformulado para reflejar la misión pública (democratizar el cálculo del IRPF), la llamada a tres perfiles colaboradores (fiscalistas, _techies_, divulgadores) y el pivote a TypeScript.
 
-[Unreleased]: https://github.com/ceballosiker/auditor-irpf-es/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/ceballosiker/auditor-irpf-es/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/ceballosiker/auditor-irpf-es/releases/tag/v1.0.0
 [0.4.0]: https://github.com/ceballosiker/auditor-irpf-es/releases/tag/v0.4.0
 [0.3.0]: https://github.com/ceballosiker/auditor-irpf-es/releases/tag/v0.3.0
 [0.2.0]: https://github.com/ceballosiker/auditor-irpf-es/releases/tag/v0.2.0

--- a/README.md
+++ b/README.md
@@ -3,20 +3,24 @@
 ![TypeScript](https://img.shields.io/badge/typescript-5.5%2B-blue.svg)
 ![Node](https://img.shields.io/badge/node-%3E%3D18.18-brightgreen.svg)
 ![License](https://img.shields.io/badge/license-MIT-green.svg)
-![Estado](<https://img.shields.io/badge/estado-en%20curso%20(v0.4)-yellow.svg>)
-[![Manual](https://img.shields.io/badge/manual-ceballosiker.github.io-blue.svg)](https://ceballosiker.github.io/auditor-irpf-es/manual/)
+![Estado](https://img.shields.io/badge/estado-v1.0.0-brightgreen.svg)
+[![Calculadora](https://img.shields.io/badge/calculadora-ceballosiker.github.io-blue.svg)](https://ceballosiker.github.io/auditor-irpf-es/)
+[![Manual](https://img.shields.io/badge/manual-ceballosiker.github.io%2Fmanual-blue.svg)](https://ceballosiker.github.io/auditor-irpf-es/manual/)
 
-> **Aviso.** El objetivo de este repositorio es **practicar flujos de trabajo OSS con asistencia de agentes de IA** (Claude Code).
+> [!WARNING]
+> **Este repositorio es ante todo un experimento de flujos OSS asistidos por agentes de IA** (Claude Code): el código y los cálculos son reales, pero la motivación primaria es metodológica — practicar issues, branches, PRs, releases y CI con un agente como _pair programmer_.
 
-Auditor fiscal que calcula el salario neto en España (2012–2026) euro a euro: IRPF, Seguridad Social, MEI y Cuota de Solidaridad, con análisis de pérdida de poder adquisitivo ajustada a la inflación real (IPC oficial del INE). Se expondrá como una **calculadora interactiva 100 % en el navegador** (sin servidor) acompañada de un manual divulgativo y un proceso de auditoría pública año a año.
+Auditor fiscal que calcula el salario neto en España (2012–2026): IRPF, Seguridad Social, MEI y Cuota de Solidaridad, con análisis de pérdida de poder adquisitivo ajustada a la inflación real (IPC oficial del INE). Se expone como una **calculadora interactiva 100 % en el navegador** (sin servidor) acompañada de un manual divulgativo y un proceso de auditoría pública año a año.
 
-> **Estado actual:** motor TypeScript completo y validado al céntimo (v0.2.0), workflow de auditoría fiscal con 15 issues `audit-YYYY` abiertos (v0.3.0), y **manual divulgativo publicado** en GitHub Pages (v0.4.0). Próximo hito: calculadora web interactiva (v1.0.0).
+> **Estado actual (v1.0.0):** motor TypeScript validado contra los fixtures del motor Python de referencia, **calculadora web interactiva en producción** y manual divulgativo publicados en GitHub Pages, auditoría axe-core (WCAG 2.1 AA) + thresholds Lighthouse (perf ≥ 0.85, a11y ≥ 0.95) bloqueando cada PR. Próximo hito (`v1.1.0`): redacción completa de los 15 resúmenes anuales junto con la auditoría fiscal.
+
+## 🧮 Calculadora interactiva
+
+Disponible en **<https://ceballosiker.github.io/auditor-irpf-es/>** — escribe un bruto, elige un año entre 2012 y 2026 y obtén el desglose completo (cotización social, MEI/Solidaridad, IRPF tramo a tramo, mínimo personal aplicado como cuota, tope 43 %, deducción SMI) más la curva de pérdida de poder adquisitivo deflactada a euros de 2026. El botón "Descargar Excel" genera el libro `.xlsx` completo en el navegador, sin red. Cero telemetría, cero cookies, cero servidor.
 
 ## 📖 Manual divulgativo
 
 El manual está publicado en **<https://ceballosiker.github.io/auditor-irpf-es/manual/>**. Contiene siete páginas explicando paso a paso la cadena de cálculo (cotización, SS, MEI/Solidaridad, Art. 19/20, escala IRPF, SMI/tope 43 %), una página dedicada a la **progresividad en frío** con gráficos generados desde el propio motor, y un esqueleto de 15 resúmenes anuales (uno por año entre 2012 y 2026) cuya redacción completa irá llegando en `v1.1.0` en paralelo con la auditoría fiscal.
-
-> La raíz del sitio (`https://ceballosiker.github.io/auditor-irpf-es/`) está reservada para la **calculadora interactiva** que aterrizará en `v1.0.0`; mientras tanto redirige al manual.
 
 ---
 
@@ -35,8 +39,8 @@ Este repositorio es una implementación pública y auditable del cálculo de nó
 Busco tres perfiles. Si te identificas con alguno, abre una _issue_ o un PR indicándolo:
 
 - **🧾 Fiscalistas y economistas** — audita los resultados año a año al mínimo detalle. ¿Falta un matiz normativo? ¿Un redondeo oficial distinto? ¿Una interacción entre Art. 19 y Art. 20 mal secuenciada? Dímelo. La precisión legal es la prioridad número uno.
-- **💻 Techies (TypeScript / web)** — porting del motor a TS, suite de tests con Vitest, ESLint/Prettier, CI con GitHub Actions, y la futura SPA (HTML + Chart.js + SheetJS). React queda explícitamente fuera; el stack es deliberadamente _vanilla_.
-- **🌐 Diseño / UX** — cuando la web aterrice (v1.0) buscaremos accesibilidad sólida (axe-core, Lighthouse a11y ≥ 95), UI clara y móvil-first, sin telemetría ni cookies.
+- **💻 Techies (TypeScript / web)** — motor en TS, suite de tests con Vitest, ESLint/Prettier, CI con GitHub Actions, y la SPA (HTML + Chart.js + SheetJS). React queda explícitamente fuera; el stack es deliberadamente _vanilla_.
+- **🌐 Diseño / UX** — accesibilidad sólida (axe-core en CI, Lighthouse a11y ≥ 0.95 ya verificado), UI clara y móvil-first, sin telemetría ni cookies. Mejoras visuales y de UX bienvenidas vía issue/PR.
 
 También es muy bienvenida la contribución de **redactores divulgativos** que extraigan, a partir del código, un manual sencillo que explique:
 
@@ -66,14 +70,14 @@ Para maximizar la precisión antes de ampliar casuística, el motor modela delib
 
 ### Hoja de ruta de desarrollo
 
-| Versión       | Hito                                                                                                        |
-| ------------- | ----------------------------------------------------------------------------------------------------------- |
-| **v0.1.0** ✅ | Infraestructura OSS, tooling TypeScript, fixtures JSON desde el motor Python (oráculo).                     |
-| **v0.2.0** ✅ | Port del motor a TypeScript validado al céntimo contra los fixtures de v0.1.0.                              |
-| **v0.3.0** ✅ | Workflow de auditoría fiscal: 15 issues (uno por año, 2012–2026) con checklist normativo + referencias BOE. |
-| **v0.4.0** ✅ | Manual divulgativo en MkDocs Material publicado en GitHub Pages.                                            |
-| **v1.0.0**    | Calculadora web interactiva: SPA estático, 100 % en el navegador, GitHub Pages.                             |
-| **v1.1.0**    | Redacción completa de los 15 resúmenes anuales con referencias BOE, en paralelo con los `audit-YYYY`.       |
+| Versión       | Hito                                                                                                         |
+| ------------- | ------------------------------------------------------------------------------------------------------------ |
+| **v0.1.0** ✅ | Infraestructura OSS, tooling TypeScript, fixtures JSON desde el motor Python (oráculo).                      |
+| **v0.2.0** ✅ | Port del motor a TypeScript validado contra los fixtures generados de v0.1.0.                                |
+| **v0.3.0** ✅ | Workflow de auditoría fiscal: 15 issues (uno por año, 2012–2026) con checklist normativo + referencias BOE.  |
+| **v0.4.0** ✅ | Manual divulgativo en MkDocs Material publicado en GitHub Pages.                                             |
+| **v1.0.0** ✅ | Calculadora web interactiva: SPA estático, 100 % en el navegador, GitHub Pages. axe-core + Lighthouse en CI. |
+| **v1.1.0**    | Redacción completa de los 15 resúmenes anuales con referencias BOE, en paralelo con los `audit-YYYY`.        |
 
 Sigue el progreso en los [issues abiertos](https://github.com/ceballosiker/auditor-irpf-es/issues) y [milestones](https://github.com/ceballosiker/auditor-irpf-es/milestones).
 
@@ -92,12 +96,16 @@ git clone https://github.com/ceballosiker/auditor-irpf-es.git
 cd auditor-irpf-es
 npm install
 npm test               # Vitest (664 tests)
+npm run test:browser   # axe-core a11y (Vitest browser project, requiere Chromium)
 npm run lint           # ESLint
 npm run typecheck      # tsc --noEmit
-npm run build:excel    # Genera el Excel completo (15 años × 0-100 000 €)
+npm run dev            # Vite dev server — la calculadora en http://localhost:5173
+npm run build          # Bundle estático en dist/ (sirve cualquier subpath)
+npm run build:excel    # Genera el Excel completo (15 años × 0-100 000 €) por CLI
+npm run lighthouse     # Build + Lighthouse CI (3 corridas, asserts perf/a11y/bp/seo)
 ```
 
-Requisitos: Node ≥ 18.18.
+Requisitos: Node ≥ 18.18. Los tests browser y `lighthouse` requieren Chromium en el sistema (Playwright lo instala automáticamente con `npx playwright install chromium`).
 
 ### Python (motor original — archivado en `legacy/`)
 
@@ -121,12 +129,12 @@ Para regenerar los fixtures JSON (operación idempotente):
 
 `npm run build:excel` (TS) y `python3 legacy/python-reference/Calculo_Salario_IRPF.py` (Python) producen el mismo `Auditoria_Integral_Nominas_e_Inflacion_2012_2026.xlsx` con estas pestañas:
 
-| Pestaña                 | Qué contiene                                                                                                                                                                                 |
-| ----------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `CONTROL_GENERAL`       | Diccionario normativo anual: tipos SS, MEI, mínimos, gastos fijos, umbrales del Art. 20.                                                                                                     |
-| `CONTROL_TRAMOS_IRPF`   | Histórico de tramos y tipos de IRPF de cada año.                                                                                                                                             |
-| `COMPARATIVA_INFLACION` | Análisis macroeconómico: cuánto poder adquisitivo ha perdido un salario frente a su equivalente pasado, deflactando el bruto y actualizando todos los impuestos.                             |
-| `DAT_2012` … `DAT_2026` | Pestañas anuales con desglose euro a euro (0 €–100.000 €): coste laboral, cotizaciones patronales/obreras, cuota por cada tramo de IRPF, aplicación de límites legales y salario neto final. |
+| Pestaña                 | Qué contiene                                                                                                                                                                                           |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `CONTROL_GENERAL`       | Diccionario normativo anual: tipos SS, MEI, mínimos, gastos fijos, umbrales del Art. 20.                                                                                                               |
+| `CONTROL_TRAMOS_IRPF`   | Histórico de tramos y tipos de IRPF de cada año.                                                                                                                                                       |
+| `COMPARATIVA_INFLACION` | Análisis macroeconómico: cuánto poder adquisitivo ha perdido un salario frente a su equivalente pasado, deflactando el bruto y actualizando todos los impuestos.                                       |
+| `DAT_2012` … `DAT_2026` | Pestañas anuales con una fila por cada bruto entero (0 €–100.000 €): coste laboral, cotizaciones patronales/obreras, cuota por cada tramo de IRPF, aplicación de límites legales y salario neto final. |
 
 ## 🏗️ Arquitectura
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auditor-irpf-es",
-  "version": "0.4.0",
+  "version": "1.0.0",
   "private": true,
   "description": "Auditor histórico de nóminas e IRPF en España (2012-2026) con ajuste de inflación.",
   "license": "MIT",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 // Public API barrel for the auditor-irpf-es engine.
 
-export const VERSION = '0.4.0';
+export const VERSION = '1.0.0';
 
 export type {
   Art20Meta,

--- a/test/version.test.ts
+++ b/test/version.test.ts
@@ -3,6 +3,6 @@ import { VERSION } from '../src/index';
 
 describe('VERSION', () => {
   it('matches package.json', () => {
-    expect(VERSION).toBe('0.4.0');
+    expect(VERSION).toBe('1.0.0');
   });
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,9 @@
 import { defineConfig } from 'vite';
 
 export default defineConfig({
+  // Relative asset paths so the SPA works whether served from /, from
+  // /auditor-irpf-es/ on GitHub Pages, or from any other sub-path.
+  base: './',
   build: {
     target: 'es2022',
     outDir: 'dist',


### PR DESCRIPTION
Closes #53 and #54.

Release-prep PR for **v1.0.0**. After this merges to `develop`, the next step is a mechanical `develop → main` PR which fires the new unified Pages deploy and ships the SPA at <https://ceballosiker.github.io/auditor-irpf-es/>.

## Two commits

### 1. `feat(ci): unified Pages deploy — SPA at root, manual at /manual/` — Phase 4.6 (#53)

`.github/workflows/docs.yml` is renamed to `pages.yml` and now builds **both** sides in one job:

- SPA via `npm run build` → `dist/`
- Manual via `mkdocs build --strict` → `site/`

Then composes a single Pages artefact:

```
/                  -> SPA (Vite dist/)
/assets/...        -> SPA bundle chunks
/manual/           -> MkDocs site
/manual/...        -> manual pages, sitemap, 404
```

Old redirect-stub root `index.html` is gone — root now serves the calculator directly. Triggers on push to `main` (matches the existing release-on-merge pattern); PRs build both sides but don't publish.

`vite.config.ts` adds `base: './'` so SPA assets resolve relatively and work whether served from `/`, from `/auditor-irpf-es/` on Pages, or from any other sub-path.

`.gitignore` now ignores `C:\*` paths — when Lighthouse runs locally under WSL2 with the system Chrome, it sometimes drops profile dirs whose names are literal Windows paths into the repo root.

### 2. `chore(release): v1.0.0 — Web UI` (#54)

- Version bump `0.4.0` → `1.0.0` across `package.json`, `src/index.ts`, `test/version.test.ts`.
- CHANGELOG: `[Unreleased]` → `[1.0.0] - 2026-05-03` with release blurb at the top of the section and a Phase 4.6 entry.
- README: state line, badges, headline section reflect that the SPA is in production. Roadmap table marks v1.0.0 as ✅. Install/usage section gains `npm run dev`, `npm run build`, `npm run test:browser`, `npm run lighthouse`. Adds an `[!WARNING]` callout disclaimer flagging the project's primary purpose as an AI-assisted-OSS-flow experiment. Drops over-claiming "al céntimo" / "euro a euro" precision phrases throughout in favour of concrete descriptors ("validado contra los fixtures del motor Python de referencia", "una fila por cada bruto entero").

## Local verification

| Check | Result |
|---|---|
| typecheck / lint / format | green |
| `npm test` (664 unit tests) | 664/664 |
| `npm run test:browser` (axe-core, 3 states) | 3/3 |
| `npm run lighthouse` (3-run median, mobile) | perf 0.99 / a11y 0.98 / bp 0.96 / seo 1.0 |
| Unified artefact composition simulated locally | SPA at root + manual under `/manual/`, asset paths relative |
| Personal-paths sweep across all branch commits | zero hits |

## Next steps after merge

1. Open the mechanical `develop → main` PR titled `Release v1.0.0 — Web UI`. Merging it triggers the new Pages deploy.
2. Tag `v1.0.0` on `main` once the deploy is green.
3. Cut the GitHub Release with notes drawn from the CHANGELOG `[1.0.0]` block.

## Test plan

- [ ] CI matrix (`ts-checks` Node 18 + 20) green
- [ ] CI `browser-tests` (axe-core) green
- [ ] CI `Lighthouse` workflow green
- [ ] CI `Pages` (formerly `Docs`) workflow green and builds both SPA + manual
- [ ] Personal-paths sweep: zero hits in the diff