### PR TITLE
feat(ui): scrubber de año fiscal y robustez de DOM helpers (#68)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -224,9 +224,13 @@ coverage/
 *.tsbuildinfo
 .vite/
 
+# Vitest/Playwright browser screenshot artefactos
+test/__screenshots__/
+
 # Bootstrap scripts (one-shot ops tooling for GitHub state, kept local)
 scripts/bootstrap_*.sh
 
 # Superpowers / brainstorming artefacts — keep local-only, never commit
 .superpowers/
 specs/
+plans/

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -10,6 +10,7 @@ export default tseslint.config(
       'coverage/',
       '.venv/',
       '.venv-*/',
+      '.cache/',
       'site/',
       'test/fixtures/**',
     ],

--- a/src/ui/dom.ts
+++ b/src/ui/dom.ts
@@ -6,6 +6,12 @@ export function requireEl<T extends Element>(
   const root: ParentNode = typeof rootOrSelector === 'string' ? document : rootOrSelector;
   const sel: string = typeof rootOrSelector === 'string' ? rootOrSelector : (selector ?? '');
   const el = root.querySelector<T>(sel);
-  if (!el) throw new Error(`requireEl: element not found for selector "${sel}"`);
+  if (!el) {
+    const rootDesc =
+      root instanceof Element
+        ? root.tagName.toLowerCase() + (root.id ? `#${root.id}` : '')
+        : 'document';
+    throw new Error(`requireEl: element not found for selector "${sel}" in ${rootDesc}`);
+  }
   return el;
 }

--- a/src/ui/form.ts
+++ b/src/ui/form.ts
@@ -40,7 +40,7 @@ export function mountForm(target: HTMLElement, opts: FormOptions): void {
           </div>
           <small>Normativa aplicable a 31 de diciembre.</small>
         </div>
-        <div class="form-row form-row--2col">
+        <div class="form-row">
           <label>
             Salario bruto anual (€)
             <input

--- a/src/ui/form.ts
+++ b/src/ui/form.ts
@@ -1,4 +1,4 @@
-import { ANIOS_SOPORTADOS } from '../normativa.js';
+import { ANIO_MAX, ANIO_MIN } from '../normativa.js';
 import { requireEl } from './dom.js';
 import { render } from './render.js';
 
@@ -15,19 +15,32 @@ export interface FormOptions {
 export function mountForm(target: HTMLElement, opts: FormOptions): void {
   const { initial, onChange } = opts;
 
-  const yearOptions = [...ANIOS_SOPORTADOS]
-    .reverse()
-    .map(
-      (y) =>
-        `<option value="${String(y)}"${y === initial.anio ? ' selected' : ''}>${String(y)}</option>`,
-    )
-    .join('');
-
   render(
     target,
     `
       <form id="calc-form" autocomplete="off" novalidate>
-        <div class="form-row">
+        <div class="anio-band">
+          <label for="input-anio">Año fiscal</label>
+          <div class="anio-track">
+            <input
+              type="range"
+              id="input-anio"
+              name="anio"
+              min="${String(ANIO_MIN)}"
+              max="${String(ANIO_MAX)}"
+              step="1"
+              value="${String(initial.anio)}"
+              aria-valuetext="${String(initial.anio)}"
+            />
+            <output for="input-anio" class="anio-output" aria-live="polite">${String(initial.anio)}</output>
+          </div>
+          <div class="anio-ticks" aria-hidden="true">
+            <span>${String(ANIO_MIN)}</span>
+            <span>${String(ANIO_MAX)}</span>
+          </div>
+          <small>Normativa aplicable a 31 de diciembre.</small>
+        </div>
+        <div class="form-row form-row--2col">
           <label>
             Salario bruto anual (€)
             <input
@@ -43,11 +56,6 @@ export function mountForm(target: HTMLElement, opts: FormOptions): void {
             <small>Importe íntegro antes de cotización social y retención.</small>
           </label>
           <label>
-            Año fiscal
-            <select id="input-anio" name="anio">${yearOptions}</select>
-            <small>Normativa aplicable a 31 de diciembre.</small>
-          </label>
-          <label>
             Comunidad Autónoma
             <select id="input-ccaa" name="ccaa" disabled>
               <option value="estatal" selected>Estatal (escala duplicada)</option>
@@ -60,21 +68,32 @@ export function mountForm(target: HTMLElement, opts: FormOptions): void {
   );
 
   const brutoInput = requireEl<HTMLInputElement>(target, '#input-bruto');
-  const anioSelect = requireEl<HTMLSelectElement>(target, '#input-anio');
+  const anioInput = requireEl<HTMLInputElement>(target, '#input-anio');
+  const anioOutput = requireEl<HTMLOutputElement>(target, 'output[for="input-anio"]');
 
   function readState(): FormState {
     const bruto = Number.parseFloat(brutoInput.value);
-    const anio = Number.parseInt(anioSelect.value, 10);
+    const anio = Number.parseInt(anioInput.value, 10);
     return {
       bruto: Number.isFinite(bruto) && bruto >= 0 ? bruto : 0,
       anio,
     };
   }
 
-  function emit(): void {
+  function syncAnioDisplay(value: string): void {
+    anioOutput.textContent = value;
+    anioInput.setAttribute('aria-valuetext', value);
+  }
+
+  function emitBruto(): void {
     onChange(readState());
   }
 
-  brutoInput.addEventListener('input', emit);
-  anioSelect.addEventListener('change', emit);
+  function emitAnio(): void {
+    syncAnioDisplay(anioInput.value);
+    onChange(readState());
+  }
+
+  brutoInput.addEventListener('input', emitBruto);
+  anioInput.addEventListener('input', emitAnio);
 }

--- a/src/ui/theme.css
+++ b/src/ui/theme.css
@@ -80,7 +80,6 @@ p {
 }
 p.lead {
   color: var(--ink-soft);
-  max-width: 56ch;
 }
 
 /* Eyebrow */

--- a/src/ui/theme.css
+++ b/src/ui/theme.css
@@ -399,7 +399,7 @@ details > summary:focus-visible {
 /* Form fields — replaces Pico's .grid */
 .form-row {
   display: grid;
-  grid-template-columns: 1fr 1fr 1fr;
+  grid-template-columns: 1fr 1fr;
   gap: 16px;
   align-items: start;
   margin-top: 14px;
@@ -499,15 +499,4 @@ input[type='range']#input-anio:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 4px;
   border-radius: 2px;
-}
-
-/* Form row variant: 2 columns (bruto + CCAA) when the año control
- * lives in its own band above. Falls back to 1 column on narrow screens. */
-.form-row--2col {
-  grid-template-columns: 1fr 1fr;
-}
-@media (max-width: 720px) {
-  .form-row--2col {
-    grid-template-columns: 1fr;
-  }
 }

--- a/src/ui/theme.css
+++ b/src/ui/theme.css
@@ -409,3 +409,105 @@ details > summary:focus-visible {
     grid-template-columns: 1fr;
   }
 }
+
+/* Año scrubber band — replaces the previous <select> for año fiscal.
+ * Sits above the .form-row, full width inside the hero. */
+.anio-band {
+  margin-top: 14px;
+  margin-bottom: 18px;
+}
+.anio-band label {
+  /* Reuse the existing eyebrow-style label spacing. */
+  display: block;
+  margin-bottom: 6px;
+}
+.anio-track {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: center;
+  gap: 16px;
+  margin-top: 6px;
+}
+.anio-output {
+  font-family: var(--font-display);
+  font-size: clamp(1.4rem, 2.4vw, 1.8rem);
+  font-weight: 700;
+  color: var(--accent);
+  font-variant-numeric: tabular-nums;
+  min-width: 4ch;
+  text-align: right;
+}
+.anio-ticks {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 4px;
+  font-family: var(--font-body);
+  font-size: 0.72rem;
+  color: var(--ink-mute);
+  letter-spacing: 0.04em;
+}
+
+/* Native range input, restyled to match the editorial palette. */
+input[type='range']#input-anio {
+  -webkit-appearance: none;
+  appearance: none;
+  background: transparent;
+  width: 100%;
+  height: 22px;
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+input[type='range']#input-anio::-webkit-slider-runnable-track {
+  height: 4px;
+  background: var(--rule);
+  border-radius: 2px;
+}
+input[type='range']#input-anio::-moz-range-track {
+  height: 4px;
+  background: var(--rule);
+  border-radius: 2px;
+  border: 0;
+}
+input[type='range']#input-anio::-moz-range-progress {
+  height: 4px;
+  background: var(--accent-soft);
+  border-radius: 2px;
+}
+input[type='range']#input-anio::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: var(--accent);
+  border: 2px solid #fff;
+  box-shadow: 0 0 0 1px var(--accent);
+  margin-top: -7px; /* centra el thumb sobre el track de 4px */
+  cursor: pointer;
+}
+input[type='range']#input-anio::-moz-range-thumb {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: var(--accent);
+  border: 2px solid #fff;
+  box-shadow: 0 0 0 1px var(--accent);
+  cursor: pointer;
+}
+input[type='range']#input-anio:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 4px;
+  border-radius: 2px;
+}
+
+/* Form row variant: 2 columns (bruto + CCAA) when the año control
+ * lives in its own band above. Falls back to 1 column on narrow screens. */
+.form-row--2col {
+  grid-template-columns: 1fr 1fr;
+}
+@media (max-width: 720px) {
+  .form-row--2col {
+    grid-template-columns: 1fr;
+  }
+}

--- a/test/app.browser.test.ts
+++ b/test/app.browser.test.ts
@@ -25,17 +25,18 @@ describe('mountApp ?anio= URL roundtrip', () => {
   it('preselects the year in the form when ?anio=YYYY is in the URL', () => {
     window.history.replaceState(null, '', `${window.location.pathname}?anio=2018`);
     setupApp();
-    const select = document.querySelector<HTMLSelectElement>('#input-anio');
-    if (!select) throw new Error('year select missing');
-    expect(select.value).toBe('2018');
+    const range = document.querySelector<HTMLInputElement>('#input-anio');
+    if (!range) throw new Error('year range missing');
+    expect(range.type).toBe('range');
+    expect(range.value).toBe('2018');
   });
 
   it('writes ?anio=YYYY to the URL when the year changes', () => {
     setupApp();
-    const select = document.querySelector<HTMLSelectElement>('#input-anio');
-    if (!select) throw new Error('year select missing');
-    select.value = '2020';
-    select.dispatchEvent(new Event('change', { bubbles: true }));
+    const range = document.querySelector<HTMLInputElement>('#input-anio');
+    if (!range) throw new Error('year range missing');
+    range.value = '2020';
+    range.dispatchEvent(new Event('input', { bubbles: true }));
     expect(window.location.search).toContain('anio=2020');
   });
 });

--- a/test/dom.browser.test.ts
+++ b/test/dom.browser.test.ts
@@ -36,5 +36,9 @@ describe('requireEl', () => {
     expect(() => requireEl(root, '.missing')).toThrow(/div#x/);
     // With document as default root, message names "document".
     expect(() => requireEl('.also-missing')).toThrow(/document/);
+    // With an Element root that has no id, message names just the tagName.
+    const noId = document.createElement('section');
+    document.body.appendChild(noId);
+    expect(() => requireEl(noId, '.missing')).toThrow(/in section$/);
   });
 });

--- a/test/dom.browser.test.ts
+++ b/test/dom.browser.test.ts
@@ -27,4 +27,14 @@ describe('requireEl', () => {
     const el = requireEl<HTMLParagraphElement>('[data-test="ok"]');
     expect(el.tagName).toBe('P');
   });
+
+  it('includes the root identifier in the error message', () => {
+    document.body.innerHTML = '<div id="x"></div>';
+    const root = document.getElementById('x');
+    if (!root) throw new Error('test setup: #x not found');
+    // With an Element root, message names tagName + #id.
+    expect(() => requireEl(root, '.missing')).toThrow(/div#x/);
+    // With document as default root, message names "document".
+    expect(() => requireEl('.also-missing')).toThrow(/document/);
+  });
 });

--- a/test/form.browser.test.ts
+++ b/test/form.browser.test.ts
@@ -1,0 +1,81 @@
+// test/form.browser.test.ts
+import '../src/ui/theme.css';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { mountForm } from '../src/ui/form';
+import type { FormState } from '../src/ui/form';
+
+function setup(initial: FormState = { bruto: 30_000, anio: 2026 }): {
+  host: HTMLElement;
+  onChange: ReturnType<typeof vi.fn>;
+  range: HTMLInputElement;
+  output: HTMLOutputElement;
+} {
+  document.body.innerHTML = '<div id="host"></div>';
+  const host = document.getElementById('host');
+  if (!host) throw new Error('test setup: #host not in DOM');
+  const onChange = vi.fn<(s: FormState) => void>();
+  mountForm(host, { initial, onChange });
+  const range = host.querySelector<HTMLInputElement>('#input-anio');
+  if (!range) throw new Error('range input missing');
+  const output = host.querySelector<HTMLOutputElement>('output[for="input-anio"]');
+  if (!output) throw new Error('output missing');
+  return { host, onChange, range, output };
+}
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('mountForm año scrubber', () => {
+  it('renders a range input with min=2012 max=2026 and the initial year as value', () => {
+    const { range } = setup({ bruto: 30_000, anio: 2018 });
+    expect(range.type).toBe('range');
+    expect(range.min).toBe('2012');
+    expect(range.max).toBe('2026');
+    expect(range.step).toBe('1');
+    expect(range.value).toBe('2018');
+  });
+
+  it('mirrors the year in <output> and aria-valuetext at mount', () => {
+    const { range, output } = setup({ bruto: 30_000, anio: 2018 });
+    expect(output.textContent).toBe('2018');
+    expect(range.getAttribute('aria-valuetext')).toBe('2018');
+  });
+
+  it('fires onChange on the input event during drag (not just change)', () => {
+    const { onChange, range } = setup();
+    range.value = '2020';
+    range.dispatchEvent(new Event('input', { bubbles: true }));
+    expect(onChange).toHaveBeenCalledWith({ bruto: 30_000, anio: 2020 });
+  });
+
+  it('updates <output> and aria-valuetext when the value changes', () => {
+    const { range, output } = setup();
+    range.value = '2015';
+    range.dispatchEvent(new Event('input', { bubbles: true }));
+    expect(output.textContent).toBe('2015');
+    expect(range.getAttribute('aria-valuetext')).toBe('2015');
+  });
+
+  it('supports keyboard arrow navigation moving the year by ±1', () => {
+    const { onChange, range } = setup({ bruto: 30_000, anio: 2020 });
+    range.value = '2019';
+    range.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true }));
+    range.dispatchEvent(new Event('input', { bubbles: true }));
+    expect(onChange).toHaveBeenLastCalledWith({ bruto: 30_000, anio: 2019 });
+  });
+
+  it('renders end-of-range tick labels 2012 and 2026', () => {
+    const { host } = setup();
+    const ticks = host.querySelectorAll('.anio-ticks span');
+    expect(ticks.length).toBe(2);
+    expect(ticks[0]?.textContent).toBe('2012');
+    expect(ticks[1]?.textContent).toBe('2026');
+  });
+
+  it('still has the bruto and CCAA controls in the form-row', () => {
+    const { host } = setup();
+    expect(host.querySelector<HTMLInputElement>('#input-bruto')).not.toBeNull();
+    expect(host.querySelector<HTMLSelectElement>('#input-ccaa')).not.toBeNull();
+  });
+});

--- a/test/form.browser.test.ts
+++ b/test/form.browser.test.ts
@@ -1,5 +1,6 @@
 // test/form.browser.test.ts
 import '../src/ui/theme.css';
+import { userEvent } from '@vitest/browser/context';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { mountForm } from '../src/ui/form';
 import type { FormState } from '../src/ui/form';
@@ -7,6 +8,7 @@ import type { FormState } from '../src/ui/form';
 function setup(initial: FormState = { bruto: 30_000, anio: 2026 }): {
   host: HTMLElement;
   onChange: ReturnType<typeof vi.fn>;
+  bruto: HTMLInputElement;
   range: HTMLInputElement;
   output: HTMLOutputElement;
 } {
@@ -15,11 +17,13 @@ function setup(initial: FormState = { bruto: 30_000, anio: 2026 }): {
   if (!host) throw new Error('test setup: #host not in DOM');
   const onChange = vi.fn<(s: FormState) => void>();
   mountForm(host, { initial, onChange });
+  const bruto = host.querySelector<HTMLInputElement>('#input-bruto');
+  if (!bruto) throw new Error('bruto input missing');
   const range = host.querySelector<HTMLInputElement>('#input-anio');
   if (!range) throw new Error('range input missing');
   const output = host.querySelector<HTMLOutputElement>('output[for="input-anio"]');
   if (!output) throw new Error('output missing');
-  return { host, onChange, range, output };
+  return { host, onChange, bruto, range, output };
 }
 
 afterEach(() => {
@@ -57,12 +61,18 @@ describe('mountForm año scrubber', () => {
     expect(range.getAttribute('aria-valuetext')).toBe('2015');
   });
 
-  it('supports keyboard arrow navigation moving the year by ±1', () => {
+  it('decrements the year by one on a real ArrowLeft keypress', async () => {
     const { onChange, range } = setup({ bruto: 30_000, anio: 2020 });
-    range.value = '2019';
-    range.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true }));
-    range.dispatchEvent(new Event('input', { bubbles: true }));
+    range.focus();
+    await userEvent.keyboard('{ArrowLeft}');
     expect(onChange).toHaveBeenLastCalledWith({ bruto: 30_000, anio: 2019 });
+  });
+
+  it('fires onChange on the bruto input event with the parsed numeric value', () => {
+    const { onChange, bruto } = setup({ bruto: 30_000, anio: 2020 });
+    bruto.value = '45000';
+    bruto.dispatchEvent(new Event('input', { bubbles: true }));
+    expect(onChange).toHaveBeenCalledWith({ bruto: 45000, anio: 2020 });
   });
 
   it('renders end-of-range tick labels 2012 and 2026', () => {


### PR DESCRIPTION
## Resumen
- Sustituye el select de año fiscal por un **scrubber** horizontal con teclado (ArrowLeft/Right/Home/End) y deep-link `?anio=YYYY`.
- Elimina el modificador redundante `form-row--2col` y simplifica el layout del hero (sin `max-width` para acompañar al scrubber).
- Endurece `requireEl` con mensaje de error enriquecido (incluye el root) y cobertura para el caso de root sin `id`.
- Ignora `.cache/` en ESLint y artefactos de Playwright/`plans/` en `.gitignore`.

## Test plan
- [x] `npm run format:check && npm run lint && npm run typecheck && npm test` localmente
- [x] `npm run test:browser` (DOM + scrubber con teclado real + a11y)
- [ ] Smoke en GitHub Pages tras el merge a `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)