### PR TITLE
feat(ui): drill-tables con anchos fijos + ejes en pequeños múltiples

### DIFF
--- a/src/ui/charts/multiples.ts
+++ b/src/ui/charts/multiples.ts
@@ -18,26 +18,37 @@ interface Series {
 
 function renderOne(s: Series, years: readonly number[]): string {
   const W = 220,
-    H = 110,
-    PAD = 12;
+    H = 110;
+  const PAD_L = 44,
+    PAD_R = 10,
+    PAD_T = 10,
+    PAD_B = 18;
   const yMin = Math.min(...s.values);
   const yMax = Math.max(...s.values);
   const span = Math.max(1e-6, yMax - yMin);
   const xMin = years[0] ?? 0;
-  const xSpan = Math.max(1, (years[years.length - 1] ?? 0) - xMin);
-  const x = (year: number): number => PAD + ((year - xMin) / xSpan) * (W - 2 * PAD);
-  const y = (v: number): number => H - PAD - ((v - yMin) / span) * (H - 2 * PAD);
+  const xMax = years[years.length - 1] ?? 0;
+  const xSpan = Math.max(1, xMax - xMin);
+  const x = (year: number): number => PAD_L + ((year - xMin) / xSpan) * (W - PAD_L - PAD_R);
+  const y = (v: number): number => H - PAD_B - ((v - yMin) / span) * (H - PAD_T - PAD_B);
   const points = years.map((yr, i) => `${String(x(yr))},${String(y(s.values[i] ?? 0))}`).join(' ');
   const first = s.values[0] ?? 0;
   const last = s.values[s.values.length - 1] ?? 0;
   const titleId = `${s.id}-t`;
+  const yMaxLabel = s.format(yMax);
+  const yMinLabel = s.format(yMin);
+  const axisAttrs = 'font-size="9" fill="var(--ink-mute)"';
 
   return `
     <div class="multi-cell">
       <div class="multi-label">${s.label}</div>
-      <div class="multi-meta">${String(years[0] ?? '')}: ${s.format(first)} → ${String(years[years.length - 1] ?? '')}: ${s.format(last)}</div>
+      <div class="multi-meta">${String(xMin)}: ${s.format(first)} → ${String(xMax)}: ${s.format(last)}</div>
       <svg class="multi" viewBox="0 0 ${String(W)} ${String(H)}" role="img" aria-labelledby="${titleId}" style="width:100%;height:auto;">
-        <title id="${titleId}">${s.label} entre ${String(years[0] ?? '')} y ${String(years[years.length - 1] ?? '')}</title>
+        <title id="${titleId}">${s.label} entre ${String(xMin)} y ${String(xMax)}</title>
+        <text class="multi-axis multi-axis-y" x="${String(PAD_L - 4)}" y="${String(PAD_T + 3)}" text-anchor="end" ${axisAttrs}>${yMaxLabel}</text>
+        <text class="multi-axis multi-axis-y" x="${String(PAD_L - 4)}" y="${String(H - PAD_B + 1)}" text-anchor="end" ${axisAttrs}>${yMinLabel}</text>
+        <text class="multi-axis multi-axis-x" x="${String(PAD_L)}" y="${String(H - 4)}" text-anchor="start" ${axisAttrs}>${String(xMin)}</text>
+        <text class="multi-axis multi-axis-x" x="${String(W - PAD_R)}" y="${String(H - 4)}" text-anchor="end" ${axisAttrs}>${String(xMax)}</text>
         <polyline points="${points}" fill="none" stroke="var(--accent)" stroke-width="1.8"/>
       </svg>
     </div>

--- a/src/ui/sections/brackets.ts
+++ b/src/ui/sections/brackets.ts
@@ -60,7 +60,7 @@ function drillTable(n: Nomina, p: Parametros): string {
     ),
     row('IRPF final', `<strong>${eur(n.irpfFinal)}</strong>`),
   ].join('');
-  return `<table>${rows}</table>`;
+  return `<table class="drill-table">${rows}</table>`;
 }
 
 export function updateBrackets(target: HTMLElement, state: State): void {

--- a/src/ui/sections/breakdown.ts
+++ b/src/ui/sections/breakdown.ts
@@ -56,7 +56,7 @@ function drillTable(n: Nomina, p: Parametros): string {
       : []),
     row('Coste laboral total', eur(n.costeLaboral)),
   ].join('');
-  return `<table>${rows}</table>`;
+  return `<table class="drill-table">${rows}</table>`;
 }
 
 export function updateBreakdown(target: HTMLElement, state: State): void {

--- a/src/ui/theme.css
+++ b/src/ui/theme.css
@@ -161,6 +161,42 @@ details[open] > summary::before {
   content: '−';
 }
 
+/* Drill-down table (used inside <details> in breakdown + brackets sections).
+ * Fixed layout with consistent column widths so rows don't auto-size to content. */
+.drill-table {
+  width: 100%;
+  table-layout: fixed;
+  border-collapse: collapse;
+  margin-top: 12px;
+  font-family: var(--font-body);
+  font-size: 0.88rem;
+}
+.drill-table th[scope='row'] {
+  width: 65%;
+  text-align: left;
+  font-weight: 500;
+  color: var(--ink-soft);
+  padding: 6px 10px 6px 0;
+  vertical-align: top;
+}
+.drill-table td {
+  width: 35%;
+  text-align: right;
+  padding: 6px 0 6px 10px;
+  vertical-align: top;
+  font-variant-numeric: tabular-nums;
+}
+.drill-table tr + tr th[scope='row'],
+.drill-table tr + tr td {
+  border-top: 1px solid var(--rule);
+}
+.drill-table small {
+  display: block;
+  font-size: 0.78rem;
+  color: var(--ink-mute);
+  margin-top: 2px;
+}
+
 /* Accent CTA button */
 .cta {
   display: inline-block;

--- a/test/charts.browser.test.ts
+++ b/test/charts.browser.test.ts
@@ -137,4 +137,19 @@ describe('renderMultiples', () => {
     const firstRow = host.querySelector('table.sr-only tbody tr');
     expect(firstRow?.querySelectorAll('th, td').length).toBe(5);
   });
+
+  it('each mini-chart includes y-axis (min/max) and x-axis (first/last year) labels', () => {
+    renderMultiples(host, data);
+    const charts = host.querySelectorAll('svg.multi');
+    expect(charts.length).toBe(4);
+    charts.forEach((svg) => {
+      expect(svg.querySelectorAll('text.multi-axis-y').length).toBe(2);
+      expect(svg.querySelectorAll('text.multi-axis-x').length).toBe(2);
+    });
+    const xLabels = Array.from(host.querySelectorAll('text.multi-axis-x')).map(
+      (t) => t.textContent ?? '',
+    );
+    expect(xLabels).toContain('2012');
+    expect(xLabels).toContain('2026');
+  });
 });

--- a/test/sections.browser.test.ts
+++ b/test/sections.browser.test.ts
@@ -89,6 +89,12 @@ describe('breakdown section', () => {
     const rows = drill?.querySelectorAll('tr') ?? [];
     expect(rows.length).toBeGreaterThan(3);
   });
+
+  it('drill-down table uses the .drill-table class for fixed-width layout', () => {
+    mountBreakdown(host);
+    updateBreakdown(host, { bruto: 30_000, anio: ANIO_MAX });
+    expect(host.querySelector('details table.drill-table')).not.toBeNull();
+  });
 });
 
 describe('brackets section', () => {
@@ -108,6 +114,12 @@ describe('brackets section', () => {
     expect(rows.length).toBeGreaterThan(0);
     const drill = host.querySelector('details table');
     expect(drill?.querySelectorAll('tr').length ?? 0).toBeGreaterThan(5);
+  });
+
+  it('drill-down table uses the .drill-table class for fixed-width layout', () => {
+    mountBrackets(host);
+    updateBrackets(host, { bruto: 30_000, anio: ANIO_MAX });
+    expect(host.querySelector('details table.drill-table')).not.toBeNull();
   });
 });
 


### PR DESCRIPTION
## Resumen

Dos correcciones visuales del rediseño editorial-dataviz introducidas en v1.1.0:

- **Drill-tables con anchos fijos.** Las tablas dentro de `<details>` en `breakdown` y `brackets` ya no auto-dimensionan por contenido — pasan a `table-layout: fixed` con columnas 65/35 y `font-variant-numeric: tabular-nums` vía la nueva clase `.drill-table` en `src/ui/theme.css`.
- **Ejes en los pequeños múltiples.** `renderMultiples` añade etiquetas mínimas: min/max del valor en Y (formateadas con el helper de cada serie) y primer/último año en X. Los paddings pasan a `PAD_L/R/T/B` para dejar sitio al label de Y sin alterar el aspecto del sparkline.

## Test plan

- [x] `test/sections.browser.test.ts` — nuevo caso `drill-down table uses the .drill-table class` en breakdown y brackets.
- [x] `test/charts.browser.test.ts` — nuevo caso `each mini-chart includes y-axis (min/max) and x-axis (first/last year) labels` con asserts sobre 2012 / 2026.
- [x] `npm run format:check && npm run lint && npm run typecheck && npm test` en local.
- [ ] CI verde antes del merge.

Closes #77