### PR TITLE
feat(ui): dark mode editorial (#70)

### DIFF
--- a/docs/assets/neto-real-bruto-real-fijo.svg
+++ b/docs/assets/neto-real-bruto-real-fijo.svg
@@ -1,452 +1,482 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 760 420" width="760" height="420" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif" font-size="13" role="img" aria-labelledby="neto-real-bruto-real-fijo-title neto-real-bruto-real-fijo-desc">
 <title id="neto-real-bruto-real-fijo-title">Neto real por bruto real, fiscalidad de cada año</title>
 <desc id="neto-real-bruto-real-fijo-desc">Para un mismo bruto medido en € constantes de 2026, qué neto real se obtiene aplicando la fiscalidad y SS de cada año. El espaciado vertical entre líneas mide el efecto neto de las reformas más la progresividad en frío.</desc>
-<rect width="760" height="420" fill="#ffffff" />
-<text x="80" y="35" font-size="16" font-weight="600" fill="#222">Neto real por bruto real, fiscalidad de cada año</text>
+<style>
+  :root {
+    --c-bg: #f7f3ec;
+    --c-axis: #333333;
+    --c-grid: #e5e5e5;
+    --c-text: #444444;
+    --c-title: #222222;
+    --c-s0: #1f77b4;
+    --c-s1: #d62728;
+    --c-s2: #2ca02c;
+    --c-s3: #9467bd;
+    --c-s4: #cc6600;
+    --c-s5: #00838f;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --c-bg: #1a1612;
+      --c-axis: #f3ede2;
+      --c-grid: #3a342c;
+      --c-text: #d4cdbf;
+      --c-title: #f3ede2;
+      --c-s0: #5d9ec9;
+      --c-s1: #e87073;
+      --c-s2: #66bf66;
+      --c-s3: #b89bd6;
+      --c-s4: #ffaa57;
+      --c-s5: #71d6e0;
+    }
+  }
+</style>
+<rect width="760" height="420" fill="var(--c-bg)" />
+<text x="80" y="35" font-size="16" font-weight="600" fill="var(--c-title)">Neto real por bruto real, fiscalidad de cada año</text>
 <g transform="translate(80,60)">
-<line x1="0" y1="246.59" x2="510" y2="246.59" stroke="#e5e5e5" stroke-width="1" />
-<line x1="0" y1="181.60" x2="510" y2="181.60" stroke="#e5e5e5" stroke-width="1" />
-<line x1="0" y1="116.61" x2="510" y2="116.61" stroke="#e5e5e5" stroke-width="1" />
-<line x1="0" y1="51.62" x2="510" y2="51.62" stroke="#e5e5e5" stroke-width="1" />
-<line x1="0" y1="300" x2="510" y2="300" stroke="#333" stroke-width="1" />
-<line x1="0" y1="0" x2="0" y2="300" stroke="#333" stroke-width="1" />
-<line x1="39.23" y1="300" x2="39.23" y2="305" stroke="#333" stroke-width="1" />
-<text x="39.23" y="322" text-anchor="middle" fill="#444">20k €</text>
-<line x1="117.69" y1="300" x2="117.69" y2="305" stroke="#333" stroke-width="1" />
-<text x="117.69" y="322" text-anchor="middle" fill="#444">30k €</text>
-<line x1="196.15" y1="300" x2="196.15" y2="305" stroke="#333" stroke-width="1" />
-<text x="196.15" y="322" text-anchor="middle" fill="#444">40k €</text>
-<line x1="274.62" y1="300" x2="274.62" y2="305" stroke="#333" stroke-width="1" />
-<text x="274.62" y="322" text-anchor="middle" fill="#444">50k €</text>
-<line x1="353.08" y1="300" x2="353.08" y2="305" stroke="#333" stroke-width="1" />
-<text x="353.08" y="322" text-anchor="middle" fill="#444">60k €</text>
-<line x1="431.54" y1="300" x2="431.54" y2="305" stroke="#333" stroke-width="1" />
-<text x="431.54" y="322" text-anchor="middle" fill="#444">70k €</text>
-<line x1="510.00" y1="300" x2="510.00" y2="305" stroke="#333" stroke-width="1" />
-<text x="510.00" y="322" text-anchor="middle" fill="#444">80k €</text>
-<line x1="-5" y1="246.59" x2="0" y2="246.59" stroke="#333" stroke-width="1" />
-<text x="-10" y="250.59" text-anchor="end" fill="#444">20k €</text>
-<line x1="-5" y1="181.60" x2="0" y2="181.60" stroke="#333" stroke-width="1" />
-<text x="-10" y="185.60" text-anchor="end" fill="#444">30k €</text>
-<line x1="-5" y1="116.61" x2="0" y2="116.61" stroke="#333" stroke-width="1" />
-<text x="-10" y="120.61" text-anchor="end" fill="#444">40k €</text>
-<line x1="-5" y1="51.62" x2="0" y2="51.62" stroke="#333" stroke-width="1" />
-<text x="-10" y="55.62" text-anchor="end" fill="#444">50k €</text>
-<text x="255" y="348" text-anchor="middle" fill="#222" font-size="13">Bruto en € de 2026</text>
-<text transform="translate(-55,150) rotate(-90)" text-anchor="middle" fill="#222" font-size="13">Neto en € de 2026</text>
-<polyline points="0.00,286.36 7.85,283.07 15.69,279.78 23.54,276.49 31.38,273.12 39.23,268.54 47.08,263.96 54.92,259.38 62.77,254.80 70.62,250.22 78.46,245.64 86.31,241.06 94.15,236.48 102.00,231.90 109.85,227.50 117.69,223.24 125.54,218.97 133.38,214.71 141.23,210.45 149.08,206.19 156.92,201.93 164.77,197.67 172.62,193.41 180.46,189.15 188.31,184.89 196.15,180.63 204.00,176.37 211.85,172.11 219.69,167.85 227.54,163.59 235.38,159.33 243.23,155.07 251.08,150.81 258.92,146.54 266.77,142.28 274.62,138.12 282.46,134.47 290.31,130.63 298.15,126.73 306.00,122.83 313.85,118.93 321.69,115.03 329.54,111.13 337.38,107.23 345.23,103.33 353.08,99.43 360.92,95.53 368.77,91.63 376.62,87.73 384.46,83.83 392.31,79.93 400.15,76.03 408.00,72.13 415.85,68.24 423.69,64.34 431.54,60.44 439.38,56.54 447.23,52.64 455.08,48.74 462.92,44.84 470.77,40.94 478.62,37.04 486.46,33.30 494.31,29.86 502.15,26.41 510.00,22.97" fill="none" stroke="#1f77b4" stroke-width="2" stroke-linejoin="round" stroke-linecap="round" />
-<circle cx="0.00" cy="286.36" r="2" fill="#1f77b4" />
-<circle cx="7.85" cy="283.07" r="2" fill="#1f77b4" />
-<circle cx="15.69" cy="279.78" r="2" fill="#1f77b4" />
-<circle cx="23.54" cy="276.49" r="2" fill="#1f77b4" />
-<circle cx="31.38" cy="273.12" r="2" fill="#1f77b4" />
-<circle cx="39.23" cy="268.54" r="2" fill="#1f77b4" />
-<circle cx="47.08" cy="263.96" r="2" fill="#1f77b4" />
-<circle cx="54.92" cy="259.38" r="2" fill="#1f77b4" />
-<circle cx="62.77" cy="254.80" r="2" fill="#1f77b4" />
-<circle cx="70.62" cy="250.22" r="2" fill="#1f77b4" />
-<circle cx="78.46" cy="245.64" r="2" fill="#1f77b4" />
-<circle cx="86.31" cy="241.06" r="2" fill="#1f77b4" />
-<circle cx="94.15" cy="236.48" r="2" fill="#1f77b4" />
-<circle cx="102.00" cy="231.90" r="2" fill="#1f77b4" />
-<circle cx="109.85" cy="227.50" r="2" fill="#1f77b4" />
-<circle cx="117.69" cy="223.24" r="2" fill="#1f77b4" />
-<circle cx="125.54" cy="218.97" r="2" fill="#1f77b4" />
-<circle cx="133.38" cy="214.71" r="2" fill="#1f77b4" />
-<circle cx="141.23" cy="210.45" r="2" fill="#1f77b4" />
-<circle cx="149.08" cy="206.19" r="2" fill="#1f77b4" />
-<circle cx="156.92" cy="201.93" r="2" fill="#1f77b4" />
-<circle cx="164.77" cy="197.67" r="2" fill="#1f77b4" />
-<circle cx="172.62" cy="193.41" r="2" fill="#1f77b4" />
-<circle cx="180.46" cy="189.15" r="2" fill="#1f77b4" />
-<circle cx="188.31" cy="184.89" r="2" fill="#1f77b4" />
-<circle cx="196.15" cy="180.63" r="2" fill="#1f77b4" />
-<circle cx="204.00" cy="176.37" r="2" fill="#1f77b4" />
-<circle cx="211.85" cy="172.11" r="2" fill="#1f77b4" />
-<circle cx="219.69" cy="167.85" r="2" fill="#1f77b4" />
-<circle cx="227.54" cy="163.59" r="2" fill="#1f77b4" />
-<circle cx="235.38" cy="159.33" r="2" fill="#1f77b4" />
-<circle cx="243.23" cy="155.07" r="2" fill="#1f77b4" />
-<circle cx="251.08" cy="150.81" r="2" fill="#1f77b4" />
-<circle cx="258.92" cy="146.54" r="2" fill="#1f77b4" />
-<circle cx="266.77" cy="142.28" r="2" fill="#1f77b4" />
-<circle cx="274.62" cy="138.12" r="2" fill="#1f77b4" />
-<circle cx="282.46" cy="134.47" r="2" fill="#1f77b4" />
-<circle cx="290.31" cy="130.63" r="2" fill="#1f77b4" />
-<circle cx="298.15" cy="126.73" r="2" fill="#1f77b4" />
-<circle cx="306.00" cy="122.83" r="2" fill="#1f77b4" />
-<circle cx="313.85" cy="118.93" r="2" fill="#1f77b4" />
-<circle cx="321.69" cy="115.03" r="2" fill="#1f77b4" />
-<circle cx="329.54" cy="111.13" r="2" fill="#1f77b4" />
-<circle cx="337.38" cy="107.23" r="2" fill="#1f77b4" />
-<circle cx="345.23" cy="103.33" r="2" fill="#1f77b4" />
-<circle cx="353.08" cy="99.43" r="2" fill="#1f77b4" />
-<circle cx="360.92" cy="95.53" r="2" fill="#1f77b4" />
-<circle cx="368.77" cy="91.63" r="2" fill="#1f77b4" />
-<circle cx="376.62" cy="87.73" r="2" fill="#1f77b4" />
-<circle cx="384.46" cy="83.83" r="2" fill="#1f77b4" />
-<circle cx="392.31" cy="79.93" r="2" fill="#1f77b4" />
-<circle cx="400.15" cy="76.03" r="2" fill="#1f77b4" />
-<circle cx="408.00" cy="72.13" r="2" fill="#1f77b4" />
-<circle cx="415.85" cy="68.24" r="2" fill="#1f77b4" />
-<circle cx="423.69" cy="64.34" r="2" fill="#1f77b4" />
-<circle cx="431.54" cy="60.44" r="2" fill="#1f77b4" />
-<circle cx="439.38" cy="56.54" r="2" fill="#1f77b4" />
-<circle cx="447.23" cy="52.64" r="2" fill="#1f77b4" />
-<circle cx="455.08" cy="48.74" r="2" fill="#1f77b4" />
-<circle cx="462.92" cy="44.84" r="2" fill="#1f77b4" />
-<circle cx="470.77" cy="40.94" r="2" fill="#1f77b4" />
-<circle cx="478.62" cy="37.04" r="2" fill="#1f77b4" />
-<circle cx="486.46" cy="33.30" r="2" fill="#1f77b4" />
-<circle cx="494.31" cy="29.86" r="2" fill="#1f77b4" />
-<circle cx="502.15" cy="26.41" r="2" fill="#1f77b4" />
-<circle cx="510.00" cy="22.97" r="2" fill="#1f77b4" />
-<polyline points="0.00,285.28 7.85,279.61 15.69,276.08 23.54,272.55 31.38,269.03 39.23,265.50 47.08,261.27 54.92,256.68 62.77,252.08 70.62,247.48 78.46,242.89 86.31,238.29 94.15,233.70 102.00,229.10 109.85,224.51 117.69,219.91 125.54,215.32 133.38,210.99 141.23,206.76 149.08,202.53 156.92,198.30 164.77,194.07 172.62,189.84 180.46,185.61 188.31,181.38 196.15,177.15 204.00,172.92 211.85,168.69 219.69,164.46 227.54,160.23 235.38,156.00 243.23,151.77 251.08,147.54 258.92,143.31 266.77,139.08 274.62,134.85 282.46,130.77 290.31,126.99 298.15,123.22 306.00,119.45 313.85,115.67 321.69,111.90 329.54,108.13 337.38,104.11 345.23,100.08 353.08,96.05 360.92,92.02 368.77,87.99 376.62,83.96 384.46,79.93 392.31,75.90 400.15,71.87 408.00,67.84 415.85,63.81 423.69,59.78 431.54,55.75 439.38,51.73 447.23,47.70 455.08,43.67 462.92,39.64 470.77,35.61 478.62,31.58 486.46,27.55 494.31,23.52 502.15,19.49 510.00,15.46" fill="none" stroke="#d62728" stroke-width="2" stroke-linejoin="round" stroke-linecap="round" />
-<circle cx="0.00" cy="285.28" r="2" fill="#d62728" />
-<circle cx="7.85" cy="279.61" r="2" fill="#d62728" />
-<circle cx="15.69" cy="276.08" r="2" fill="#d62728" />
-<circle cx="23.54" cy="272.55" r="2" fill="#d62728" />
-<circle cx="31.38" cy="269.03" r="2" fill="#d62728" />
-<circle cx="39.23" cy="265.50" r="2" fill="#d62728" />
-<circle cx="47.08" cy="261.27" r="2" fill="#d62728" />
-<circle cx="54.92" cy="256.68" r="2" fill="#d62728" />
-<circle cx="62.77" cy="252.08" r="2" fill="#d62728" />
-<circle cx="70.62" cy="247.48" r="2" fill="#d62728" />
-<circle cx="78.46" cy="242.89" r="2" fill="#d62728" />
-<circle cx="86.31" cy="238.29" r="2" fill="#d62728" />
-<circle cx="94.15" cy="233.70" r="2" fill="#d62728" />
-<circle cx="102.00" cy="229.10" r="2" fill="#d62728" />
-<circle cx="109.85" cy="224.51" r="2" fill="#d62728" />
-<circle cx="117.69" cy="219.91" r="2" fill="#d62728" />
-<circle cx="125.54" cy="215.32" r="2" fill="#d62728" />
-<circle cx="133.38" cy="210.99" r="2" fill="#d62728" />
-<circle cx="141.23" cy="206.76" r="2" fill="#d62728" />
-<circle cx="149.08" cy="202.53" r="2" fill="#d62728" />
-<circle cx="156.92" cy="198.30" r="2" fill="#d62728" />
-<circle cx="164.77" cy="194.07" r="2" fill="#d62728" />
-<circle cx="172.62" cy="189.84" r="2" fill="#d62728" />
-<circle cx="180.46" cy="185.61" r="2" fill="#d62728" />
-<circle cx="188.31" cy="181.38" r="2" fill="#d62728" />
-<circle cx="196.15" cy="177.15" r="2" fill="#d62728" />
-<circle cx="204.00" cy="172.92" r="2" fill="#d62728" />
-<circle cx="211.85" cy="168.69" r="2" fill="#d62728" />
-<circle cx="219.69" cy="164.46" r="2" fill="#d62728" />
-<circle cx="227.54" cy="160.23" r="2" fill="#d62728" />
-<circle cx="235.38" cy="156.00" r="2" fill="#d62728" />
-<circle cx="243.23" cy="151.77" r="2" fill="#d62728" />
-<circle cx="251.08" cy="147.54" r="2" fill="#d62728" />
-<circle cx="258.92" cy="143.31" r="2" fill="#d62728" />
-<circle cx="266.77" cy="139.08" r="2" fill="#d62728" />
-<circle cx="274.62" cy="134.85" r="2" fill="#d62728" />
-<circle cx="282.46" cy="130.77" r="2" fill="#d62728" />
-<circle cx="290.31" cy="126.99" r="2" fill="#d62728" />
-<circle cx="298.15" cy="123.22" r="2" fill="#d62728" />
-<circle cx="306.00" cy="119.45" r="2" fill="#d62728" />
-<circle cx="313.85" cy="115.67" r="2" fill="#d62728" />
-<circle cx="321.69" cy="111.90" r="2" fill="#d62728" />
-<circle cx="329.54" cy="108.13" r="2" fill="#d62728" />
-<circle cx="337.38" cy="104.11" r="2" fill="#d62728" />
-<circle cx="345.23" cy="100.08" r="2" fill="#d62728" />
-<circle cx="353.08" cy="96.05" r="2" fill="#d62728" />
-<circle cx="360.92" cy="92.02" r="2" fill="#d62728" />
-<circle cx="368.77" cy="87.99" r="2" fill="#d62728" />
-<circle cx="376.62" cy="83.96" r="2" fill="#d62728" />
-<circle cx="384.46" cy="79.93" r="2" fill="#d62728" />
-<circle cx="392.31" cy="75.90" r="2" fill="#d62728" />
-<circle cx="400.15" cy="71.87" r="2" fill="#d62728" />
-<circle cx="408.00" cy="67.84" r="2" fill="#d62728" />
-<circle cx="415.85" cy="63.81" r="2" fill="#d62728" />
-<circle cx="423.69" cy="59.78" r="2" fill="#d62728" />
-<circle cx="431.54" cy="55.75" r="2" fill="#d62728" />
-<circle cx="439.38" cy="51.73" r="2" fill="#d62728" />
-<circle cx="447.23" cy="47.70" r="2" fill="#d62728" />
-<circle cx="455.08" cy="43.67" r="2" fill="#d62728" />
-<circle cx="462.92" cy="39.64" r="2" fill="#d62728" />
-<circle cx="470.77" cy="35.61" r="2" fill="#d62728" />
-<circle cx="478.62" cy="31.58" r="2" fill="#d62728" />
-<circle cx="486.46" cy="27.55" r="2" fill="#d62728" />
-<circle cx="494.31" cy="23.52" r="2" fill="#d62728" />
-<circle cx="502.15" cy="19.49" r="2" fill="#d62728" />
-<circle cx="510.00" cy="15.46" r="2" fill="#d62728" />
-<polyline points="0.00,285.28 7.85,279.19 15.69,274.87 23.54,270.81 31.38,267.42 39.23,263.74 47.08,259.70 54.92,256.17 62.77,252.41 70.62,247.78 78.46,243.15 86.31,238.53 94.15,233.90 102.00,229.28 109.85,224.65 117.69,220.03 125.54,215.74 133.38,211.48 141.23,207.22 149.08,202.96 156.92,198.70 164.77,194.44 172.62,190.18 180.46,185.92 188.31,181.66 196.15,177.40 204.00,173.14 211.85,168.87 219.69,164.61 227.54,160.35 235.38,156.09 243.23,151.83 251.08,147.57 258.92,143.31 266.77,139.05 274.62,134.79 282.46,130.79 290.31,126.96 298.15,123.12 306.00,119.29 313.85,115.46 321.69,111.62 329.54,107.79 337.38,103.72 345.23,99.62 353.08,95.53 360.92,91.43 368.77,87.34 376.62,83.24 384.46,79.15 392.31,75.05 400.15,70.96 408.00,66.87 415.85,62.77 423.69,58.68 431.54,54.58 439.38,50.49 447.23,46.39 455.08,42.30 462.92,38.20 470.77,34.11 478.62,30.01 486.46,25.92 494.31,21.83 502.15,17.73 510.00,13.64" fill="none" stroke="#2ca02c" stroke-width="2" stroke-linejoin="round" stroke-linecap="round" />
-<circle cx="0.00" cy="285.28" r="2" fill="#2ca02c" />
-<circle cx="7.85" cy="279.19" r="2" fill="#2ca02c" />
-<circle cx="15.69" cy="274.87" r="2" fill="#2ca02c" />
-<circle cx="23.54" cy="270.81" r="2" fill="#2ca02c" />
-<circle cx="31.38" cy="267.42" r="2" fill="#2ca02c" />
-<circle cx="39.23" cy="263.74" r="2" fill="#2ca02c" />
-<circle cx="47.08" cy="259.70" r="2" fill="#2ca02c" />
-<circle cx="54.92" cy="256.17" r="2" fill="#2ca02c" />
-<circle cx="62.77" cy="252.41" r="2" fill="#2ca02c" />
-<circle cx="70.62" cy="247.78" r="2" fill="#2ca02c" />
-<circle cx="78.46" cy="243.15" r="2" fill="#2ca02c" />
-<circle cx="86.31" cy="238.53" r="2" fill="#2ca02c" />
-<circle cx="94.15" cy="233.90" r="2" fill="#2ca02c" />
-<circle cx="102.00" cy="229.28" r="2" fill="#2ca02c" />
-<circle cx="109.85" cy="224.65" r="2" fill="#2ca02c" />
-<circle cx="117.69" cy="220.03" r="2" fill="#2ca02c" />
-<circle cx="125.54" cy="215.74" r="2" fill="#2ca02c" />
-<circle cx="133.38" cy="211.48" r="2" fill="#2ca02c" />
-<circle cx="141.23" cy="207.22" r="2" fill="#2ca02c" />
-<circle cx="149.08" cy="202.96" r="2" fill="#2ca02c" />
-<circle cx="156.92" cy="198.70" r="2" fill="#2ca02c" />
-<circle cx="164.77" cy="194.44" r="2" fill="#2ca02c" />
-<circle cx="172.62" cy="190.18" r="2" fill="#2ca02c" />
-<circle cx="180.46" cy="185.92" r="2" fill="#2ca02c" />
-<circle cx="188.31" cy="181.66" r="2" fill="#2ca02c" />
-<circle cx="196.15" cy="177.40" r="2" fill="#2ca02c" />
-<circle cx="204.00" cy="173.14" r="2" fill="#2ca02c" />
-<circle cx="211.85" cy="168.87" r="2" fill="#2ca02c" />
-<circle cx="219.69" cy="164.61" r="2" fill="#2ca02c" />
-<circle cx="227.54" cy="160.35" r="2" fill="#2ca02c" />
-<circle cx="235.38" cy="156.09" r="2" fill="#2ca02c" />
-<circle cx="243.23" cy="151.83" r="2" fill="#2ca02c" />
-<circle cx="251.08" cy="147.57" r="2" fill="#2ca02c" />
-<circle cx="258.92" cy="143.31" r="2" fill="#2ca02c" />
-<circle cx="266.77" cy="139.05" r="2" fill="#2ca02c" />
-<circle cx="274.62" cy="134.79" r="2" fill="#2ca02c" />
-<circle cx="282.46" cy="130.79" r="2" fill="#2ca02c" />
-<circle cx="290.31" cy="126.96" r="2" fill="#2ca02c" />
-<circle cx="298.15" cy="123.12" r="2" fill="#2ca02c" />
-<circle cx="306.00" cy="119.29" r="2" fill="#2ca02c" />
-<circle cx="313.85" cy="115.46" r="2" fill="#2ca02c" />
-<circle cx="321.69" cy="111.62" r="2" fill="#2ca02c" />
-<circle cx="329.54" cy="107.79" r="2" fill="#2ca02c" />
-<circle cx="337.38" cy="103.72" r="2" fill="#2ca02c" />
-<circle cx="345.23" cy="99.62" r="2" fill="#2ca02c" />
-<circle cx="353.08" cy="95.53" r="2" fill="#2ca02c" />
-<circle cx="360.92" cy="91.43" r="2" fill="#2ca02c" />
-<circle cx="368.77" cy="87.34" r="2" fill="#2ca02c" />
-<circle cx="376.62" cy="83.24" r="2" fill="#2ca02c" />
-<circle cx="384.46" cy="79.15" r="2" fill="#2ca02c" />
-<circle cx="392.31" cy="75.05" r="2" fill="#2ca02c" />
-<circle cx="400.15" cy="70.96" r="2" fill="#2ca02c" />
-<circle cx="408.00" cy="66.87" r="2" fill="#2ca02c" />
-<circle cx="415.85" cy="62.77" r="2" fill="#2ca02c" />
-<circle cx="423.69" cy="58.68" r="2" fill="#2ca02c" />
-<circle cx="431.54" cy="54.58" r="2" fill="#2ca02c" />
-<circle cx="439.38" cy="50.49" r="2" fill="#2ca02c" />
-<circle cx="447.23" cy="46.39" r="2" fill="#2ca02c" />
-<circle cx="455.08" cy="42.30" r="2" fill="#2ca02c" />
-<circle cx="462.92" cy="38.20" r="2" fill="#2ca02c" />
-<circle cx="470.77" cy="34.11" r="2" fill="#2ca02c" />
-<circle cx="478.62" cy="30.01" r="2" fill="#2ca02c" />
-<circle cx="486.46" cy="25.92" r="2" fill="#2ca02c" />
-<circle cx="494.31" cy="21.83" r="2" fill="#2ca02c" />
-<circle cx="502.15" cy="17.73" r="2" fill="#2ca02c" />
-<circle cx="510.00" cy="13.64" r="2" fill="#2ca02c" />
-<polyline points="0.00,285.28 7.85,279.96 15.69,276.67 23.54,273.37 31.38,270.08 39.23,266.79 47.08,263.50 54.92,259.06 62.77,254.44 70.62,249.81 78.46,245.19 86.31,240.56 94.15,236.07 102.00,231.81 109.85,227.55 117.69,223.29 125.54,219.03 133.38,214.77 141.23,210.51 149.08,206.25 156.92,201.99 164.77,197.72 172.62,193.46 180.46,189.20 188.31,184.94 196.15,180.68 204.00,176.42 211.85,172.16 219.69,167.90 227.54,163.64 235.38,159.54 243.23,155.71 251.08,151.87 258.92,148.04 266.77,144.20 274.62,140.37 282.46,136.53 290.31,132.70 298.15,128.86 306.00,125.03 313.85,121.20 321.69,117.31 329.54,113.21 337.38,109.12 345.23,105.03 353.08,100.93 360.92,96.84 368.77,92.74 376.62,88.65 384.46,84.55 392.31,80.46 400.15,76.36 408.00,72.27 415.85,68.17 423.69,64.08 431.54,59.99 439.38,55.89 447.23,51.80 455.08,47.70 462.92,44.03 470.77,40.45 478.62,36.88 486.46,33.31 494.31,29.73 502.15,26.16 510.00,22.58" fill="none" stroke="#9467bd" stroke-width="2" stroke-linejoin="round" stroke-linecap="round" />
-<circle cx="0.00" cy="285.28" r="2" fill="#9467bd" />
-<circle cx="7.85" cy="279.96" r="2" fill="#9467bd" />
-<circle cx="15.69" cy="276.67" r="2" fill="#9467bd" />
-<circle cx="23.54" cy="273.37" r="2" fill="#9467bd" />
-<circle cx="31.38" cy="270.08" r="2" fill="#9467bd" />
-<circle cx="39.23" cy="266.79" r="2" fill="#9467bd" />
-<circle cx="47.08" cy="263.50" r="2" fill="#9467bd" />
-<circle cx="54.92" cy="259.06" r="2" fill="#9467bd" />
-<circle cx="62.77" cy="254.44" r="2" fill="#9467bd" />
-<circle cx="70.62" cy="249.81" r="2" fill="#9467bd" />
-<circle cx="78.46" cy="245.19" r="2" fill="#9467bd" />
-<circle cx="86.31" cy="240.56" r="2" fill="#9467bd" />
-<circle cx="94.15" cy="236.07" r="2" fill="#9467bd" />
-<circle cx="102.00" cy="231.81" r="2" fill="#9467bd" />
-<circle cx="109.85" cy="227.55" r="2" fill="#9467bd" />
-<circle cx="117.69" cy="223.29" r="2" fill="#9467bd" />
-<circle cx="125.54" cy="219.03" r="2" fill="#9467bd" />
-<circle cx="133.38" cy="214.77" r="2" fill="#9467bd" />
-<circle cx="141.23" cy="210.51" r="2" fill="#9467bd" />
-<circle cx="149.08" cy="206.25" r="2" fill="#9467bd" />
-<circle cx="156.92" cy="201.99" r="2" fill="#9467bd" />
-<circle cx="164.77" cy="197.72" r="2" fill="#9467bd" />
-<circle cx="172.62" cy="193.46" r="2" fill="#9467bd" />
-<circle cx="180.46" cy="189.20" r="2" fill="#9467bd" />
-<circle cx="188.31" cy="184.94" r="2" fill="#9467bd" />
-<circle cx="196.15" cy="180.68" r="2" fill="#9467bd" />
-<circle cx="204.00" cy="176.42" r="2" fill="#9467bd" />
-<circle cx="211.85" cy="172.16" r="2" fill="#9467bd" />
-<circle cx="219.69" cy="167.90" r="2" fill="#9467bd" />
-<circle cx="227.54" cy="163.64" r="2" fill="#9467bd" />
-<circle cx="235.38" cy="159.54" r="2" fill="#9467bd" />
-<circle cx="243.23" cy="155.71" r="2" fill="#9467bd" />
-<circle cx="251.08" cy="151.87" r="2" fill="#9467bd" />
-<circle cx="258.92" cy="148.04" r="2" fill="#9467bd" />
-<circle cx="266.77" cy="144.20" r="2" fill="#9467bd" />
-<circle cx="274.62" cy="140.37" r="2" fill="#9467bd" />
-<circle cx="282.46" cy="136.53" r="2" fill="#9467bd" />
-<circle cx="290.31" cy="132.70" r="2" fill="#9467bd" />
-<circle cx="298.15" cy="128.86" r="2" fill="#9467bd" />
-<circle cx="306.00" cy="125.03" r="2" fill="#9467bd" />
-<circle cx="313.85" cy="121.20" r="2" fill="#9467bd" />
-<circle cx="321.69" cy="117.31" r="2" fill="#9467bd" />
-<circle cx="329.54" cy="113.21" r="2" fill="#9467bd" />
-<circle cx="337.38" cy="109.12" r="2" fill="#9467bd" />
-<circle cx="345.23" cy="105.03" r="2" fill="#9467bd" />
-<circle cx="353.08" cy="100.93" r="2" fill="#9467bd" />
-<circle cx="360.92" cy="96.84" r="2" fill="#9467bd" />
-<circle cx="368.77" cy="92.74" r="2" fill="#9467bd" />
-<circle cx="376.62" cy="88.65" r="2" fill="#9467bd" />
-<circle cx="384.46" cy="84.55" r="2" fill="#9467bd" />
-<circle cx="392.31" cy="80.46" r="2" fill="#9467bd" />
-<circle cx="400.15" cy="76.36" r="2" fill="#9467bd" />
-<circle cx="408.00" cy="72.27" r="2" fill="#9467bd" />
-<circle cx="415.85" cy="68.17" r="2" fill="#9467bd" />
-<circle cx="423.69" cy="64.08" r="2" fill="#9467bd" />
-<circle cx="431.54" cy="59.99" r="2" fill="#9467bd" />
-<circle cx="439.38" cy="55.89" r="2" fill="#9467bd" />
-<circle cx="447.23" cy="51.80" r="2" fill="#9467bd" />
-<circle cx="455.08" cy="47.70" r="2" fill="#9467bd" />
-<circle cx="462.92" cy="44.03" r="2" fill="#9467bd" />
-<circle cx="470.77" cy="40.45" r="2" fill="#9467bd" />
-<circle cx="478.62" cy="36.88" r="2" fill="#9467bd" />
-<circle cx="486.46" cy="33.31" r="2" fill="#9467bd" />
-<circle cx="494.31" cy="29.73" r="2" fill="#9467bd" />
-<circle cx="502.15" cy="26.16" r="2" fill="#9467bd" />
-<circle cx="510.00" cy="22.58" r="2" fill="#9467bd" />
-<polyline points="0.00,285.40 7.85,279.32 15.69,273.72 23.54,270.44 31.38,267.16 39.23,263.87 47.08,260.59 54.92,257.30 62.77,254.02 70.62,250.74 78.46,246.22 86.31,241.91 94.15,237.66 102.00,233.40 109.85,229.15 117.69,224.89 125.54,220.64 133.38,216.38 141.23,212.13 149.08,207.87 156.92,203.62 164.77,199.36 172.62,195.11 180.46,190.85 188.31,186.59 196.15,182.34 204.00,178.08 211.85,173.83 219.69,169.93 227.54,166.10 235.38,162.27 243.23,158.45 251.08,154.62 258.92,150.79 266.77,146.96 274.62,143.13 282.46,139.30 290.31,135.47 298.15,131.64 306.00,127.81 313.85,123.98 321.69,120.15 329.54,116.32 337.38,112.49 345.23,108.66 353.08,104.83 360.92,100.75 368.77,96.65 376.62,92.56 384.46,88.46 392.31,84.37 400.15,80.27 408.00,76.18 415.85,72.08 423.69,67.99 431.54,64.11 439.38,60.53 447.23,56.96 455.08,53.38 462.92,49.81 470.77,46.23 478.62,42.66 486.46,39.08 494.31,35.51 502.15,31.93 510.00,28.36" fill="none" stroke="#ff7f0e" stroke-width="2" stroke-linejoin="round" stroke-linecap="round" />
-<circle cx="0.00" cy="285.40" r="2" fill="#ff7f0e" />
-<circle cx="7.85" cy="279.32" r="2" fill="#ff7f0e" />
-<circle cx="15.69" cy="273.72" r="2" fill="#ff7f0e" />
-<circle cx="23.54" cy="270.44" r="2" fill="#ff7f0e" />
-<circle cx="31.38" cy="267.16" r="2" fill="#ff7f0e" />
-<circle cx="39.23" cy="263.87" r="2" fill="#ff7f0e" />
-<circle cx="47.08" cy="260.59" r="2" fill="#ff7f0e" />
-<circle cx="54.92" cy="257.30" r="2" fill="#ff7f0e" />
-<circle cx="62.77" cy="254.02" r="2" fill="#ff7f0e" />
-<circle cx="70.62" cy="250.74" r="2" fill="#ff7f0e" />
-<circle cx="78.46" cy="246.22" r="2" fill="#ff7f0e" />
-<circle cx="86.31" cy="241.91" r="2" fill="#ff7f0e" />
-<circle cx="94.15" cy="237.66" r="2" fill="#ff7f0e" />
-<circle cx="102.00" cy="233.40" r="2" fill="#ff7f0e" />
-<circle cx="109.85" cy="229.15" r="2" fill="#ff7f0e" />
-<circle cx="117.69" cy="224.89" r="2" fill="#ff7f0e" />
-<circle cx="125.54" cy="220.64" r="2" fill="#ff7f0e" />
-<circle cx="133.38" cy="216.38" r="2" fill="#ff7f0e" />
-<circle cx="141.23" cy="212.13" r="2" fill="#ff7f0e" />
-<circle cx="149.08" cy="207.87" r="2" fill="#ff7f0e" />
-<circle cx="156.92" cy="203.62" r="2" fill="#ff7f0e" />
-<circle cx="164.77" cy="199.36" r="2" fill="#ff7f0e" />
-<circle cx="172.62" cy="195.11" r="2" fill="#ff7f0e" />
-<circle cx="180.46" cy="190.85" r="2" fill="#ff7f0e" />
-<circle cx="188.31" cy="186.59" r="2" fill="#ff7f0e" />
-<circle cx="196.15" cy="182.34" r="2" fill="#ff7f0e" />
-<circle cx="204.00" cy="178.08" r="2" fill="#ff7f0e" />
-<circle cx="211.85" cy="173.83" r="2" fill="#ff7f0e" />
-<circle cx="219.69" cy="169.93" r="2" fill="#ff7f0e" />
-<circle cx="227.54" cy="166.10" r="2" fill="#ff7f0e" />
-<circle cx="235.38" cy="162.27" r="2" fill="#ff7f0e" />
-<circle cx="243.23" cy="158.45" r="2" fill="#ff7f0e" />
-<circle cx="251.08" cy="154.62" r="2" fill="#ff7f0e" />
-<circle cx="258.92" cy="150.79" r="2" fill="#ff7f0e" />
-<circle cx="266.77" cy="146.96" r="2" fill="#ff7f0e" />
-<circle cx="274.62" cy="143.13" r="2" fill="#ff7f0e" />
-<circle cx="282.46" cy="139.30" r="2" fill="#ff7f0e" />
-<circle cx="290.31" cy="135.47" r="2" fill="#ff7f0e" />
-<circle cx="298.15" cy="131.64" r="2" fill="#ff7f0e" />
-<circle cx="306.00" cy="127.81" r="2" fill="#ff7f0e" />
-<circle cx="313.85" cy="123.98" r="2" fill="#ff7f0e" />
-<circle cx="321.69" cy="120.15" r="2" fill="#ff7f0e" />
-<circle cx="329.54" cy="116.32" r="2" fill="#ff7f0e" />
-<circle cx="337.38" cy="112.49" r="2" fill="#ff7f0e" />
-<circle cx="345.23" cy="108.66" r="2" fill="#ff7f0e" />
-<circle cx="353.08" cy="104.83" r="2" fill="#ff7f0e" />
-<circle cx="360.92" cy="100.75" r="2" fill="#ff7f0e" />
-<circle cx="368.77" cy="96.65" r="2" fill="#ff7f0e" />
-<circle cx="376.62" cy="92.56" r="2" fill="#ff7f0e" />
-<circle cx="384.46" cy="88.46" r="2" fill="#ff7f0e" />
-<circle cx="392.31" cy="84.37" r="2" fill="#ff7f0e" />
-<circle cx="400.15" cy="80.27" r="2" fill="#ff7f0e" />
-<circle cx="408.00" cy="76.18" r="2" fill="#ff7f0e" />
-<circle cx="415.85" cy="72.08" r="2" fill="#ff7f0e" />
-<circle cx="423.69" cy="67.99" r="2" fill="#ff7f0e" />
-<circle cx="431.54" cy="64.11" r="2" fill="#ff7f0e" />
-<circle cx="439.38" cy="60.53" r="2" fill="#ff7f0e" />
-<circle cx="447.23" cy="56.96" r="2" fill="#ff7f0e" />
-<circle cx="455.08" cy="53.38" r="2" fill="#ff7f0e" />
-<circle cx="462.92" cy="49.81" r="2" fill="#ff7f0e" />
-<circle cx="470.77" cy="46.23" r="2" fill="#ff7f0e" />
-<circle cx="478.62" cy="42.66" r="2" fill="#ff7f0e" />
-<circle cx="486.46" cy="39.08" r="2" fill="#ff7f0e" />
-<circle cx="494.31" cy="35.51" r="2" fill="#ff7f0e" />
-<circle cx="502.15" cy="31.93" r="2" fill="#ff7f0e" />
-<circle cx="510.00" cy="28.36" r="2" fill="#ff7f0e" />
-<polyline points="0.00,285.43 7.85,279.35 15.69,273.27 23.54,271.25 31.38,269.85 39.23,266.57 47.08,263.29 54.92,260.00 62.77,256.34 70.62,251.81 78.46,247.56 86.31,243.30 94.15,239.05 102.00,234.80 109.85,230.54 117.69,226.29 125.54,222.04 133.38,217.78 141.23,213.53 149.08,209.27 156.92,205.02 164.77,200.77 172.62,196.51 180.46,192.26 188.31,188.01 196.15,183.84 204.00,180.01 211.85,176.19 219.69,172.36 227.54,168.53 235.38,164.70 243.23,160.87 251.08,157.04 258.92,153.22 266.77,149.39 274.62,145.56 282.46,141.73 290.31,137.90 298.15,134.07 306.00,130.25 313.85,126.42 321.69,122.59 329.54,118.76 337.38,114.93 345.23,111.10 353.08,107.28 360.92,103.45 368.77,99.42 376.62,95.33 384.46,91.24 392.31,87.16 400.15,83.08 408.00,79.51 415.85,75.94 423.69,72.37 431.54,68.81 439.38,65.24 447.23,61.67 455.08,58.10 462.92,54.54 470.77,50.97 478.62,47.40 486.46,43.84 494.31,40.27 502.15,36.70 510.00,33.13" fill="none" stroke="#17becf" stroke-width="2" stroke-linejoin="round" stroke-linecap="round" />
-<circle cx="0.00" cy="285.43" r="2" fill="#17becf" />
-<circle cx="7.85" cy="279.35" r="2" fill="#17becf" />
-<circle cx="15.69" cy="273.27" r="2" fill="#17becf" />
-<circle cx="23.54" cy="271.25" r="2" fill="#17becf" />
-<circle cx="31.38" cy="269.85" r="2" fill="#17becf" />
-<circle cx="39.23" cy="266.57" r="2" fill="#17becf" />
-<circle cx="47.08" cy="263.29" r="2" fill="#17becf" />
-<circle cx="54.92" cy="260.00" r="2" fill="#17becf" />
-<circle cx="62.77" cy="256.34" r="2" fill="#17becf" />
-<circle cx="70.62" cy="251.81" r="2" fill="#17becf" />
-<circle cx="78.46" cy="247.56" r="2" fill="#17becf" />
-<circle cx="86.31" cy="243.30" r="2" fill="#17becf" />
-<circle cx="94.15" cy="239.05" r="2" fill="#17becf" />
-<circle cx="102.00" cy="234.80" r="2" fill="#17becf" />
-<circle cx="109.85" cy="230.54" r="2" fill="#17becf" />
-<circle cx="117.69" cy="226.29" r="2" fill="#17becf" />
-<circle cx="125.54" cy="222.04" r="2" fill="#17becf" />
-<circle cx="133.38" cy="217.78" r="2" fill="#17becf" />
-<circle cx="141.23" cy="213.53" r="2" fill="#17becf" />
-<circle cx="149.08" cy="209.27" r="2" fill="#17becf" />
-<circle cx="156.92" cy="205.02" r="2" fill="#17becf" />
-<circle cx="164.77" cy="200.77" r="2" fill="#17becf" />
-<circle cx="172.62" cy="196.51" r="2" fill="#17becf" />
-<circle cx="180.46" cy="192.26" r="2" fill="#17becf" />
-<circle cx="188.31" cy="188.01" r="2" fill="#17becf" />
-<circle cx="196.15" cy="183.84" r="2" fill="#17becf" />
-<circle cx="204.00" cy="180.01" r="2" fill="#17becf" />
-<circle cx="211.85" cy="176.19" r="2" fill="#17becf" />
-<circle cx="219.69" cy="172.36" r="2" fill="#17becf" />
-<circle cx="227.54" cy="168.53" r="2" fill="#17becf" />
-<circle cx="235.38" cy="164.70" r="2" fill="#17becf" />
-<circle cx="243.23" cy="160.87" r="2" fill="#17becf" />
-<circle cx="251.08" cy="157.04" r="2" fill="#17becf" />
-<circle cx="258.92" cy="153.22" r="2" fill="#17becf" />
-<circle cx="266.77" cy="149.39" r="2" fill="#17becf" />
-<circle cx="274.62" cy="145.56" r="2" fill="#17becf" />
-<circle cx="282.46" cy="141.73" r="2" fill="#17becf" />
-<circle cx="290.31" cy="137.90" r="2" fill="#17becf" />
-<circle cx="298.15" cy="134.07" r="2" fill="#17becf" />
-<circle cx="306.00" cy="130.25" r="2" fill="#17becf" />
-<circle cx="313.85" cy="126.42" r="2" fill="#17becf" />
-<circle cx="321.69" cy="122.59" r="2" fill="#17becf" />
-<circle cx="329.54" cy="118.76" r="2" fill="#17becf" />
-<circle cx="337.38" cy="114.93" r="2" fill="#17becf" />
-<circle cx="345.23" cy="111.10" r="2" fill="#17becf" />
-<circle cx="353.08" cy="107.28" r="2" fill="#17becf" />
-<circle cx="360.92" cy="103.45" r="2" fill="#17becf" />
-<circle cx="368.77" cy="99.42" r="2" fill="#17becf" />
-<circle cx="376.62" cy="95.33" r="2" fill="#17becf" />
-<circle cx="384.46" cy="91.24" r="2" fill="#17becf" />
-<circle cx="392.31" cy="87.16" r="2" fill="#17becf" />
-<circle cx="400.15" cy="83.08" r="2" fill="#17becf" />
-<circle cx="408.00" cy="79.51" r="2" fill="#17becf" />
-<circle cx="415.85" cy="75.94" r="2" fill="#17becf" />
-<circle cx="423.69" cy="72.37" r="2" fill="#17becf" />
-<circle cx="431.54" cy="68.81" r="2" fill="#17becf" />
-<circle cx="439.38" cy="65.24" r="2" fill="#17becf" />
-<circle cx="447.23" cy="61.67" r="2" fill="#17becf" />
-<circle cx="455.08" cy="58.10" r="2" fill="#17becf" />
-<circle cx="462.92" cy="54.54" r="2" fill="#17becf" />
-<circle cx="470.77" cy="50.97" r="2" fill="#17becf" />
-<circle cx="478.62" cy="47.40" r="2" fill="#17becf" />
-<circle cx="486.46" cy="43.84" r="2" fill="#17becf" />
-<circle cx="494.31" cy="40.27" r="2" fill="#17becf" />
-<circle cx="502.15" cy="36.70" r="2" fill="#17becf" />
-<circle cx="510.00" cy="33.13" r="2" fill="#17becf" />
-<rect x="528" y="0" width="14" height="3" fill="#1f77b4" />
-<text x="550" y="6" fill="#222" font-size="12">2012</text>
-<rect x="528" y="22" width="14" height="3" fill="#d62728" />
-<text x="550" y="28" fill="#222" font-size="12">2015</text>
-<rect x="528" y="44" width="14" height="3" fill="#2ca02c" />
-<text x="550" y="50" fill="#222" font-size="12">2018</text>
-<rect x="528" y="66" width="14" height="3" fill="#9467bd" />
-<text x="550" y="72" fill="#222" font-size="12">2022</text>
-<rect x="528" y="88" width="14" height="3" fill="#ff7f0e" />
-<text x="550" y="94" fill="#222" font-size="12">2024</text>
-<rect x="528" y="110" width="14" height="3" fill="#17becf" />
-<text x="550" y="116" fill="#222" font-size="12">2026</text>
+<line x1="0" y1="246.59" x2="510" y2="246.59" stroke="var(--c-grid)" stroke-width="1" />
+<line x1="0" y1="181.60" x2="510" y2="181.60" stroke="var(--c-grid)" stroke-width="1" />
+<line x1="0" y1="116.61" x2="510" y2="116.61" stroke="var(--c-grid)" stroke-width="1" />
+<line x1="0" y1="51.62" x2="510" y2="51.62" stroke="var(--c-grid)" stroke-width="1" />
+<line x1="0" y1="300" x2="510" y2="300" stroke="var(--c-axis)" stroke-width="1" />
+<line x1="0" y1="0" x2="0" y2="300" stroke="var(--c-axis)" stroke-width="1" />
+<line x1="39.23" y1="300" x2="39.23" y2="305" stroke="var(--c-axis)" stroke-width="1" />
+<text x="39.23" y="322" text-anchor="middle" fill="var(--c-text)">20k €</text>
+<line x1="117.69" y1="300" x2="117.69" y2="305" stroke="var(--c-axis)" stroke-width="1" />
+<text x="117.69" y="322" text-anchor="middle" fill="var(--c-text)">30k €</text>
+<line x1="196.15" y1="300" x2="196.15" y2="305" stroke="var(--c-axis)" stroke-width="1" />
+<text x="196.15" y="322" text-anchor="middle" fill="var(--c-text)">40k €</text>
+<line x1="274.62" y1="300" x2="274.62" y2="305" stroke="var(--c-axis)" stroke-width="1" />
+<text x="274.62" y="322" text-anchor="middle" fill="var(--c-text)">50k €</text>
+<line x1="353.08" y1="300" x2="353.08" y2="305" stroke="var(--c-axis)" stroke-width="1" />
+<text x="353.08" y="322" text-anchor="middle" fill="var(--c-text)">60k €</text>
+<line x1="431.54" y1="300" x2="431.54" y2="305" stroke="var(--c-axis)" stroke-width="1" />
+<text x="431.54" y="322" text-anchor="middle" fill="var(--c-text)">70k €</text>
+<line x1="510.00" y1="300" x2="510.00" y2="305" stroke="var(--c-axis)" stroke-width="1" />
+<text x="510.00" y="322" text-anchor="middle" fill="var(--c-text)">80k €</text>
+<line x1="-5" y1="246.59" x2="0" y2="246.59" stroke="var(--c-axis)" stroke-width="1" />
+<text x="-10" y="250.59" text-anchor="end" fill="var(--c-text)">20k €</text>
+<line x1="-5" y1="181.60" x2="0" y2="181.60" stroke="var(--c-axis)" stroke-width="1" />
+<text x="-10" y="185.60" text-anchor="end" fill="var(--c-text)">30k €</text>
+<line x1="-5" y1="116.61" x2="0" y2="116.61" stroke="var(--c-axis)" stroke-width="1" />
+<text x="-10" y="120.61" text-anchor="end" fill="var(--c-text)">40k €</text>
+<line x1="-5" y1="51.62" x2="0" y2="51.62" stroke="var(--c-axis)" stroke-width="1" />
+<text x="-10" y="55.62" text-anchor="end" fill="var(--c-text)">50k €</text>
+<text x="255" y="348" text-anchor="middle" fill="var(--c-title)" font-size="13">Bruto en € de 2026</text>
+<text transform="translate(-55,150) rotate(-90)" text-anchor="middle" fill="var(--c-title)" font-size="13">Neto en € de 2026</text>
+<polyline points="0.00,286.36 7.85,283.07 15.69,279.78 23.54,276.49 31.38,273.12 39.23,268.54 47.08,263.96 54.92,259.38 62.77,254.80 70.62,250.22 78.46,245.64 86.31,241.06 94.15,236.48 102.00,231.90 109.85,227.50 117.69,223.24 125.54,218.97 133.38,214.71 141.23,210.45 149.08,206.19 156.92,201.93 164.77,197.67 172.62,193.41 180.46,189.15 188.31,184.89 196.15,180.63 204.00,176.37 211.85,172.11 219.69,167.85 227.54,163.59 235.38,159.33 243.23,155.07 251.08,150.81 258.92,146.54 266.77,142.28 274.62,138.12 282.46,134.47 290.31,130.63 298.15,126.73 306.00,122.83 313.85,118.93 321.69,115.03 329.54,111.13 337.38,107.23 345.23,103.33 353.08,99.43 360.92,95.53 368.77,91.63 376.62,87.73 384.46,83.83 392.31,79.93 400.15,76.03 408.00,72.13 415.85,68.24 423.69,64.34 431.54,60.44 439.38,56.54 447.23,52.64 455.08,48.74 462.92,44.84 470.77,40.94 478.62,37.04 486.46,33.30 494.31,29.86 502.15,26.41 510.00,22.97" fill="none" stroke="var(--c-s0)" stroke-width="2" stroke-linejoin="round" stroke-linecap="round" />
+<circle cx="0.00" cy="286.36" r="2" fill="var(--c-s0)" />
+<circle cx="7.85" cy="283.07" r="2" fill="var(--c-s0)" />
+<circle cx="15.69" cy="279.78" r="2" fill="var(--c-s0)" />
+<circle cx="23.54" cy="276.49" r="2" fill="var(--c-s0)" />
+<circle cx="31.38" cy="273.12" r="2" fill="var(--c-s0)" />
+<circle cx="39.23" cy="268.54" r="2" fill="var(--c-s0)" />
+<circle cx="47.08" cy="263.96" r="2" fill="var(--c-s0)" />
+<circle cx="54.92" cy="259.38" r="2" fill="var(--c-s0)" />
+<circle cx="62.77" cy="254.80" r="2" fill="var(--c-s0)" />
+<circle cx="70.62" cy="250.22" r="2" fill="var(--c-s0)" />
+<circle cx="78.46" cy="245.64" r="2" fill="var(--c-s0)" />
+<circle cx="86.31" cy="241.06" r="2" fill="var(--c-s0)" />
+<circle cx="94.15" cy="236.48" r="2" fill="var(--c-s0)" />
+<circle cx="102.00" cy="231.90" r="2" fill="var(--c-s0)" />
+<circle cx="109.85" cy="227.50" r="2" fill="var(--c-s0)" />
+<circle cx="117.69" cy="223.24" r="2" fill="var(--c-s0)" />
+<circle cx="125.54" cy="218.97" r="2" fill="var(--c-s0)" />
+<circle cx="133.38" cy="214.71" r="2" fill="var(--c-s0)" />
+<circle cx="141.23" cy="210.45" r="2" fill="var(--c-s0)" />
+<circle cx="149.08" cy="206.19" r="2" fill="var(--c-s0)" />
+<circle cx="156.92" cy="201.93" r="2" fill="var(--c-s0)" />
+<circle cx="164.77" cy="197.67" r="2" fill="var(--c-s0)" />
+<circle cx="172.62" cy="193.41" r="2" fill="var(--c-s0)" />
+<circle cx="180.46" cy="189.15" r="2" fill="var(--c-s0)" />
+<circle cx="188.31" cy="184.89" r="2" fill="var(--c-s0)" />
+<circle cx="196.15" cy="180.63" r="2" fill="var(--c-s0)" />
+<circle cx="204.00" cy="176.37" r="2" fill="var(--c-s0)" />
+<circle cx="211.85" cy="172.11" r="2" fill="var(--c-s0)" />
+<circle cx="219.69" cy="167.85" r="2" fill="var(--c-s0)" />
+<circle cx="227.54" cy="163.59" r="2" fill="var(--c-s0)" />
+<circle cx="235.38" cy="159.33" r="2" fill="var(--c-s0)" />
+<circle cx="243.23" cy="155.07" r="2" fill="var(--c-s0)" />
+<circle cx="251.08" cy="150.81" r="2" fill="var(--c-s0)" />
+<circle cx="258.92" cy="146.54" r="2" fill="var(--c-s0)" />
+<circle cx="266.77" cy="142.28" r="2" fill="var(--c-s0)" />
+<circle cx="274.62" cy="138.12" r="2" fill="var(--c-s0)" />
+<circle cx="282.46" cy="134.47" r="2" fill="var(--c-s0)" />
+<circle cx="290.31" cy="130.63" r="2" fill="var(--c-s0)" />
+<circle cx="298.15" cy="126.73" r="2" fill="var(--c-s0)" />
+<circle cx="306.00" cy="122.83" r="2" fill="var(--c-s0)" />
+<circle cx="313.85" cy="118.93" r="2" fill="var(--c-s0)" />
+<circle cx="321.69" cy="115.03" r="2" fill="var(--c-s0)" />
+<circle cx="329.54" cy="111.13" r="2" fill="var(--c-s0)" />
+<circle cx="337.38" cy="107.23" r="2" fill="var(--c-s0)" />
+<circle cx="345.23" cy="103.33" r="2" fill="var(--c-s0)" />
+<circle cx="353.08" cy="99.43" r="2" fill="var(--c-s0)" />
+<circle cx="360.92" cy="95.53" r="2" fill="var(--c-s0)" />
+<circle cx="368.77" cy="91.63" r="2" fill="var(--c-s0)" />
+<circle cx="376.62" cy="87.73" r="2" fill="var(--c-s0)" />
+<circle cx="384.46" cy="83.83" r="2" fill="var(--c-s0)" />
+<circle cx="392.31" cy="79.93" r="2" fill="var(--c-s0)" />
+<circle cx="400.15" cy="76.03" r="2" fill="var(--c-s0)" />
+<circle cx="408.00" cy="72.13" r="2" fill="var(--c-s0)" />
+<circle cx="415.85" cy="68.24" r="2" fill="var(--c-s0)" />
+<circle cx="423.69" cy="64.34" r="2" fill="var(--c-s0)" />
+<circle cx="431.54" cy="60.44" r="2" fill="var(--c-s0)" />
+<circle cx="439.38" cy="56.54" r="2" fill="var(--c-s0)" />
+<circle cx="447.23" cy="52.64" r="2" fill="var(--c-s0)" />
+<circle cx="455.08" cy="48.74" r="2" fill="var(--c-s0)" />
+<circle cx="462.92" cy="44.84" r="2" fill="var(--c-s0)" />
+<circle cx="470.77" cy="40.94" r="2" fill="var(--c-s0)" />
+<circle cx="478.62" cy="37.04" r="2" fill="var(--c-s0)" />
+<circle cx="486.46" cy="33.30" r="2" fill="var(--c-s0)" />
+<circle cx="494.31" cy="29.86" r="2" fill="var(--c-s0)" />
+<circle cx="502.15" cy="26.41" r="2" fill="var(--c-s0)" />
+<circle cx="510.00" cy="22.97" r="2" fill="var(--c-s0)" />
+<polyline points="0.00,285.28 7.85,279.61 15.69,276.08 23.54,272.55 31.38,269.03 39.23,265.50 47.08,261.27 54.92,256.68 62.77,252.08 70.62,247.48 78.46,242.89 86.31,238.29 94.15,233.70 102.00,229.10 109.85,224.51 117.69,219.91 125.54,215.32 133.38,210.99 141.23,206.76 149.08,202.53 156.92,198.30 164.77,194.07 172.62,189.84 180.46,185.61 188.31,181.38 196.15,177.15 204.00,172.92 211.85,168.69 219.69,164.46 227.54,160.23 235.38,156.00 243.23,151.77 251.08,147.54 258.92,143.31 266.77,139.08 274.62,134.85 282.46,130.77 290.31,126.99 298.15,123.22 306.00,119.45 313.85,115.67 321.69,111.90 329.54,108.13 337.38,104.11 345.23,100.08 353.08,96.05 360.92,92.02 368.77,87.99 376.62,83.96 384.46,79.93 392.31,75.90 400.15,71.87 408.00,67.84 415.85,63.81 423.69,59.78 431.54,55.75 439.38,51.73 447.23,47.70 455.08,43.67 462.92,39.64 470.77,35.61 478.62,31.58 486.46,27.55 494.31,23.52 502.15,19.49 510.00,15.46" fill="none" stroke="var(--c-s1)" stroke-width="2" stroke-linejoin="round" stroke-linecap="round" />
+<circle cx="0.00" cy="285.28" r="2" fill="var(--c-s1)" />
+<circle cx="7.85" cy="279.61" r="2" fill="var(--c-s1)" />
+<circle cx="15.69" cy="276.08" r="2" fill="var(--c-s1)" />
+<circle cx="23.54" cy="272.55" r="2" fill="var(--c-s1)" />
+<circle cx="31.38" cy="269.03" r="2" fill="var(--c-s1)" />
+<circle cx="39.23" cy="265.50" r="2" fill="var(--c-s1)" />
+<circle cx="47.08" cy="261.27" r="2" fill="var(--c-s1)" />
+<circle cx="54.92" cy="256.68" r="2" fill="var(--c-s1)" />
+<circle cx="62.77" cy="252.08" r="2" fill="var(--c-s1)" />
+<circle cx="70.62" cy="247.48" r="2" fill="var(--c-s1)" />
+<circle cx="78.46" cy="242.89" r="2" fill="var(--c-s1)" />
+<circle cx="86.31" cy="238.29" r="2" fill="var(--c-s1)" />
+<circle cx="94.15" cy="233.70" r="2" fill="var(--c-s1)" />
+<circle cx="102.00" cy="229.10" r="2" fill="var(--c-s1)" />
+<circle cx="109.85" cy="224.51" r="2" fill="var(--c-s1)" />
+<circle cx="117.69" cy="219.91" r="2" fill="var(--c-s1)" />
+<circle cx="125.54" cy="215.32" r="2" fill="var(--c-s1)" />
+<circle cx="133.38" cy="210.99" r="2" fill="var(--c-s1)" />
+<circle cx="141.23" cy="206.76" r="2" fill="var(--c-s1)" />
+<circle cx="149.08" cy="202.53" r="2" fill="var(--c-s1)" />
+<circle cx="156.92" cy="198.30" r="2" fill="var(--c-s1)" />
+<circle cx="164.77" cy="194.07" r="2" fill="var(--c-s1)" />
+<circle cx="172.62" cy="189.84" r="2" fill="var(--c-s1)" />
+<circle cx="180.46" cy="185.61" r="2" fill="var(--c-s1)" />
+<circle cx="188.31" cy="181.38" r="2" fill="var(--c-s1)" />
+<circle cx="196.15" cy="177.15" r="2" fill="var(--c-s1)" />
+<circle cx="204.00" cy="172.92" r="2" fill="var(--c-s1)" />
+<circle cx="211.85" cy="168.69" r="2" fill="var(--c-s1)" />
+<circle cx="219.69" cy="164.46" r="2" fill="var(--c-s1)" />
+<circle cx="227.54" cy="160.23" r="2" fill="var(--c-s1)" />
+<circle cx="235.38" cy="156.00" r="2" fill="var(--c-s1)" />
+<circle cx="243.23" cy="151.77" r="2" fill="var(--c-s1)" />
+<circle cx="251.08" cy="147.54" r="2" fill="var(--c-s1)" />
+<circle cx="258.92" cy="143.31" r="2" fill="var(--c-s1)" />
+<circle cx="266.77" cy="139.08" r="2" fill="var(--c-s1)" />
+<circle cx="274.62" cy="134.85" r="2" fill="var(--c-s1)" />
+<circle cx="282.46" cy="130.77" r="2" fill="var(--c-s1)" />
+<circle cx="290.31" cy="126.99" r="2" fill="var(--c-s1)" />
+<circle cx="298.15" cy="123.22" r="2" fill="var(--c-s1)" />
+<circle cx="306.00" cy="119.45" r="2" fill="var(--c-s1)" />
+<circle cx="313.85" cy="115.67" r="2" fill="var(--c-s1)" />
+<circle cx="321.69" cy="111.90" r="2" fill="var(--c-s1)" />
+<circle cx="329.54" cy="108.13" r="2" fill="var(--c-s1)" />
+<circle cx="337.38" cy="104.11" r="2" fill="var(--c-s1)" />
+<circle cx="345.23" cy="100.08" r="2" fill="var(--c-s1)" />
+<circle cx="353.08" cy="96.05" r="2" fill="var(--c-s1)" />
+<circle cx="360.92" cy="92.02" r="2" fill="var(--c-s1)" />
+<circle cx="368.77" cy="87.99" r="2" fill="var(--c-s1)" />
+<circle cx="376.62" cy="83.96" r="2" fill="var(--c-s1)" />
+<circle cx="384.46" cy="79.93" r="2" fill="var(--c-s1)" />
+<circle cx="392.31" cy="75.90" r="2" fill="var(--c-s1)" />
+<circle cx="400.15" cy="71.87" r="2" fill="var(--c-s1)" />
+<circle cx="408.00" cy="67.84" r="2" fill="var(--c-s1)" />
+<circle cx="415.85" cy="63.81" r="2" fill="var(--c-s1)" />
+<circle cx="423.69" cy="59.78" r="2" fill="var(--c-s1)" />
+<circle cx="431.54" cy="55.75" r="2" fill="var(--c-s1)" />
+<circle cx="439.38" cy="51.73" r="2" fill="var(--c-s1)" />
+<circle cx="447.23" cy="47.70" r="2" fill="var(--c-s1)" />
+<circle cx="455.08" cy="43.67" r="2" fill="var(--c-s1)" />
+<circle cx="462.92" cy="39.64" r="2" fill="var(--c-s1)" />
+<circle cx="470.77" cy="35.61" r="2" fill="var(--c-s1)" />
+<circle cx="478.62" cy="31.58" r="2" fill="var(--c-s1)" />
+<circle cx="486.46" cy="27.55" r="2" fill="var(--c-s1)" />
+<circle cx="494.31" cy="23.52" r="2" fill="var(--c-s1)" />
+<circle cx="502.15" cy="19.49" r="2" fill="var(--c-s1)" />
+<circle cx="510.00" cy="15.46" r="2" fill="var(--c-s1)" />
+<polyline points="0.00,285.28 7.85,279.19 15.69,274.87 23.54,270.81 31.38,267.42 39.23,263.74 47.08,259.70 54.92,256.17 62.77,252.41 70.62,247.78 78.46,243.15 86.31,238.53 94.15,233.90 102.00,229.28 109.85,224.65 117.69,220.03 125.54,215.74 133.38,211.48 141.23,207.22 149.08,202.96 156.92,198.70 164.77,194.44 172.62,190.18 180.46,185.92 188.31,181.66 196.15,177.40 204.00,173.14 211.85,168.87 219.69,164.61 227.54,160.35 235.38,156.09 243.23,151.83 251.08,147.57 258.92,143.31 266.77,139.05 274.62,134.79 282.46,130.79 290.31,126.96 298.15,123.12 306.00,119.29 313.85,115.46 321.69,111.62 329.54,107.79 337.38,103.72 345.23,99.62 353.08,95.53 360.92,91.43 368.77,87.34 376.62,83.24 384.46,79.15 392.31,75.05 400.15,70.96 408.00,66.87 415.85,62.77 423.69,58.68 431.54,54.58 439.38,50.49 447.23,46.39 455.08,42.30 462.92,38.20 470.77,34.11 478.62,30.01 486.46,25.92 494.31,21.83 502.15,17.73 510.00,13.64" fill="none" stroke="var(--c-s2)" stroke-width="2" stroke-linejoin="round" stroke-linecap="round" />
+<circle cx="0.00" cy="285.28" r="2" fill="var(--c-s2)" />
+<circle cx="7.85" cy="279.19" r="2" fill="var(--c-s2)" />
+<circle cx="15.69" cy="274.87" r="2" fill="var(--c-s2)" />
+<circle cx="23.54" cy="270.81" r="2" fill="var(--c-s2)" />
+<circle cx="31.38" cy="267.42" r="2" fill="var(--c-s2)" />
+<circle cx="39.23" cy="263.74" r="2" fill="var(--c-s2)" />
+<circle cx="47.08" cy="259.70" r="2" fill="var(--c-s2)" />
+<circle cx="54.92" cy="256.17" r="2" fill="var(--c-s2)" />
+<circle cx="62.77" cy="252.41" r="2" fill="var(--c-s2)" />
+<circle cx="70.62" cy="247.78" r="2" fill="var(--c-s2)" />
+<circle cx="78.46" cy="243.15" r="2" fill="var(--c-s2)" />
+<circle cx="86.31" cy="238.53" r="2" fill="var(--c-s2)" />
+<circle cx="94.15" cy="233.90" r="2" fill="var(--c-s2)" />
+<circle cx="102.00" cy="229.28" r="2" fill="var(--c-s2)" />
+<circle cx="109.85" cy="224.65" r="2" fill="var(--c-s2)" />
+<circle cx="117.69" cy="220.03" r="2" fill="var(--c-s2)" />
+<circle cx="125.54" cy="215.74" r="2" fill="var(--c-s2)" />
+<circle cx="133.38" cy="211.48" r="2" fill="var(--c-s2)" />
+<circle cx="141.23" cy="207.22" r="2" fill="var(--c-s2)" />
+<circle cx="149.08" cy="202.96" r="2" fill="var(--c-s2)" />
+<circle cx="156.92" cy="198.70" r="2" fill="var(--c-s2)" />
+<circle cx="164.77" cy="194.44" r="2" fill="var(--c-s2)" />
+<circle cx="172.62" cy="190.18" r="2" fill="var(--c-s2)" />
+<circle cx="180.46" cy="185.92" r="2" fill="var(--c-s2)" />
+<circle cx="188.31" cy="181.66" r="2" fill="var(--c-s2)" />
+<circle cx="196.15" cy="177.40" r="2" fill="var(--c-s2)" />
+<circle cx="204.00" cy="173.14" r="2" fill="var(--c-s2)" />
+<circle cx="211.85" cy="168.87" r="2" fill="var(--c-s2)" />
+<circle cx="219.69" cy="164.61" r="2" fill="var(--c-s2)" />
+<circle cx="227.54" cy="160.35" r="2" fill="var(--c-s2)" />
+<circle cx="235.38" cy="156.09" r="2" fill="var(--c-s2)" />
+<circle cx="243.23" cy="151.83" r="2" fill="var(--c-s2)" />
+<circle cx="251.08" cy="147.57" r="2" fill="var(--c-s2)" />
+<circle cx="258.92" cy="143.31" r="2" fill="var(--c-s2)" />
+<circle cx="266.77" cy="139.05" r="2" fill="var(--c-s2)" />
+<circle cx="274.62" cy="134.79" r="2" fill="var(--c-s2)" />
+<circle cx="282.46" cy="130.79" r="2" fill="var(--c-s2)" />
+<circle cx="290.31" cy="126.96" r="2" fill="var(--c-s2)" />
+<circle cx="298.15" cy="123.12" r="2" fill="var(--c-s2)" />
+<circle cx="306.00" cy="119.29" r="2" fill="var(--c-s2)" />
+<circle cx="313.85" cy="115.46" r="2" fill="var(--c-s2)" />
+<circle cx="321.69" cy="111.62" r="2" fill="var(--c-s2)" />
+<circle cx="329.54" cy="107.79" r="2" fill="var(--c-s2)" />
+<circle cx="337.38" cy="103.72" r="2" fill="var(--c-s2)" />
+<circle cx="345.23" cy="99.62" r="2" fill="var(--c-s2)" />
+<circle cx="353.08" cy="95.53" r="2" fill="var(--c-s2)" />
+<circle cx="360.92" cy="91.43" r="2" fill="var(--c-s2)" />
+<circle cx="368.77" cy="87.34" r="2" fill="var(--c-s2)" />
+<circle cx="376.62" cy="83.24" r="2" fill="var(--c-s2)" />
+<circle cx="384.46" cy="79.15" r="2" fill="var(--c-s2)" />
+<circle cx="392.31" cy="75.05" r="2" fill="var(--c-s2)" />
+<circle cx="400.15" cy="70.96" r="2" fill="var(--c-s2)" />
+<circle cx="408.00" cy="66.87" r="2" fill="var(--c-s2)" />
+<circle cx="415.85" cy="62.77" r="2" fill="var(--c-s2)" />
+<circle cx="423.69" cy="58.68" r="2" fill="var(--c-s2)" />
+<circle cx="431.54" cy="54.58" r="2" fill="var(--c-s2)" />
+<circle cx="439.38" cy="50.49" r="2" fill="var(--c-s2)" />
+<circle cx="447.23" cy="46.39" r="2" fill="var(--c-s2)" />
+<circle cx="455.08" cy="42.30" r="2" fill="var(--c-s2)" />
+<circle cx="462.92" cy="38.20" r="2" fill="var(--c-s2)" />
+<circle cx="470.77" cy="34.11" r="2" fill="var(--c-s2)" />
+<circle cx="478.62" cy="30.01" r="2" fill="var(--c-s2)" />
+<circle cx="486.46" cy="25.92" r="2" fill="var(--c-s2)" />
+<circle cx="494.31" cy="21.83" r="2" fill="var(--c-s2)" />
+<circle cx="502.15" cy="17.73" r="2" fill="var(--c-s2)" />
+<circle cx="510.00" cy="13.64" r="2" fill="var(--c-s2)" />
+<polyline points="0.00,285.28 7.85,279.96 15.69,276.67 23.54,273.37 31.38,270.08 39.23,266.79 47.08,263.50 54.92,259.06 62.77,254.44 70.62,249.81 78.46,245.19 86.31,240.56 94.15,236.07 102.00,231.81 109.85,227.55 117.69,223.29 125.54,219.03 133.38,214.77 141.23,210.51 149.08,206.25 156.92,201.99 164.77,197.72 172.62,193.46 180.46,189.20 188.31,184.94 196.15,180.68 204.00,176.42 211.85,172.16 219.69,167.90 227.54,163.64 235.38,159.54 243.23,155.71 251.08,151.87 258.92,148.04 266.77,144.20 274.62,140.37 282.46,136.53 290.31,132.70 298.15,128.86 306.00,125.03 313.85,121.20 321.69,117.31 329.54,113.21 337.38,109.12 345.23,105.03 353.08,100.93 360.92,96.84 368.77,92.74 376.62,88.65 384.46,84.55 392.31,80.46 400.15,76.36 408.00,72.27 415.85,68.17 423.69,64.08 431.54,59.99 439.38,55.89 447.23,51.80 455.08,47.70 462.92,44.03 470.77,40.45 478.62,36.88 486.46,33.31 494.31,29.73 502.15,26.16 510.00,22.58" fill="none" stroke="var(--c-s3)" stroke-width="2" stroke-linejoin="round" stroke-linecap="round" />
+<circle cx="0.00" cy="285.28" r="2" fill="var(--c-s3)" />
+<circle cx="7.85" cy="279.96" r="2" fill="var(--c-s3)" />
+<circle cx="15.69" cy="276.67" r="2" fill="var(--c-s3)" />
+<circle cx="23.54" cy="273.37" r="2" fill="var(--c-s3)" />
+<circle cx="31.38" cy="270.08" r="2" fill="var(--c-s3)" />
+<circle cx="39.23" cy="266.79" r="2" fill="var(--c-s3)" />
+<circle cx="47.08" cy="263.50" r="2" fill="var(--c-s3)" />
+<circle cx="54.92" cy="259.06" r="2" fill="var(--c-s3)" />
+<circle cx="62.77" cy="254.44" r="2" fill="var(--c-s3)" />
+<circle cx="70.62" cy="249.81" r="2" fill="var(--c-s3)" />
+<circle cx="78.46" cy="245.19" r="2" fill="var(--c-s3)" />
+<circle cx="86.31" cy="240.56" r="2" fill="var(--c-s3)" />
+<circle cx="94.15" cy="236.07" r="2" fill="var(--c-s3)" />
+<circle cx="102.00" cy="231.81" r="2" fill="var(--c-s3)" />
+<circle cx="109.85" cy="227.55" r="2" fill="var(--c-s3)" />
+<circle cx="117.69" cy="223.29" r="2" fill="var(--c-s3)" />
+<circle cx="125.54" cy="219.03" r="2" fill="var(--c-s3)" />
+<circle cx="133.38" cy="214.77" r="2" fill="var(--c-s3)" />
+<circle cx="141.23" cy="210.51" r="2" fill="var(--c-s3)" />
+<circle cx="149.08" cy="206.25" r="2" fill="var(--c-s3)" />
+<circle cx="156.92" cy="201.99" r="2" fill="var(--c-s3)" />
+<circle cx="164.77" cy="197.72" r="2" fill="var(--c-s3)" />
+<circle cx="172.62" cy="193.46" r="2" fill="var(--c-s3)" />
+<circle cx="180.46" cy="189.20" r="2" fill="var(--c-s3)" />
+<circle cx="188.31" cy="184.94" r="2" fill="var(--c-s3)" />
+<circle cx="196.15" cy="180.68" r="2" fill="var(--c-s3)" />
+<circle cx="204.00" cy="176.42" r="2" fill="var(--c-s3)" />
+<circle cx="211.85" cy="172.16" r="2" fill="var(--c-s3)" />
+<circle cx="219.69" cy="167.90" r="2" fill="var(--c-s3)" />
+<circle cx="227.54" cy="163.64" r="2" fill="var(--c-s3)" />
+<circle cx="235.38" cy="159.54" r="2" fill="var(--c-s3)" />
+<circle cx="243.23" cy="155.71" r="2" fill="var(--c-s3)" />
+<circle cx="251.08" cy="151.87" r="2" fill="var(--c-s3)" />
+<circle cx="258.92" cy="148.04" r="2" fill="var(--c-s3)" />
+<circle cx="266.77" cy="144.20" r="2" fill="var(--c-s3)" />
+<circle cx="274.62" cy="140.37" r="2" fill="var(--c-s3)" />
+<circle cx="282.46" cy="136.53" r="2" fill="var(--c-s3)" />
+<circle cx="290.31" cy="132.70" r="2" fill="var(--c-s3)" />
+<circle cx="298.15" cy="128.86" r="2" fill="var(--c-s3)" />
+<circle cx="306.00" cy="125.03" r="2" fill="var(--c-s3)" />
+<circle cx="313.85" cy="121.20" r="2" fill="var(--c-s3)" />
+<circle cx="321.69" cy="117.31" r="2" fill="var(--c-s3)" />
+<circle cx="329.54" cy="113.21" r="2" fill="var(--c-s3)" />
+<circle cx="337.38" cy="109.12" r="2" fill="var(--c-s3)" />
+<circle cx="345.23" cy="105.03" r="2" fill="var(--c-s3)" />
+<circle cx="353.08" cy="100.93" r="2" fill="var(--c-s3)" />
+<circle cx="360.92" cy="96.84" r="2" fill="var(--c-s3)" />
+<circle cx="368.77" cy="92.74" r="2" fill="var(--c-s3)" />
+<circle cx="376.62" cy="88.65" r="2" fill="var(--c-s3)" />
+<circle cx="384.46" cy="84.55" r="2" fill="var(--c-s3)" />
+<circle cx="392.31" cy="80.46" r="2" fill="var(--c-s3)" />
+<circle cx="400.15" cy="76.36" r="2" fill="var(--c-s3)" />
+<circle cx="408.00" cy="72.27" r="2" fill="var(--c-s3)" />
+<circle cx="415.85" cy="68.17" r="2" fill="var(--c-s3)" />
+<circle cx="423.69" cy="64.08" r="2" fill="var(--c-s3)" />
+<circle cx="431.54" cy="59.99" r="2" fill="var(--c-s3)" />
+<circle cx="439.38" cy="55.89" r="2" fill="var(--c-s3)" />
+<circle cx="447.23" cy="51.80" r="2" fill="var(--c-s3)" />
+<circle cx="455.08" cy="47.70" r="2" fill="var(--c-s3)" />
+<circle cx="462.92" cy="44.03" r="2" fill="var(--c-s3)" />
+<circle cx="470.77" cy="40.45" r="2" fill="var(--c-s3)" />
+<circle cx="478.62" cy="36.88" r="2" fill="var(--c-s3)" />
+<circle cx="486.46" cy="33.31" r="2" fill="var(--c-s3)" />
+<circle cx="494.31" cy="29.73" r="2" fill="var(--c-s3)" />
+<circle cx="502.15" cy="26.16" r="2" fill="var(--c-s3)" />
+<circle cx="510.00" cy="22.58" r="2" fill="var(--c-s3)" />
+<polyline points="0.00,285.40 7.85,279.32 15.69,273.72 23.54,270.44 31.38,267.16 39.23,263.87 47.08,260.59 54.92,257.30 62.77,254.02 70.62,250.74 78.46,246.22 86.31,241.91 94.15,237.66 102.00,233.40 109.85,229.15 117.69,224.89 125.54,220.64 133.38,216.38 141.23,212.13 149.08,207.87 156.92,203.62 164.77,199.36 172.62,195.11 180.46,190.85 188.31,186.59 196.15,182.34 204.00,178.08 211.85,173.83 219.69,169.93 227.54,166.10 235.38,162.27 243.23,158.45 251.08,154.62 258.92,150.79 266.77,146.96 274.62,143.13 282.46,139.30 290.31,135.47 298.15,131.64 306.00,127.81 313.85,123.98 321.69,120.15 329.54,116.32 337.38,112.49 345.23,108.66 353.08,104.83 360.92,100.75 368.77,96.65 376.62,92.56 384.46,88.46 392.31,84.37 400.15,80.27 408.00,76.18 415.85,72.08 423.69,67.99 431.54,64.11 439.38,60.53 447.23,56.96 455.08,53.38 462.92,49.81 470.77,46.23 478.62,42.66 486.46,39.08 494.31,35.51 502.15,31.93 510.00,28.36" fill="none" stroke="var(--c-s4)" stroke-width="2" stroke-linejoin="round" stroke-linecap="round" />
+<circle cx="0.00" cy="285.40" r="2" fill="var(--c-s4)" />
+<circle cx="7.85" cy="279.32" r="2" fill="var(--c-s4)" />
+<circle cx="15.69" cy="273.72" r="2" fill="var(--c-s4)" />
+<circle cx="23.54" cy="270.44" r="2" fill="var(--c-s4)" />
+<circle cx="31.38" cy="267.16" r="2" fill="var(--c-s4)" />
+<circle cx="39.23" cy="263.87" r="2" fill="var(--c-s4)" />
+<circle cx="47.08" cy="260.59" r="2" fill="var(--c-s4)" />
+<circle cx="54.92" cy="257.30" r="2" fill="var(--c-s4)" />
+<circle cx="62.77" cy="254.02" r="2" fill="var(--c-s4)" />
+<circle cx="70.62" cy="250.74" r="2" fill="var(--c-s4)" />
+<circle cx="78.46" cy="246.22" r="2" fill="var(--c-s4)" />
+<circle cx="86.31" cy="241.91" r="2" fill="var(--c-s4)" />
+<circle cx="94.15" cy="237.66" r="2" fill="var(--c-s4)" />
+<circle cx="102.00" cy="233.40" r="2" fill="var(--c-s4)" />
+<circle cx="109.85" cy="229.15" r="2" fill="var(--c-s4)" />
+<circle cx="117.69" cy="224.89" r="2" fill="var(--c-s4)" />
+<circle cx="125.54" cy="220.64" r="2" fill="var(--c-s4)" />
+<circle cx="133.38" cy="216.38" r="2" fill="var(--c-s4)" />
+<circle cx="141.23" cy="212.13" r="2" fill="var(--c-s4)" />
+<circle cx="149.08" cy="207.87" r="2" fill="var(--c-s4)" />
+<circle cx="156.92" cy="203.62" r="2" fill="var(--c-s4)" />
+<circle cx="164.77" cy="199.36" r="2" fill="var(--c-s4)" />
+<circle cx="172.62" cy="195.11" r="2" fill="var(--c-s4)" />
+<circle cx="180.46" cy="190.85" r="2" fill="var(--c-s4)" />
+<circle cx="188.31" cy="186.59" r="2" fill="var(--c-s4)" />
+<circle cx="196.15" cy="182.34" r="2" fill="var(--c-s4)" />
+<circle cx="204.00" cy="178.08" r="2" fill="var(--c-s4)" />
+<circle cx="211.85" cy="173.83" r="2" fill="var(--c-s4)" />
+<circle cx="219.69" cy="169.93" r="2" fill="var(--c-s4)" />
+<circle cx="227.54" cy="166.10" r="2" fill="var(--c-s4)" />
+<circle cx="235.38" cy="162.27" r="2" fill="var(--c-s4)" />
+<circle cx="243.23" cy="158.45" r="2" fill="var(--c-s4)" />
+<circle cx="251.08" cy="154.62" r="2" fill="var(--c-s4)" />
+<circle cx="258.92" cy="150.79" r="2" fill="var(--c-s4)" />
+<circle cx="266.77" cy="146.96" r="2" fill="var(--c-s4)" />
+<circle cx="274.62" cy="143.13" r="2" fill="var(--c-s4)" />
+<circle cx="282.46" cy="139.30" r="2" fill="var(--c-s4)" />
+<circle cx="290.31" cy="135.47" r="2" fill="var(--c-s4)" />
+<circle cx="298.15" cy="131.64" r="2" fill="var(--c-s4)" />
+<circle cx="306.00" cy="127.81" r="2" fill="var(--c-s4)" />
+<circle cx="313.85" cy="123.98" r="2" fill="var(--c-s4)" />
+<circle cx="321.69" cy="120.15" r="2" fill="var(--c-s4)" />
+<circle cx="329.54" cy="116.32" r="2" fill="var(--c-s4)" />
+<circle cx="337.38" cy="112.49" r="2" fill="var(--c-s4)" />
+<circle cx="345.23" cy="108.66" r="2" fill="var(--c-s4)" />
+<circle cx="353.08" cy="104.83" r="2" fill="var(--c-s4)" />
+<circle cx="360.92" cy="100.75" r="2" fill="var(--c-s4)" />
+<circle cx="368.77" cy="96.65" r="2" fill="var(--c-s4)" />
+<circle cx="376.62" cy="92.56" r="2" fill="var(--c-s4)" />
+<circle cx="384.46" cy="88.46" r="2" fill="var(--c-s4)" />
+<circle cx="392.31" cy="84.37" r="2" fill="var(--c-s4)" />
+<circle cx="400.15" cy="80.27" r="2" fill="var(--c-s4)" />
+<circle cx="408.00" cy="76.18" r="2" fill="var(--c-s4)" />
+<circle cx="415.85" cy="72.08" r="2" fill="var(--c-s4)" />
+<circle cx="423.69" cy="67.99" r="2" fill="var(--c-s4)" />
+<circle cx="431.54" cy="64.11" r="2" fill="var(--c-s4)" />
+<circle cx="439.38" cy="60.53" r="2" fill="var(--c-s4)" />
+<circle cx="447.23" cy="56.96" r="2" fill="var(--c-s4)" />
+<circle cx="455.08" cy="53.38" r="2" fill="var(--c-s4)" />
+<circle cx="462.92" cy="49.81" r="2" fill="var(--c-s4)" />
+<circle cx="470.77" cy="46.23" r="2" fill="var(--c-s4)" />
+<circle cx="478.62" cy="42.66" r="2" fill="var(--c-s4)" />
+<circle cx="486.46" cy="39.08" r="2" fill="var(--c-s4)" />
+<circle cx="494.31" cy="35.51" r="2" fill="var(--c-s4)" />
+<circle cx="502.15" cy="31.93" r="2" fill="var(--c-s4)" />
+<circle cx="510.00" cy="28.36" r="2" fill="var(--c-s4)" />
+<polyline points="0.00,285.43 7.85,279.35 15.69,273.27 23.54,271.25 31.38,269.85 39.23,266.57 47.08,263.29 54.92,260.00 62.77,256.34 70.62,251.81 78.46,247.56 86.31,243.30 94.15,239.05 102.00,234.80 109.85,230.54 117.69,226.29 125.54,222.04 133.38,217.78 141.23,213.53 149.08,209.27 156.92,205.02 164.77,200.77 172.62,196.51 180.46,192.26 188.31,188.01 196.15,183.84 204.00,180.01 211.85,176.19 219.69,172.36 227.54,168.53 235.38,164.70 243.23,160.87 251.08,157.04 258.92,153.22 266.77,149.39 274.62,145.56 282.46,141.73 290.31,137.90 298.15,134.07 306.00,130.25 313.85,126.42 321.69,122.59 329.54,118.76 337.38,114.93 345.23,111.10 353.08,107.28 360.92,103.45 368.77,99.42 376.62,95.33 384.46,91.24 392.31,87.16 400.15,83.08 408.00,79.51 415.85,75.94 423.69,72.37 431.54,68.81 439.38,65.24 447.23,61.67 455.08,58.10 462.92,54.54 470.77,50.97 478.62,47.40 486.46,43.84 494.31,40.27 502.15,36.70 510.00,33.13" fill="none" stroke="var(--c-s5)" stroke-width="2" stroke-linejoin="round" stroke-linecap="round" />
+<circle cx="0.00" cy="285.43" r="2" fill="var(--c-s5)" />
+<circle cx="7.85" cy="279.35" r="2" fill="var(--c-s5)" />
+<circle cx="15.69" cy="273.27" r="2" fill="var(--c-s5)" />
+<circle cx="23.54" cy="271.25" r="2" fill="var(--c-s5)" />
+<circle cx="31.38" cy="269.85" r="2" fill="var(--c-s5)" />
+<circle cx="39.23" cy="266.57" r="2" fill="var(--c-s5)" />
+<circle cx="47.08" cy="263.29" r="2" fill="var(--c-s5)" />
+<circle cx="54.92" cy="260.00" r="2" fill="var(--c-s5)" />
+<circle cx="62.77" cy="256.34" r="2" fill="var(--c-s5)" />
+<circle cx="70.62" cy="251.81" r="2" fill="var(--c-s5)" />
+<circle cx="78.46" cy="247.56" r="2" fill="var(--c-s5)" />
+<circle cx="86.31" cy="243.30" r="2" fill="var(--c-s5)" />
+<circle cx="94.15" cy="239.05" r="2" fill="var(--c-s5)" />
+<circle cx="102.00" cy="234.80" r="2" fill="var(--c-s5)" />
+<circle cx="109.85" cy="230.54" r="2" fill="var(--c-s5)" />
+<circle cx="117.69" cy="226.29" r="2" fill="var(--c-s5)" />
+<circle cx="125.54" cy="222.04" r="2" fill="var(--c-s5)" />
+<circle cx="133.38" cy="217.78" r="2" fill="var(--c-s5)" />
+<circle cx="141.23" cy="213.53" r="2" fill="var(--c-s5)" />
+<circle cx="149.08" cy="209.27" r="2" fill="var(--c-s5)" />
+<circle cx="156.92" cy="205.02" r="2" fill="var(--c-s5)" />
+<circle cx="164.77" cy="200.77" r="2" fill="var(--c-s5)" />
+<circle cx="172.62" cy="196.51" r="2" fill="var(--c-s5)" />
+<circle cx="180.46" cy="192.26" r="2" fill="var(--c-s5)" />
+<circle cx="188.31" cy="188.01" r="2" fill="var(--c-s5)" />
+<circle cx="196.15" cy="183.84" r="2" fill="var(--c-s5)" />
+<circle cx="204.00" cy="180.01" r="2" fill="var(--c-s5)" />
+<circle cx="211.85" cy="176.19" r="2" fill="var(--c-s5)" />
+<circle cx="219.69" cy="172.36" r="2" fill="var(--c-s5)" />
+<circle cx="227.54" cy="168.53" r="2" fill="var(--c-s5)" />
+<circle cx="235.38" cy="164.70" r="2" fill="var(--c-s5)" />
+<circle cx="243.23" cy="160.87" r="2" fill="var(--c-s5)" />
+<circle cx="251.08" cy="157.04" r="2" fill="var(--c-s5)" />
+<circle cx="258.92" cy="153.22" r="2" fill="var(--c-s5)" />
+<circle cx="266.77" cy="149.39" r="2" fill="var(--c-s5)" />
+<circle cx="274.62" cy="145.56" r="2" fill="var(--c-s5)" />
+<circle cx="282.46" cy="141.73" r="2" fill="var(--c-s5)" />
+<circle cx="290.31" cy="137.90" r="2" fill="var(--c-s5)" />
+<circle cx="298.15" cy="134.07" r="2" fill="var(--c-s5)" />
+<circle cx="306.00" cy="130.25" r="2" fill="var(--c-s5)" />
+<circle cx="313.85" cy="126.42" r="2" fill="var(--c-s5)" />
+<circle cx="321.69" cy="122.59" r="2" fill="var(--c-s5)" />
+<circle cx="329.54" cy="118.76" r="2" fill="var(--c-s5)" />
+<circle cx="337.38" cy="114.93" r="2" fill="var(--c-s5)" />
+<circle cx="345.23" cy="111.10" r="2" fill="var(--c-s5)" />
+<circle cx="353.08" cy="107.28" r="2" fill="var(--c-s5)" />
+<circle cx="360.92" cy="103.45" r="2" fill="var(--c-s5)" />
+<circle cx="368.77" cy="99.42" r="2" fill="var(--c-s5)" />
+<circle cx="376.62" cy="95.33" r="2" fill="var(--c-s5)" />
+<circle cx="384.46" cy="91.24" r="2" fill="var(--c-s5)" />
+<circle cx="392.31" cy="87.16" r="2" fill="var(--c-s5)" />
+<circle cx="400.15" cy="83.08" r="2" fill="var(--c-s5)" />
+<circle cx="408.00" cy="79.51" r="2" fill="var(--c-s5)" />
+<circle cx="415.85" cy="75.94" r="2" fill="var(--c-s5)" />
+<circle cx="423.69" cy="72.37" r="2" fill="var(--c-s5)" />
+<circle cx="431.54" cy="68.81" r="2" fill="var(--c-s5)" />
+<circle cx="439.38" cy="65.24" r="2" fill="var(--c-s5)" />
+<circle cx="447.23" cy="61.67" r="2" fill="var(--c-s5)" />
+<circle cx="455.08" cy="58.10" r="2" fill="var(--c-s5)" />
+<circle cx="462.92" cy="54.54" r="2" fill="var(--c-s5)" />
+<circle cx="470.77" cy="50.97" r="2" fill="var(--c-s5)" />
+<circle cx="478.62" cy="47.40" r="2" fill="var(--c-s5)" />
+<circle cx="486.46" cy="43.84" r="2" fill="var(--c-s5)" />
+<circle cx="494.31" cy="40.27" r="2" fill="var(--c-s5)" />
+<circle cx="502.15" cy="36.70" r="2" fill="var(--c-s5)" />
+<circle cx="510.00" cy="33.13" r="2" fill="var(--c-s5)" />
+<rect x="528" y="0" width="14" height="3" fill="var(--c-s0)" />
+<text x="550" y="6" fill="var(--c-title)" font-size="12">2012</text>
+<rect x="528" y="22" width="14" height="3" fill="var(--c-s1)" />
+<text x="550" y="28" fill="var(--c-title)" font-size="12">2015</text>
+<rect x="528" y="44" width="14" height="3" fill="var(--c-s2)" />
+<text x="550" y="50" fill="var(--c-title)" font-size="12">2018</text>
+<rect x="528" y="66" width="14" height="3" fill="var(--c-s3)" />
+<text x="550" y="72" fill="var(--c-title)" font-size="12">2022</text>
+<rect x="528" y="88" width="14" height="3" fill="var(--c-s4)" />
+<text x="550" y="94" fill="var(--c-title)" font-size="12">2024</text>
+<rect x="528" y="110" width="14" height="3" fill="var(--c-s5)" />
+<text x="550" y="116" fill="var(--c-title)" font-size="12">2026</text>
 </g>
 </svg>

--- a/docs/assets/neto-real-mismo-nominal.svg
+++ b/docs/assets/neto-real-mismo-nominal.svg
@@ -1,70 +1,100 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 760 420" width="760" height="420" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif" font-size="13" role="img" aria-labelledby="neto-real-mismo-nominal-title neto-real-mismo-nominal-desc">
 <title id="neto-real-mismo-nominal-title">Neto real con bruto nominal fijo en 30 000 €</title>
 <desc id="neto-real-mismo-nominal-desc">Bruto nominal de 30 000 € en cada año entre 2012 y 2026, expresado el neto en € constantes de 2026. Pendiente decreciente: el mismo bruto nominal pierde poder adquisitivo real cada año.</desc>
-<rect width="760" height="420" fill="#ffffff" />
-<text x="80" y="35" font-size="16" font-weight="600" fill="#222">Neto real con bruto nominal fijo en 30 000 €</text>
+<style>
+  :root {
+    --c-bg: #f7f3ec;
+    --c-axis: #333333;
+    --c-grid: #e5e5e5;
+    --c-text: #444444;
+    --c-title: #222222;
+    --c-s0: #1f77b4;
+    --c-s1: #d62728;
+    --c-s2: #2ca02c;
+    --c-s3: #9467bd;
+    --c-s4: #cc6600;
+    --c-s5: #00838f;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --c-bg: #1a1612;
+      --c-axis: #f3ede2;
+      --c-grid: #3a342c;
+      --c-text: #d4cdbf;
+      --c-title: #f3ede2;
+      --c-s0: #5d9ec9;
+      --c-s1: #e87073;
+      --c-s2: #66bf66;
+      --c-s3: #b89bd6;
+      --c-s4: #ffaa57;
+      --c-s5: #71d6e0;
+    }
+  }
+</style>
+<rect width="760" height="420" fill="var(--c-bg)" />
+<text x="80" y="35" font-size="16" font-weight="600" fill="var(--c-title)">Neto real con bruto nominal fijo en 30 000 €</text>
 <g transform="translate(80,60)">
-<line x1="0" y1="291.02" x2="510" y2="291.02" stroke="#e5e5e5" stroke-width="1" />
-<line x1="0" y1="253.49" x2="510" y2="253.49" stroke="#e5e5e5" stroke-width="1" />
-<line x1="0" y1="215.97" x2="510" y2="215.97" stroke="#e5e5e5" stroke-width="1" />
-<line x1="0" y1="178.45" x2="510" y2="178.45" stroke="#e5e5e5" stroke-width="1" />
-<line x1="0" y1="140.92" x2="510" y2="140.92" stroke="#e5e5e5" stroke-width="1" />
-<line x1="0" y1="103.40" x2="510" y2="103.40" stroke="#e5e5e5" stroke-width="1" />
-<line x1="0" y1="65.87" x2="510" y2="65.87" stroke="#e5e5e5" stroke-width="1" />
-<line x1="0" y1="28.35" x2="510" y2="28.35" stroke="#e5e5e5" stroke-width="1" />
-<line x1="0" y1="300" x2="510" y2="300" stroke="#333" stroke-width="1" />
-<line x1="0" y1="0" x2="0" y2="300" stroke="#333" stroke-width="1" />
-<line x1="0.00" y1="300" x2="0.00" y2="305" stroke="#333" stroke-width="1" />
-<text x="0.00" y="322" text-anchor="middle" fill="#444">2012</text>
-<line x1="72.86" y1="300" x2="72.86" y2="305" stroke="#333" stroke-width="1" />
-<text x="72.86" y="322" text-anchor="middle" fill="#444">2014</text>
-<line x1="145.71" y1="300" x2="145.71" y2="305" stroke="#333" stroke-width="1" />
-<text x="145.71" y="322" text-anchor="middle" fill="#444">2016</text>
-<line x1="218.57" y1="300" x2="218.57" y2="305" stroke="#333" stroke-width="1" />
-<text x="218.57" y="322" text-anchor="middle" fill="#444">2018</text>
-<line x1="291.43" y1="300" x2="291.43" y2="305" stroke="#333" stroke-width="1" />
-<text x="291.43" y="322" text-anchor="middle" fill="#444">2020</text>
-<line x1="364.29" y1="300" x2="364.29" y2="305" stroke="#333" stroke-width="1" />
-<text x="364.29" y="322" text-anchor="middle" fill="#444">2022</text>
-<line x1="437.14" y1="300" x2="437.14" y2="305" stroke="#333" stroke-width="1" />
-<text x="437.14" y="322" text-anchor="middle" fill="#444">2024</text>
-<line x1="510.00" y1="300" x2="510.00" y2="305" stroke="#333" stroke-width="1" />
-<text x="510.00" y="322" text-anchor="middle" fill="#444">2026</text>
-<line x1="-5" y1="291.02" x2="0" y2="291.02" stroke="#333" stroke-width="1" />
-<text x="-10" y="295.02" text-anchor="end" fill="#444">23.000 €</text>
-<line x1="-5" y1="253.49" x2="0" y2="253.49" stroke="#333" stroke-width="1" />
-<text x="-10" y="257.49" text-anchor="end" fill="#444">24.000 €</text>
-<line x1="-5" y1="215.97" x2="0" y2="215.97" stroke="#333" stroke-width="1" />
-<text x="-10" y="219.97" text-anchor="end" fill="#444">25.000 €</text>
-<line x1="-5" y1="178.45" x2="0" y2="178.45" stroke="#333" stroke-width="1" />
-<text x="-10" y="182.45" text-anchor="end" fill="#444">26.000 €</text>
-<line x1="-5" y1="140.92" x2="0" y2="140.92" stroke="#333" stroke-width="1" />
-<text x="-10" y="144.92" text-anchor="end" fill="#444">27.000 €</text>
-<line x1="-5" y1="103.40" x2="0" y2="103.40" stroke="#333" stroke-width="1" />
-<text x="-10" y="107.40" text-anchor="end" fill="#444">28.000 €</text>
-<line x1="-5" y1="65.87" x2="0" y2="65.87" stroke="#333" stroke-width="1" />
-<text x="-10" y="69.87" text-anchor="end" fill="#444">29.000 €</text>
-<line x1="-5" y1="28.35" x2="0" y2="28.35" stroke="#333" stroke-width="1" />
-<text x="-10" y="32.35" text-anchor="end" fill="#444">30.000 €</text>
-<text x="255" y="348" text-anchor="middle" fill="#222" font-size="13">Año</text>
-<text transform="translate(-55,150) rotate(-90)" text-anchor="middle" fill="#222" font-size="13">Neto en € de 2026</text>
-<polyline points="0.00,40.62 36.43,43.95 72.86,32.74 109.29,13.64 145.71,26.59 182.14,38.86 218.57,52.08 255.00,60.83 291.43,55.34 327.86,122.40 364.29,178.03 400.71,208.24 437.14,234.16 473.57,260.17 510.00,286.36" fill="none" stroke="#1f77b4" stroke-width="2" stroke-linejoin="round" stroke-linecap="round" />
-<circle cx="0.00" cy="40.62" r="2" fill="#1f77b4" />
-<circle cx="36.43" cy="43.95" r="2" fill="#1f77b4" />
-<circle cx="72.86" cy="32.74" r="2" fill="#1f77b4" />
-<circle cx="109.29" cy="13.64" r="2" fill="#1f77b4" />
-<circle cx="145.71" cy="26.59" r="2" fill="#1f77b4" />
-<circle cx="182.14" cy="38.86" r="2" fill="#1f77b4" />
-<circle cx="218.57" cy="52.08" r="2" fill="#1f77b4" />
-<circle cx="255.00" cy="60.83" r="2" fill="#1f77b4" />
-<circle cx="291.43" cy="55.34" r="2" fill="#1f77b4" />
-<circle cx="327.86" cy="122.40" r="2" fill="#1f77b4" />
-<circle cx="364.29" cy="178.03" r="2" fill="#1f77b4" />
-<circle cx="400.71" cy="208.24" r="2" fill="#1f77b4" />
-<circle cx="437.14" cy="234.16" r="2" fill="#1f77b4" />
-<circle cx="473.57" cy="260.17" r="2" fill="#1f77b4" />
-<circle cx="510.00" cy="286.36" r="2" fill="#1f77b4" />
-<rect x="528" y="0" width="14" height="3" fill="#1f77b4" />
-<text x="550" y="6" fill="#222" font-size="12">Neto real (€ 2026)</text>
+<line x1="0" y1="291.02" x2="510" y2="291.02" stroke="var(--c-grid)" stroke-width="1" />
+<line x1="0" y1="253.49" x2="510" y2="253.49" stroke="var(--c-grid)" stroke-width="1" />
+<line x1="0" y1="215.97" x2="510" y2="215.97" stroke="var(--c-grid)" stroke-width="1" />
+<line x1="0" y1="178.45" x2="510" y2="178.45" stroke="var(--c-grid)" stroke-width="1" />
+<line x1="0" y1="140.92" x2="510" y2="140.92" stroke="var(--c-grid)" stroke-width="1" />
+<line x1="0" y1="103.40" x2="510" y2="103.40" stroke="var(--c-grid)" stroke-width="1" />
+<line x1="0" y1="65.87" x2="510" y2="65.87" stroke="var(--c-grid)" stroke-width="1" />
+<line x1="0" y1="28.35" x2="510" y2="28.35" stroke="var(--c-grid)" stroke-width="1" />
+<line x1="0" y1="300" x2="510" y2="300" stroke="var(--c-axis)" stroke-width="1" />
+<line x1="0" y1="0" x2="0" y2="300" stroke="var(--c-axis)" stroke-width="1" />
+<line x1="0.00" y1="300" x2="0.00" y2="305" stroke="var(--c-axis)" stroke-width="1" />
+<text x="0.00" y="322" text-anchor="middle" fill="var(--c-text)">2012</text>
+<line x1="72.86" y1="300" x2="72.86" y2="305" stroke="var(--c-axis)" stroke-width="1" />
+<text x="72.86" y="322" text-anchor="middle" fill="var(--c-text)">2014</text>
+<line x1="145.71" y1="300" x2="145.71" y2="305" stroke="var(--c-axis)" stroke-width="1" />
+<text x="145.71" y="322" text-anchor="middle" fill="var(--c-text)">2016</text>
+<line x1="218.57" y1="300" x2="218.57" y2="305" stroke="var(--c-axis)" stroke-width="1" />
+<text x="218.57" y="322" text-anchor="middle" fill="var(--c-text)">2018</text>
+<line x1="291.43" y1="300" x2="291.43" y2="305" stroke="var(--c-axis)" stroke-width="1" />
+<text x="291.43" y="322" text-anchor="middle" fill="var(--c-text)">2020</text>
+<line x1="364.29" y1="300" x2="364.29" y2="305" stroke="var(--c-axis)" stroke-width="1" />
+<text x="364.29" y="322" text-anchor="middle" fill="var(--c-text)">2022</text>
+<line x1="437.14" y1="300" x2="437.14" y2="305" stroke="var(--c-axis)" stroke-width="1" />
+<text x="437.14" y="322" text-anchor="middle" fill="var(--c-text)">2024</text>
+<line x1="510.00" y1="300" x2="510.00" y2="305" stroke="var(--c-axis)" stroke-width="1" />
+<text x="510.00" y="322" text-anchor="middle" fill="var(--c-text)">2026</text>
+<line x1="-5" y1="291.02" x2="0" y2="291.02" stroke="var(--c-axis)" stroke-width="1" />
+<text x="-10" y="295.02" text-anchor="end" fill="var(--c-text)">23.000 €</text>
+<line x1="-5" y1="253.49" x2="0" y2="253.49" stroke="var(--c-axis)" stroke-width="1" />
+<text x="-10" y="257.49" text-anchor="end" fill="var(--c-text)">24.000 €</text>
+<line x1="-5" y1="215.97" x2="0" y2="215.97" stroke="var(--c-axis)" stroke-width="1" />
+<text x="-10" y="219.97" text-anchor="end" fill="var(--c-text)">25.000 €</text>
+<line x1="-5" y1="178.45" x2="0" y2="178.45" stroke="var(--c-axis)" stroke-width="1" />
+<text x="-10" y="182.45" text-anchor="end" fill="var(--c-text)">26.000 €</text>
+<line x1="-5" y1="140.92" x2="0" y2="140.92" stroke="var(--c-axis)" stroke-width="1" />
+<text x="-10" y="144.92" text-anchor="end" fill="var(--c-text)">27.000 €</text>
+<line x1="-5" y1="103.40" x2="0" y2="103.40" stroke="var(--c-axis)" stroke-width="1" />
+<text x="-10" y="107.40" text-anchor="end" fill="var(--c-text)">28.000 €</text>
+<line x1="-5" y1="65.87" x2="0" y2="65.87" stroke="var(--c-axis)" stroke-width="1" />
+<text x="-10" y="69.87" text-anchor="end" fill="var(--c-text)">29.000 €</text>
+<line x1="-5" y1="28.35" x2="0" y2="28.35" stroke="var(--c-axis)" stroke-width="1" />
+<text x="-10" y="32.35" text-anchor="end" fill="var(--c-text)">30.000 €</text>
+<text x="255" y="348" text-anchor="middle" fill="var(--c-title)" font-size="13">Año</text>
+<text transform="translate(-55,150) rotate(-90)" text-anchor="middle" fill="var(--c-title)" font-size="13">Neto en € de 2026</text>
+<polyline points="0.00,40.62 36.43,43.95 72.86,32.74 109.29,13.64 145.71,26.59 182.14,38.86 218.57,52.08 255.00,60.83 291.43,55.34 327.86,122.40 364.29,178.03 400.71,208.24 437.14,234.16 473.57,260.17 510.00,286.36" fill="none" stroke="var(--c-s0)" stroke-width="2" stroke-linejoin="round" stroke-linecap="round" />
+<circle cx="0.00" cy="40.62" r="2" fill="var(--c-s0)" />
+<circle cx="36.43" cy="43.95" r="2" fill="var(--c-s0)" />
+<circle cx="72.86" cy="32.74" r="2" fill="var(--c-s0)" />
+<circle cx="109.29" cy="13.64" r="2" fill="var(--c-s0)" />
+<circle cx="145.71" cy="26.59" r="2" fill="var(--c-s0)" />
+<circle cx="182.14" cy="38.86" r="2" fill="var(--c-s0)" />
+<circle cx="218.57" cy="52.08" r="2" fill="var(--c-s0)" />
+<circle cx="255.00" cy="60.83" r="2" fill="var(--c-s0)" />
+<circle cx="291.43" cy="55.34" r="2" fill="var(--c-s0)" />
+<circle cx="327.86" cy="122.40" r="2" fill="var(--c-s0)" />
+<circle cx="364.29" cy="178.03" r="2" fill="var(--c-s0)" />
+<circle cx="400.71" cy="208.24" r="2" fill="var(--c-s0)" />
+<circle cx="437.14" cy="234.16" r="2" fill="var(--c-s0)" />
+<circle cx="473.57" cy="260.17" r="2" fill="var(--c-s0)" />
+<circle cx="510.00" cy="286.36" r="2" fill="var(--c-s0)" />
+<rect x="528" y="0" width="14" height="3" fill="var(--c-s0)" />
+<text x="550" y="6" fill="var(--c-title)" font-size="12">Neto real (€ 2026)</text>
 </g>
 </svg>

--- a/docs/assets/tipo-medio-efectivo.svg
+++ b/docs/assets/tipo-medio-efectivo.svg
@@ -1,461 +1,491 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 760 420" width="760" height="420" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif" font-size="13" role="img" aria-labelledby="tipo-medio-efectivo-title tipo-medio-efectivo-desc">
 <title id="tipo-medio-efectivo-title">Tipo medio efectivo: cotización + IRPF sobre bruto</title>
 <desc id="tipo-medio-efectivo-desc">Cuánto de cada euro bruto se convierte en cotización del trabajador más IRPF, expresado en porcentaje. Eje X en bruto real (€ de 2026) para que años distintos sean comparables a igual poder adquisitivo.</desc>
-<rect width="760" height="420" fill="#ffffff" />
-<text x="80" y="35" font-size="16" font-weight="600" fill="#222">Tipo medio efectivo: cotización + IRPF sobre bruto</text>
+<style>
+  :root {
+    --c-bg: #f7f3ec;
+    --c-axis: #333333;
+    --c-grid: #e5e5e5;
+    --c-text: #444444;
+    --c-title: #222222;
+    --c-s0: #1f77b4;
+    --c-s1: #d62728;
+    --c-s2: #2ca02c;
+    --c-s3: #9467bd;
+    --c-s4: #cc6600;
+    --c-s5: #00838f;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --c-bg: #1a1612;
+      --c-axis: #f3ede2;
+      --c-grid: #3a342c;
+      --c-text: #d4cdbf;
+      --c-title: #f3ede2;
+      --c-s0: #5d9ec9;
+      --c-s1: #e87073;
+      --c-s2: #66bf66;
+      --c-s3: #b89bd6;
+      --c-s4: #ffaa57;
+      --c-s5: #71d6e0;
+    }
+  }
+</style>
+<rect width="760" height="420" fill="var(--c-bg)" />
+<text x="80" y="35" font-size="16" font-weight="600" fill="var(--c-title)">Tipo medio efectivo: cotización + IRPF sobre bruto</text>
 <g transform="translate(80,60)">
-<line x1="0" y1="299.71" x2="510" y2="299.71" stroke="#e5e5e5" stroke-width="1" />
-<line x1="0" y1="250.29" x2="510" y2="250.29" stroke="#e5e5e5" stroke-width="1" />
-<line x1="0" y1="200.88" x2="510" y2="200.88" stroke="#e5e5e5" stroke-width="1" />
-<line x1="0" y1="151.46" x2="510" y2="151.46" stroke="#e5e5e5" stroke-width="1" />
-<line x1="0" y1="102.04" x2="510" y2="102.04" stroke="#e5e5e5" stroke-width="1" />
-<line x1="0" y1="52.63" x2="510" y2="52.63" stroke="#e5e5e5" stroke-width="1" />
-<line x1="0" y1="3.21" x2="510" y2="3.21" stroke="#e5e5e5" stroke-width="1" />
-<line x1="0" y1="300" x2="510" y2="300" stroke="#333" stroke-width="1" />
-<line x1="0" y1="0" x2="0" y2="300" stroke="#333" stroke-width="1" />
-<line x1="39.23" y1="300" x2="39.23" y2="305" stroke="#333" stroke-width="1" />
-<text x="39.23" y="322" text-anchor="middle" fill="#444">20k €</text>
-<line x1="117.69" y1="300" x2="117.69" y2="305" stroke="#333" stroke-width="1" />
-<text x="117.69" y="322" text-anchor="middle" fill="#444">30k €</text>
-<line x1="196.15" y1="300" x2="196.15" y2="305" stroke="#333" stroke-width="1" />
-<text x="196.15" y="322" text-anchor="middle" fill="#444">40k €</text>
-<line x1="274.62" y1="300" x2="274.62" y2="305" stroke="#333" stroke-width="1" />
-<text x="274.62" y="322" text-anchor="middle" fill="#444">50k €</text>
-<line x1="353.08" y1="300" x2="353.08" y2="305" stroke="#333" stroke-width="1" />
-<text x="353.08" y="322" text-anchor="middle" fill="#444">60k €</text>
-<line x1="431.54" y1="300" x2="431.54" y2="305" stroke="#333" stroke-width="1" />
-<text x="431.54" y="322" text-anchor="middle" fill="#444">70k €</text>
-<line x1="510.00" y1="300" x2="510.00" y2="305" stroke="#333" stroke-width="1" />
-<text x="510.00" y="322" text-anchor="middle" fill="#444">80k €</text>
-<line x1="-5" y1="299.71" x2="0" y2="299.71" stroke="#333" stroke-width="1" />
-<text x="-10" y="303.71" text-anchor="end" fill="#444">5.0 %</text>
-<line x1="-5" y1="250.29" x2="0" y2="250.29" stroke="#333" stroke-width="1" />
-<text x="-10" y="254.29" text-anchor="end" fill="#444">10.0 %</text>
-<line x1="-5" y1="200.88" x2="0" y2="200.88" stroke="#333" stroke-width="1" />
-<text x="-10" y="204.88" text-anchor="end" fill="#444">15.0 %</text>
-<line x1="-5" y1="151.46" x2="0" y2="151.46" stroke="#333" stroke-width="1" />
-<text x="-10" y="155.46" text-anchor="end" fill="#444">20.0 %</text>
-<line x1="-5" y1="102.04" x2="0" y2="102.04" stroke="#333" stroke-width="1" />
-<text x="-10" y="106.04" text-anchor="end" fill="#444">25.0 %</text>
-<line x1="-5" y1="52.63" x2="0" y2="52.63" stroke="#333" stroke-width="1" />
-<text x="-10" y="56.63" text-anchor="end" fill="#444">30.0 %</text>
-<line x1="-5" y1="3.21" x2="0" y2="3.21" stroke="#333" stroke-width="1" />
-<text x="-10" y="7.21" text-anchor="end" fill="#444">35.0 %</text>
-<text x="255" y="348" text-anchor="middle" fill="#222" font-size="13">Bruto en € de 2026</text>
-<text transform="translate(-55,150) rotate(-90)" text-anchor="middle" fill="#222" font-size="13">Tipo medio efectivo</text>
-<polyline points="0.00,275.38 7.85,249.50 15.69,226.67 23.54,206.38 31.38,188.80 39.23,182.22 47.08,176.27 54.92,170.86 62.77,165.93 70.62,161.40 78.46,157.24 86.31,153.39 94.15,149.83 102.00,146.53 109.85,142.54 117.69,138.08 125.54,133.91 133.38,130.00 141.23,126.32 149.08,122.86 156.92,119.60 164.77,116.52 172.62,113.60 180.46,110.84 188.31,108.23 196.15,105.74 204.00,103.37 211.85,101.12 219.69,98.97 227.54,96.92 235.38,94.95 243.23,93.08 251.08,91.28 258.92,89.56 266.77,87.91 274.62,86.05 282.46,82.71 290.31,80.05 298.15,77.67 306.00,75.38 313.85,73.17 321.69,71.03 329.54,68.98 337.38,66.99 345.23,65.07 353.08,63.22 360.92,61.43 368.77,59.69 376.62,58.01 384.46,56.38 392.31,54.80 400.15,53.27 408.00,51.79 415.85,50.35 423.69,48.95 431.54,47.59 439.38,46.27 447.23,44.98 455.08,43.73 462.92,42.52 470.77,41.34 478.62,40.18 486.46,38.74 494.31,36.76 502.15,34.84 510.00,32.96" fill="none" stroke="#1f77b4" stroke-width="2" stroke-linejoin="round" stroke-linecap="round" />
-<circle cx="0.00" cy="275.38" r="2" fill="#1f77b4" />
-<circle cx="7.85" cy="249.50" r="2" fill="#1f77b4" />
-<circle cx="15.69" cy="226.67" r="2" fill="#1f77b4" />
-<circle cx="23.54" cy="206.38" r="2" fill="#1f77b4" />
-<circle cx="31.38" cy="188.80" r="2" fill="#1f77b4" />
-<circle cx="39.23" cy="182.22" r="2" fill="#1f77b4" />
-<circle cx="47.08" cy="176.27" r="2" fill="#1f77b4" />
-<circle cx="54.92" cy="170.86" r="2" fill="#1f77b4" />
-<circle cx="62.77" cy="165.93" r="2" fill="#1f77b4" />
-<circle cx="70.62" cy="161.40" r="2" fill="#1f77b4" />
-<circle cx="78.46" cy="157.24" r="2" fill="#1f77b4" />
-<circle cx="86.31" cy="153.39" r="2" fill="#1f77b4" />
-<circle cx="94.15" cy="149.83" r="2" fill="#1f77b4" />
-<circle cx="102.00" cy="146.53" r="2" fill="#1f77b4" />
-<circle cx="109.85" cy="142.54" r="2" fill="#1f77b4" />
-<circle cx="117.69" cy="138.08" r="2" fill="#1f77b4" />
-<circle cx="125.54" cy="133.91" r="2" fill="#1f77b4" />
-<circle cx="133.38" cy="130.00" r="2" fill="#1f77b4" />
-<circle cx="141.23" cy="126.32" r="2" fill="#1f77b4" />
-<circle cx="149.08" cy="122.86" r="2" fill="#1f77b4" />
-<circle cx="156.92" cy="119.60" r="2" fill="#1f77b4" />
-<circle cx="164.77" cy="116.52" r="2" fill="#1f77b4" />
-<circle cx="172.62" cy="113.60" r="2" fill="#1f77b4" />
-<circle cx="180.46" cy="110.84" r="2" fill="#1f77b4" />
-<circle cx="188.31" cy="108.23" r="2" fill="#1f77b4" />
-<circle cx="196.15" cy="105.74" r="2" fill="#1f77b4" />
-<circle cx="204.00" cy="103.37" r="2" fill="#1f77b4" />
-<circle cx="211.85" cy="101.12" r="2" fill="#1f77b4" />
-<circle cx="219.69" cy="98.97" r="2" fill="#1f77b4" />
-<circle cx="227.54" cy="96.92" r="2" fill="#1f77b4" />
-<circle cx="235.38" cy="94.95" r="2" fill="#1f77b4" />
-<circle cx="243.23" cy="93.08" r="2" fill="#1f77b4" />
-<circle cx="251.08" cy="91.28" r="2" fill="#1f77b4" />
-<circle cx="258.92" cy="89.56" r="2" fill="#1f77b4" />
-<circle cx="266.77" cy="87.91" r="2" fill="#1f77b4" />
-<circle cx="274.62" cy="86.05" r="2" fill="#1f77b4" />
-<circle cx="282.46" cy="82.71" r="2" fill="#1f77b4" />
-<circle cx="290.31" cy="80.05" r="2" fill="#1f77b4" />
-<circle cx="298.15" cy="77.67" r="2" fill="#1f77b4" />
-<circle cx="306.00" cy="75.38" r="2" fill="#1f77b4" />
-<circle cx="313.85" cy="73.17" r="2" fill="#1f77b4" />
-<circle cx="321.69" cy="71.03" r="2" fill="#1f77b4" />
-<circle cx="329.54" cy="68.98" r="2" fill="#1f77b4" />
-<circle cx="337.38" cy="66.99" r="2" fill="#1f77b4" />
-<circle cx="345.23" cy="65.07" r="2" fill="#1f77b4" />
-<circle cx="353.08" cy="63.22" r="2" fill="#1f77b4" />
-<circle cx="360.92" cy="61.43" r="2" fill="#1f77b4" />
-<circle cx="368.77" cy="59.69" r="2" fill="#1f77b4" />
-<circle cx="376.62" cy="58.01" r="2" fill="#1f77b4" />
-<circle cx="384.46" cy="56.38" r="2" fill="#1f77b4" />
-<circle cx="392.31" cy="54.80" r="2" fill="#1f77b4" />
-<circle cx="400.15" cy="53.27" r="2" fill="#1f77b4" />
-<circle cx="408.00" cy="51.79" r="2" fill="#1f77b4" />
-<circle cx="415.85" cy="50.35" r="2" fill="#1f77b4" />
-<circle cx="423.69" cy="48.95" r="2" fill="#1f77b4" />
-<circle cx="431.54" cy="47.59" r="2" fill="#1f77b4" />
-<circle cx="439.38" cy="46.27" r="2" fill="#1f77b4" />
-<circle cx="447.23" cy="44.98" r="2" fill="#1f77b4" />
-<circle cx="455.08" cy="43.73" r="2" fill="#1f77b4" />
-<circle cx="462.92" cy="42.52" r="2" fill="#1f77b4" />
-<circle cx="470.77" cy="41.34" r="2" fill="#1f77b4" />
-<circle cx="478.62" cy="40.18" r="2" fill="#1f77b4" />
-<circle cx="486.46" cy="38.74" r="2" fill="#1f77b4" />
-<circle cx="494.31" cy="36.76" r="2" fill="#1f77b4" />
-<circle cx="502.15" cy="34.84" r="2" fill="#1f77b4" />
-<circle cx="510.00" cy="32.96" r="2" fill="#1f77b4" />
-<polyline points="0.00,286.36 7.85,282.41 15.69,259.75 23.54,239.61 31.38,221.59 39.23,205.37 47.08,195.78 54.92,189.59 62.77,183.94 70.62,178.76 78.46,173.99 86.31,169.59 94.15,165.52 102.00,161.74 109.85,158.21 117.69,154.93 125.54,151.85 133.38,147.67 141.23,143.32 149.08,139.22 156.92,135.36 164.77,131.72 172.62,128.27 180.46,125.00 188.31,121.90 196.15,118.95 204.00,116.15 211.85,113.48 219.69,110.94 227.54,108.51 235.38,106.19 243.23,103.97 251.08,101.84 258.92,99.80 266.77,97.85 274.62,95.98 282.46,93.74 290.31,90.68 298.15,87.73 306.00,84.90 313.85,82.17 321.69,79.53 329.54,76.99 337.38,75.18 345.23,73.45 353.08,71.79 360.92,70.18 368.77,68.62 376.62,67.11 384.46,65.65 392.31,64.23 400.15,62.86 408.00,61.53 415.85,60.23 423.69,58.98 431.54,57.76 439.38,56.57 447.23,55.42 455.08,54.30 462.92,53.21 470.77,52.14 478.62,51.11 486.46,50.10 494.31,49.12 502.15,48.17 510.00,47.23" fill="none" stroke="#d62728" stroke-width="2" stroke-linejoin="round" stroke-linecap="round" />
-<circle cx="0.00" cy="286.36" r="2" fill="#d62728" />
-<circle cx="7.85" cy="282.41" r="2" fill="#d62728" />
-<circle cx="15.69" cy="259.75" r="2" fill="#d62728" />
-<circle cx="23.54" cy="239.61" r="2" fill="#d62728" />
-<circle cx="31.38" cy="221.59" r="2" fill="#d62728" />
-<circle cx="39.23" cy="205.37" r="2" fill="#d62728" />
-<circle cx="47.08" cy="195.78" r="2" fill="#d62728" />
-<circle cx="54.92" cy="189.59" r="2" fill="#d62728" />
-<circle cx="62.77" cy="183.94" r="2" fill="#d62728" />
-<circle cx="70.62" cy="178.76" r="2" fill="#d62728" />
-<circle cx="78.46" cy="173.99" r="2" fill="#d62728" />
-<circle cx="86.31" cy="169.59" r="2" fill="#d62728" />
-<circle cx="94.15" cy="165.52" r="2" fill="#d62728" />
-<circle cx="102.00" cy="161.74" r="2" fill="#d62728" />
-<circle cx="109.85" cy="158.21" r="2" fill="#d62728" />
-<circle cx="117.69" cy="154.93" r="2" fill="#d62728" />
-<circle cx="125.54" cy="151.85" r="2" fill="#d62728" />
-<circle cx="133.38" cy="147.67" r="2" fill="#d62728" />
-<circle cx="141.23" cy="143.32" r="2" fill="#d62728" />
-<circle cx="149.08" cy="139.22" r="2" fill="#d62728" />
-<circle cx="156.92" cy="135.36" r="2" fill="#d62728" />
-<circle cx="164.77" cy="131.72" r="2" fill="#d62728" />
-<circle cx="172.62" cy="128.27" r="2" fill="#d62728" />
-<circle cx="180.46" cy="125.00" r="2" fill="#d62728" />
-<circle cx="188.31" cy="121.90" r="2" fill="#d62728" />
-<circle cx="196.15" cy="118.95" r="2" fill="#d62728" />
-<circle cx="204.00" cy="116.15" r="2" fill="#d62728" />
-<circle cx="211.85" cy="113.48" r="2" fill="#d62728" />
-<circle cx="219.69" cy="110.94" r="2" fill="#d62728" />
-<circle cx="227.54" cy="108.51" r="2" fill="#d62728" />
-<circle cx="235.38" cy="106.19" r="2" fill="#d62728" />
-<circle cx="243.23" cy="103.97" r="2" fill="#d62728" />
-<circle cx="251.08" cy="101.84" r="2" fill="#d62728" />
-<circle cx="258.92" cy="99.80" r="2" fill="#d62728" />
-<circle cx="266.77" cy="97.85" r="2" fill="#d62728" />
-<circle cx="274.62" cy="95.98" r="2" fill="#d62728" />
-<circle cx="282.46" cy="93.74" r="2" fill="#d62728" />
-<circle cx="290.31" cy="90.68" r="2" fill="#d62728" />
-<circle cx="298.15" cy="87.73" r="2" fill="#d62728" />
-<circle cx="306.00" cy="84.90" r="2" fill="#d62728" />
-<circle cx="313.85" cy="82.17" r="2" fill="#d62728" />
-<circle cx="321.69" cy="79.53" r="2" fill="#d62728" />
-<circle cx="329.54" cy="76.99" r="2" fill="#d62728" />
-<circle cx="337.38" cy="75.18" r="2" fill="#d62728" />
-<circle cx="345.23" cy="73.45" r="2" fill="#d62728" />
-<circle cx="353.08" cy="71.79" r="2" fill="#d62728" />
-<circle cx="360.92" cy="70.18" r="2" fill="#d62728" />
-<circle cx="368.77" cy="68.62" r="2" fill="#d62728" />
-<circle cx="376.62" cy="67.11" r="2" fill="#d62728" />
-<circle cx="384.46" cy="65.65" r="2" fill="#d62728" />
-<circle cx="392.31" cy="64.23" r="2" fill="#d62728" />
-<circle cx="400.15" cy="62.86" r="2" fill="#d62728" />
-<circle cx="408.00" cy="61.53" r="2" fill="#d62728" />
-<circle cx="415.85" cy="60.23" r="2" fill="#d62728" />
-<circle cx="423.69" cy="58.98" r="2" fill="#d62728" />
-<circle cx="431.54" cy="57.76" r="2" fill="#d62728" />
-<circle cx="439.38" cy="56.57" r="2" fill="#d62728" />
-<circle cx="447.23" cy="55.42" r="2" fill="#d62728" />
-<circle cx="455.08" cy="54.30" r="2" fill="#d62728" />
-<circle cx="462.92" cy="53.21" r="2" fill="#d62728" />
-<circle cx="470.77" cy="52.14" r="2" fill="#d62728" />
-<circle cx="478.62" cy="51.11" r="2" fill="#d62728" />
-<circle cx="486.46" cy="50.10" r="2" fill="#d62728" />
-<circle cx="494.31" cy="49.12" r="2" fill="#d62728" />
-<circle cx="502.15" cy="48.17" r="2" fill="#d62728" />
-<circle cx="510.00" cy="47.23" r="2" fill="#d62728" />
-<polyline points="0.00,286.36 7.85,286.36 15.69,270.62 23.54,254.33 31.38,234.47 39.23,218.78 47.08,207.14 54.92,193.08 62.77,181.78 70.62,176.89 78.46,172.38 86.31,168.22 94.15,164.37 102.00,160.79 109.85,157.46 117.69,154.35 125.54,149.77 133.38,145.36 141.23,141.22 149.08,137.32 156.92,133.65 164.77,130.18 172.62,126.90 180.46,123.79 188.31,120.83 196.15,118.03 204.00,115.36 211.85,112.82 219.69,110.40 227.54,108.09 235.38,105.88 243.23,103.77 251.08,101.75 258.92,99.81 266.77,97.95 274.62,96.16 282.46,93.66 290.31,90.78 298.15,88.01 306.00,85.34 313.85,82.77 321.69,80.29 329.54,77.90 337.38,76.21 345.23,74.63 353.08,73.12 360.92,71.65 368.77,70.22 376.62,68.85 384.46,67.51 392.31,66.22 400.15,64.96 408.00,63.75 415.85,62.57 423.69,61.42 431.54,60.31 439.38,59.22 447.23,58.17 455.08,57.15 462.92,56.15 470.77,55.18 478.62,54.24 486.46,53.32 494.31,52.42 502.15,51.55 510.00,50.70" fill="none" stroke="#2ca02c" stroke-width="2" stroke-linejoin="round" stroke-linecap="round" />
-<circle cx="0.00" cy="286.36" r="2" fill="#2ca02c" />
-<circle cx="7.85" cy="286.36" r="2" fill="#2ca02c" />
-<circle cx="15.69" cy="270.62" r="2" fill="#2ca02c" />
-<circle cx="23.54" cy="254.33" r="2" fill="#2ca02c" />
-<circle cx="31.38" cy="234.47" r="2" fill="#2ca02c" />
-<circle cx="39.23" cy="218.78" r="2" fill="#2ca02c" />
-<circle cx="47.08" cy="207.14" r="2" fill="#2ca02c" />
-<circle cx="54.92" cy="193.08" r="2" fill="#2ca02c" />
-<circle cx="62.77" cy="181.78" r="2" fill="#2ca02c" />
-<circle cx="70.62" cy="176.89" r="2" fill="#2ca02c" />
-<circle cx="78.46" cy="172.38" r="2" fill="#2ca02c" />
-<circle cx="86.31" cy="168.22" r="2" fill="#2ca02c" />
-<circle cx="94.15" cy="164.37" r="2" fill="#2ca02c" />
-<circle cx="102.00" cy="160.79" r="2" fill="#2ca02c" />
-<circle cx="109.85" cy="157.46" r="2" fill="#2ca02c" />
-<circle cx="117.69" cy="154.35" r="2" fill="#2ca02c" />
-<circle cx="125.54" cy="149.77" r="2" fill="#2ca02c" />
-<circle cx="133.38" cy="145.36" r="2" fill="#2ca02c" />
-<circle cx="141.23" cy="141.22" r="2" fill="#2ca02c" />
-<circle cx="149.08" cy="137.32" r="2" fill="#2ca02c" />
-<circle cx="156.92" cy="133.65" r="2" fill="#2ca02c" />
-<circle cx="164.77" cy="130.18" r="2" fill="#2ca02c" />
-<circle cx="172.62" cy="126.90" r="2" fill="#2ca02c" />
-<circle cx="180.46" cy="123.79" r="2" fill="#2ca02c" />
-<circle cx="188.31" cy="120.83" r="2" fill="#2ca02c" />
-<circle cx="196.15" cy="118.03" r="2" fill="#2ca02c" />
-<circle cx="204.00" cy="115.36" r="2" fill="#2ca02c" />
-<circle cx="211.85" cy="112.82" r="2" fill="#2ca02c" />
-<circle cx="219.69" cy="110.40" r="2" fill="#2ca02c" />
-<circle cx="227.54" cy="108.09" r="2" fill="#2ca02c" />
-<circle cx="235.38" cy="105.88" r="2" fill="#2ca02c" />
-<circle cx="243.23" cy="103.77" r="2" fill="#2ca02c" />
-<circle cx="251.08" cy="101.75" r="2" fill="#2ca02c" />
-<circle cx="258.92" cy="99.81" r="2" fill="#2ca02c" />
-<circle cx="266.77" cy="97.95" r="2" fill="#2ca02c" />
-<circle cx="274.62" cy="96.16" r="2" fill="#2ca02c" />
-<circle cx="282.46" cy="93.66" r="2" fill="#2ca02c" />
-<circle cx="290.31" cy="90.78" r="2" fill="#2ca02c" />
-<circle cx="298.15" cy="88.01" r="2" fill="#2ca02c" />
-<circle cx="306.00" cy="85.34" r="2" fill="#2ca02c" />
-<circle cx="313.85" cy="82.77" r="2" fill="#2ca02c" />
-<circle cx="321.69" cy="80.29" r="2" fill="#2ca02c" />
-<circle cx="329.54" cy="77.90" r="2" fill="#2ca02c" />
-<circle cx="337.38" cy="76.21" r="2" fill="#2ca02c" />
-<circle cx="345.23" cy="74.63" r="2" fill="#2ca02c" />
-<circle cx="353.08" cy="73.12" r="2" fill="#2ca02c" />
-<circle cx="360.92" cy="71.65" r="2" fill="#2ca02c" />
-<circle cx="368.77" cy="70.22" r="2" fill="#2ca02c" />
-<circle cx="376.62" cy="68.85" r="2" fill="#2ca02c" />
-<circle cx="384.46" cy="67.51" r="2" fill="#2ca02c" />
-<circle cx="392.31" cy="66.22" r="2" fill="#2ca02c" />
-<circle cx="400.15" cy="64.96" r="2" fill="#2ca02c" />
-<circle cx="408.00" cy="63.75" r="2" fill="#2ca02c" />
-<circle cx="415.85" cy="62.57" r="2" fill="#2ca02c" />
-<circle cx="423.69" cy="61.42" r="2" fill="#2ca02c" />
-<circle cx="431.54" cy="60.31" r="2" fill="#2ca02c" />
-<circle cx="439.38" cy="59.22" r="2" fill="#2ca02c" />
-<circle cx="447.23" cy="58.17" r="2" fill="#2ca02c" />
-<circle cx="455.08" cy="57.15" r="2" fill="#2ca02c" />
-<circle cx="462.92" cy="56.15" r="2" fill="#2ca02c" />
-<circle cx="470.77" cy="55.18" r="2" fill="#2ca02c" />
-<circle cx="478.62" cy="54.24" r="2" fill="#2ca02c" />
-<circle cx="486.46" cy="53.32" r="2" fill="#2ca02c" />
-<circle cx="494.31" cy="52.42" r="2" fill="#2ca02c" />
-<circle cx="502.15" cy="51.55" r="2" fill="#2ca02c" />
-<circle cx="510.00" cy="50.70" r="2" fill="#2ca02c" />
-<polyline points="0.00,286.36 7.85,279.10 15.69,254.53 23.54,232.69 31.38,213.15 39.23,195.56 47.08,179.65 54.92,173.08 62.77,168.35 70.62,164.01 78.46,160.02 86.31,156.33 94.15,152.16 102.00,147.04 109.85,142.27 117.69,137.81 125.54,133.65 133.38,129.74 141.23,126.08 149.08,122.62 156.92,119.37 164.77,116.29 172.62,113.39 180.46,110.63 188.31,108.02 196.15,105.54 204.00,103.17 211.85,100.92 219.69,98.78 227.54,96.73 235.38,94.23 243.23,90.96 251.08,87.83 258.92,84.84 266.77,81.96 274.62,79.20 282.46,76.55 290.31,73.99 298.15,71.54 306.00,69.18 313.85,66.90 321.69,64.85 329.54,63.42 337.38,62.04 345.23,60.71 353.08,59.42 360.92,58.17 368.77,56.97 376.62,55.80 384.46,54.67 392.31,53.58 400.15,52.51 408.00,51.48 415.85,50.48 423.69,49.51 431.54,48.57 439.38,47.65 447.23,46.76 455.08,45.89 462.92,44.18 470.77,42.32 478.62,40.50 486.46,38.73 494.31,37.01 502.15,35.33 510.00,33.70" fill="none" stroke="#9467bd" stroke-width="2" stroke-linejoin="round" stroke-linecap="round" />
-<circle cx="0.00" cy="286.36" r="2" fill="#9467bd" />
-<circle cx="7.85" cy="279.10" r="2" fill="#9467bd" />
-<circle cx="15.69" cy="254.53" r="2" fill="#9467bd" />
-<circle cx="23.54" cy="232.69" r="2" fill="#9467bd" />
-<circle cx="31.38" cy="213.15" r="2" fill="#9467bd" />
-<circle cx="39.23" cy="195.56" r="2" fill="#9467bd" />
-<circle cx="47.08" cy="179.65" r="2" fill="#9467bd" />
-<circle cx="54.92" cy="173.08" r="2" fill="#9467bd" />
-<circle cx="62.77" cy="168.35" r="2" fill="#9467bd" />
-<circle cx="70.62" cy="164.01" r="2" fill="#9467bd" />
-<circle cx="78.46" cy="160.02" r="2" fill="#9467bd" />
-<circle cx="86.31" cy="156.33" r="2" fill="#9467bd" />
-<circle cx="94.15" cy="152.16" r="2" fill="#9467bd" />
-<circle cx="102.00" cy="147.04" r="2" fill="#9467bd" />
-<circle cx="109.85" cy="142.27" r="2" fill="#9467bd" />
-<circle cx="117.69" cy="137.81" r="2" fill="#9467bd" />
-<circle cx="125.54" cy="133.65" r="2" fill="#9467bd" />
-<circle cx="133.38" cy="129.74" r="2" fill="#9467bd" />
-<circle cx="141.23" cy="126.08" r="2" fill="#9467bd" />
-<circle cx="149.08" cy="122.62" r="2" fill="#9467bd" />
-<circle cx="156.92" cy="119.37" r="2" fill="#9467bd" />
-<circle cx="164.77" cy="116.29" r="2" fill="#9467bd" />
-<circle cx="172.62" cy="113.39" r="2" fill="#9467bd" />
-<circle cx="180.46" cy="110.63" r="2" fill="#9467bd" />
-<circle cx="188.31" cy="108.02" r="2" fill="#9467bd" />
-<circle cx="196.15" cy="105.54" r="2" fill="#9467bd" />
-<circle cx="204.00" cy="103.17" r="2" fill="#9467bd" />
-<circle cx="211.85" cy="100.92" r="2" fill="#9467bd" />
-<circle cx="219.69" cy="98.78" r="2" fill="#9467bd" />
-<circle cx="227.54" cy="96.73" r="2" fill="#9467bd" />
-<circle cx="235.38" cy="94.23" r="2" fill="#9467bd" />
-<circle cx="243.23" cy="90.96" r="2" fill="#9467bd" />
-<circle cx="251.08" cy="87.83" r="2" fill="#9467bd" />
-<circle cx="258.92" cy="84.84" r="2" fill="#9467bd" />
-<circle cx="266.77" cy="81.96" r="2" fill="#9467bd" />
-<circle cx="274.62" cy="79.20" r="2" fill="#9467bd" />
-<circle cx="282.46" cy="76.55" r="2" fill="#9467bd" />
-<circle cx="290.31" cy="73.99" r="2" fill="#9467bd" />
-<circle cx="298.15" cy="71.54" r="2" fill="#9467bd" />
-<circle cx="306.00" cy="69.18" r="2" fill="#9467bd" />
-<circle cx="313.85" cy="66.90" r="2" fill="#9467bd" />
-<circle cx="321.69" cy="64.85" r="2" fill="#9467bd" />
-<circle cx="329.54" cy="63.42" r="2" fill="#9467bd" />
-<circle cx="337.38" cy="62.04" r="2" fill="#9467bd" />
-<circle cx="345.23" cy="60.71" r="2" fill="#9467bd" />
-<circle cx="353.08" cy="59.42" r="2" fill="#9467bd" />
-<circle cx="360.92" cy="58.17" r="2" fill="#9467bd" />
-<circle cx="368.77" cy="56.97" r="2" fill="#9467bd" />
-<circle cx="376.62" cy="55.80" r="2" fill="#9467bd" />
-<circle cx="384.46" cy="54.67" r="2" fill="#9467bd" />
-<circle cx="392.31" cy="53.58" r="2" fill="#9467bd" />
-<circle cx="400.15" cy="52.51" r="2" fill="#9467bd" />
-<circle cx="408.00" cy="51.48" r="2" fill="#9467bd" />
-<circle cx="415.85" cy="50.48" r="2" fill="#9467bd" />
-<circle cx="423.69" cy="49.51" r="2" fill="#9467bd" />
-<circle cx="431.54" cy="48.57" r="2" fill="#9467bd" />
-<circle cx="439.38" cy="47.65" r="2" fill="#9467bd" />
-<circle cx="447.23" cy="46.76" r="2" fill="#9467bd" />
-<circle cx="455.08" cy="45.89" r="2" fill="#9467bd" />
-<circle cx="462.92" cy="44.18" r="2" fill="#9467bd" />
-<circle cx="470.77" cy="42.32" r="2" fill="#9467bd" />
-<circle cx="478.62" cy="40.50" r="2" fill="#9467bd" />
-<circle cx="486.46" cy="38.73" r="2" fill="#9467bd" />
-<circle cx="494.31" cy="37.01" r="2" fill="#9467bd" />
-<circle cx="502.15" cy="35.33" r="2" fill="#9467bd" />
-<circle cx="510.00" cy="33.70" r="2" fill="#9467bd" />
-<polyline points="0.00,285.18 7.85,285.18 15.69,280.84 23.54,257.47 31.38,236.56 39.23,217.75 47.08,200.72 54.92,185.24 62.77,171.11 70.62,158.16 78.46,153.71 86.31,148.43 94.15,143.23 102.00,138.39 109.85,133.89 117.69,129.69 125.54,125.76 133.38,122.08 141.23,118.62 149.08,115.36 156.92,112.29 164.77,109.39 172.62,106.64 180.46,104.04 188.31,101.58 196.15,99.24 204.00,97.01 211.85,94.88 219.69,91.59 227.54,88.22 235.38,84.99 243.23,81.91 251.08,78.96 258.92,76.13 266.77,73.41 274.62,70.81 282.46,68.31 290.31,65.90 298.15,63.58 306.00,61.35 313.85,59.21 321.69,57.13 329.54,55.13 337.38,53.20 345.23,51.34 353.08,49.54 360.92,48.43 368.77,47.38 376.62,46.36 384.46,45.38 392.31,44.43 400.15,43.50 408.00,42.61 415.85,41.74 423.69,40.89 431.54,39.62 439.38,37.71 447.23,35.86 455.08,34.06 462.92,32.31 470.77,30.60 478.62,28.94 486.46,27.32 494.31,25.75 502.15,24.21 510.00,22.71" fill="none" stroke="#ff7f0e" stroke-width="2" stroke-linejoin="round" stroke-linecap="round" />
-<circle cx="0.00" cy="285.18" r="2" fill="#ff7f0e" />
-<circle cx="7.85" cy="285.18" r="2" fill="#ff7f0e" />
-<circle cx="15.69" cy="280.84" r="2" fill="#ff7f0e" />
-<circle cx="23.54" cy="257.47" r="2" fill="#ff7f0e" />
-<circle cx="31.38" cy="236.56" r="2" fill="#ff7f0e" />
-<circle cx="39.23" cy="217.75" r="2" fill="#ff7f0e" />
-<circle cx="47.08" cy="200.72" r="2" fill="#ff7f0e" />
-<circle cx="54.92" cy="185.24" r="2" fill="#ff7f0e" />
-<circle cx="62.77" cy="171.11" r="2" fill="#ff7f0e" />
-<circle cx="70.62" cy="158.16" r="2" fill="#ff7f0e" />
-<circle cx="78.46" cy="153.71" r="2" fill="#ff7f0e" />
-<circle cx="86.31" cy="148.43" r="2" fill="#ff7f0e" />
-<circle cx="94.15" cy="143.23" r="2" fill="#ff7f0e" />
-<circle cx="102.00" cy="138.39" r="2" fill="#ff7f0e" />
-<circle cx="109.85" cy="133.89" r="2" fill="#ff7f0e" />
-<circle cx="117.69" cy="129.69" r="2" fill="#ff7f0e" />
-<circle cx="125.54" cy="125.76" r="2" fill="#ff7f0e" />
-<circle cx="133.38" cy="122.08" r="2" fill="#ff7f0e" />
-<circle cx="141.23" cy="118.62" r="2" fill="#ff7f0e" />
-<circle cx="149.08" cy="115.36" r="2" fill="#ff7f0e" />
-<circle cx="156.92" cy="112.29" r="2" fill="#ff7f0e" />
-<circle cx="164.77" cy="109.39" r="2" fill="#ff7f0e" />
-<circle cx="172.62" cy="106.64" r="2" fill="#ff7f0e" />
-<circle cx="180.46" cy="104.04" r="2" fill="#ff7f0e" />
-<circle cx="188.31" cy="101.58" r="2" fill="#ff7f0e" />
-<circle cx="196.15" cy="99.24" r="2" fill="#ff7f0e" />
-<circle cx="204.00" cy="97.01" r="2" fill="#ff7f0e" />
-<circle cx="211.85" cy="94.88" r="2" fill="#ff7f0e" />
-<circle cx="219.69" cy="91.59" r="2" fill="#ff7f0e" />
-<circle cx="227.54" cy="88.22" r="2" fill="#ff7f0e" />
-<circle cx="235.38" cy="84.99" r="2" fill="#ff7f0e" />
-<circle cx="243.23" cy="81.91" r="2" fill="#ff7f0e" />
-<circle cx="251.08" cy="78.96" r="2" fill="#ff7f0e" />
-<circle cx="258.92" cy="76.13" r="2" fill="#ff7f0e" />
-<circle cx="266.77" cy="73.41" r="2" fill="#ff7f0e" />
-<circle cx="274.62" cy="70.81" r="2" fill="#ff7f0e" />
-<circle cx="282.46" cy="68.31" r="2" fill="#ff7f0e" />
-<circle cx="290.31" cy="65.90" r="2" fill="#ff7f0e" />
-<circle cx="298.15" cy="63.58" r="2" fill="#ff7f0e" />
-<circle cx="306.00" cy="61.35" r="2" fill="#ff7f0e" />
-<circle cx="313.85" cy="59.21" r="2" fill="#ff7f0e" />
-<circle cx="321.69" cy="57.13" r="2" fill="#ff7f0e" />
-<circle cx="329.54" cy="55.13" r="2" fill="#ff7f0e" />
-<circle cx="337.38" cy="53.20" r="2" fill="#ff7f0e" />
-<circle cx="345.23" cy="51.34" r="2" fill="#ff7f0e" />
-<circle cx="353.08" cy="49.54" r="2" fill="#ff7f0e" />
-<circle cx="360.92" cy="48.43" r="2" fill="#ff7f0e" />
-<circle cx="368.77" cy="47.38" r="2" fill="#ff7f0e" />
-<circle cx="376.62" cy="46.36" r="2" fill="#ff7f0e" />
-<circle cx="384.46" cy="45.38" r="2" fill="#ff7f0e" />
-<circle cx="392.31" cy="44.43" r="2" fill="#ff7f0e" />
-<circle cx="400.15" cy="43.50" r="2" fill="#ff7f0e" />
-<circle cx="408.00" cy="42.61" r="2" fill="#ff7f0e" />
-<circle cx="415.85" cy="41.74" r="2" fill="#ff7f0e" />
-<circle cx="423.69" cy="40.89" r="2" fill="#ff7f0e" />
-<circle cx="431.54" cy="39.62" r="2" fill="#ff7f0e" />
-<circle cx="439.38" cy="37.71" r="2" fill="#ff7f0e" />
-<circle cx="447.23" cy="35.86" r="2" fill="#ff7f0e" />
-<circle cx="455.08" cy="34.06" r="2" fill="#ff7f0e" />
-<circle cx="462.92" cy="32.31" r="2" fill="#ff7f0e" />
-<circle cx="470.77" cy="30.60" r="2" fill="#ff7f0e" />
-<circle cx="478.62" cy="28.94" r="2" fill="#ff7f0e" />
-<circle cx="486.46" cy="27.32" r="2" fill="#ff7f0e" />
-<circle cx="494.31" cy="25.75" r="2" fill="#ff7f0e" />
-<circle cx="502.15" cy="24.21" r="2" fill="#ff7f0e" />
-<circle cx="510.00" cy="22.71" r="2" fill="#ff7f0e" />
-<polyline points="0.00,284.88 7.85,284.88 15.69,284.88 23.54,250.63 31.38,215.01 39.23,197.25 47.08,181.19 54.92,166.58 62.77,155.79 70.62,151.34 78.46,145.59 86.31,140.28 94.15,135.37 102.00,130.81 109.85,126.57 117.69,122.60 125.54,118.89 133.38,115.42 141.23,112.15 149.08,109.08 156.92,106.18 164.77,103.44 172.62,100.86 180.46,98.40 188.31,96.08 196.15,93.52 204.00,89.85 211.85,86.35 219.69,83.02 227.54,79.83 235.38,76.79 243.23,73.88 251.08,71.10 258.92,68.43 266.77,65.87 274.62,63.41 282.46,61.05 290.31,58.78 298.15,56.59 306.00,54.49 313.85,52.46 321.69,50.51 329.54,48.62 337.38,46.80 345.23,45.04 353.08,43.34 360.92,41.69 368.77,40.60 376.62,39.67 384.46,38.78 392.31,37.91 400.15,37.05 408.00,35.05 415.85,33.12 423.69,31.23 431.54,29.41 439.38,27.63 447.23,25.90 455.08,24.22 462.92,22.59 470.77,21.00 478.62,19.45 486.46,17.94 494.31,16.47 502.15,15.03 510.00,13.64" fill="none" stroke="#17becf" stroke-width="2" stroke-linejoin="round" stroke-linecap="round" />
-<circle cx="0.00" cy="284.88" r="2" fill="#17becf" />
-<circle cx="7.85" cy="284.88" r="2" fill="#17becf" />
-<circle cx="15.69" cy="284.88" r="2" fill="#17becf" />
-<circle cx="23.54" cy="250.63" r="2" fill="#17becf" />
-<circle cx="31.38" cy="215.01" r="2" fill="#17becf" />
-<circle cx="39.23" cy="197.25" r="2" fill="#17becf" />
-<circle cx="47.08" cy="181.19" r="2" fill="#17becf" />
-<circle cx="54.92" cy="166.58" r="2" fill="#17becf" />
-<circle cx="62.77" cy="155.79" r="2" fill="#17becf" />
-<circle cx="70.62" cy="151.34" r="2" fill="#17becf" />
-<circle cx="78.46" cy="145.59" r="2" fill="#17becf" />
-<circle cx="86.31" cy="140.28" r="2" fill="#17becf" />
-<circle cx="94.15" cy="135.37" r="2" fill="#17becf" />
-<circle cx="102.00" cy="130.81" r="2" fill="#17becf" />
-<circle cx="109.85" cy="126.57" r="2" fill="#17becf" />
-<circle cx="117.69" cy="122.60" r="2" fill="#17becf" />
-<circle cx="125.54" cy="118.89" r="2" fill="#17becf" />
-<circle cx="133.38" cy="115.42" r="2" fill="#17becf" />
-<circle cx="141.23" cy="112.15" r="2" fill="#17becf" />
-<circle cx="149.08" cy="109.08" r="2" fill="#17becf" />
-<circle cx="156.92" cy="106.18" r="2" fill="#17becf" />
-<circle cx="164.77" cy="103.44" r="2" fill="#17becf" />
-<circle cx="172.62" cy="100.86" r="2" fill="#17becf" />
-<circle cx="180.46" cy="98.40" r="2" fill="#17becf" />
-<circle cx="188.31" cy="96.08" r="2" fill="#17becf" />
-<circle cx="196.15" cy="93.52" r="2" fill="#17becf" />
-<circle cx="204.00" cy="89.85" r="2" fill="#17becf" />
-<circle cx="211.85" cy="86.35" r="2" fill="#17becf" />
-<circle cx="219.69" cy="83.02" r="2" fill="#17becf" />
-<circle cx="227.54" cy="79.83" r="2" fill="#17becf" />
-<circle cx="235.38" cy="76.79" r="2" fill="#17becf" />
-<circle cx="243.23" cy="73.88" r="2" fill="#17becf" />
-<circle cx="251.08" cy="71.10" r="2" fill="#17becf" />
-<circle cx="258.92" cy="68.43" r="2" fill="#17becf" />
-<circle cx="266.77" cy="65.87" r="2" fill="#17becf" />
-<circle cx="274.62" cy="63.41" r="2" fill="#17becf" />
-<circle cx="282.46" cy="61.05" r="2" fill="#17becf" />
-<circle cx="290.31" cy="58.78" r="2" fill="#17becf" />
-<circle cx="298.15" cy="56.59" r="2" fill="#17becf" />
-<circle cx="306.00" cy="54.49" r="2" fill="#17becf" />
-<circle cx="313.85" cy="52.46" r="2" fill="#17becf" />
-<circle cx="321.69" cy="50.51" r="2" fill="#17becf" />
-<circle cx="329.54" cy="48.62" r="2" fill="#17becf" />
-<circle cx="337.38" cy="46.80" r="2" fill="#17becf" />
-<circle cx="345.23" cy="45.04" r="2" fill="#17becf" />
-<circle cx="353.08" cy="43.34" r="2" fill="#17becf" />
-<circle cx="360.92" cy="41.69" r="2" fill="#17becf" />
-<circle cx="368.77" cy="40.60" r="2" fill="#17becf" />
-<circle cx="376.62" cy="39.67" r="2" fill="#17becf" />
-<circle cx="384.46" cy="38.78" r="2" fill="#17becf" />
-<circle cx="392.31" cy="37.91" r="2" fill="#17becf" />
-<circle cx="400.15" cy="37.05" r="2" fill="#17becf" />
-<circle cx="408.00" cy="35.05" r="2" fill="#17becf" />
-<circle cx="415.85" cy="33.12" r="2" fill="#17becf" />
-<circle cx="423.69" cy="31.23" r="2" fill="#17becf" />
-<circle cx="431.54" cy="29.41" r="2" fill="#17becf" />
-<circle cx="439.38" cy="27.63" r="2" fill="#17becf" />
-<circle cx="447.23" cy="25.90" r="2" fill="#17becf" />
-<circle cx="455.08" cy="24.22" r="2" fill="#17becf" />
-<circle cx="462.92" cy="22.59" r="2" fill="#17becf" />
-<circle cx="470.77" cy="21.00" r="2" fill="#17becf" />
-<circle cx="478.62" cy="19.45" r="2" fill="#17becf" />
-<circle cx="486.46" cy="17.94" r="2" fill="#17becf" />
-<circle cx="494.31" cy="16.47" r="2" fill="#17becf" />
-<circle cx="502.15" cy="15.03" r="2" fill="#17becf" />
-<circle cx="510.00" cy="13.64" r="2" fill="#17becf" />
-<rect x="528" y="0" width="14" height="3" fill="#1f77b4" />
-<text x="550" y="6" fill="#222" font-size="12">2012</text>
-<rect x="528" y="22" width="14" height="3" fill="#d62728" />
-<text x="550" y="28" fill="#222" font-size="12">2015</text>
-<rect x="528" y="44" width="14" height="3" fill="#2ca02c" />
-<text x="550" y="50" fill="#222" font-size="12">2018</text>
-<rect x="528" y="66" width="14" height="3" fill="#9467bd" />
-<text x="550" y="72" fill="#222" font-size="12">2022</text>
-<rect x="528" y="88" width="14" height="3" fill="#ff7f0e" />
-<text x="550" y="94" fill="#222" font-size="12">2024</text>
-<rect x="528" y="110" width="14" height="3" fill="#17becf" />
-<text x="550" y="116" fill="#222" font-size="12">2026</text>
+<line x1="0" y1="299.71" x2="510" y2="299.71" stroke="var(--c-grid)" stroke-width="1" />
+<line x1="0" y1="250.29" x2="510" y2="250.29" stroke="var(--c-grid)" stroke-width="1" />
+<line x1="0" y1="200.88" x2="510" y2="200.88" stroke="var(--c-grid)" stroke-width="1" />
+<line x1="0" y1="151.46" x2="510" y2="151.46" stroke="var(--c-grid)" stroke-width="1" />
+<line x1="0" y1="102.04" x2="510" y2="102.04" stroke="var(--c-grid)" stroke-width="1" />
+<line x1="0" y1="52.63" x2="510" y2="52.63" stroke="var(--c-grid)" stroke-width="1" />
+<line x1="0" y1="3.21" x2="510" y2="3.21" stroke="var(--c-grid)" stroke-width="1" />
+<line x1="0" y1="300" x2="510" y2="300" stroke="var(--c-axis)" stroke-width="1" />
+<line x1="0" y1="0" x2="0" y2="300" stroke="var(--c-axis)" stroke-width="1" />
+<line x1="39.23" y1="300" x2="39.23" y2="305" stroke="var(--c-axis)" stroke-width="1" />
+<text x="39.23" y="322" text-anchor="middle" fill="var(--c-text)">20k €</text>
+<line x1="117.69" y1="300" x2="117.69" y2="305" stroke="var(--c-axis)" stroke-width="1" />
+<text x="117.69" y="322" text-anchor="middle" fill="var(--c-text)">30k €</text>
+<line x1="196.15" y1="300" x2="196.15" y2="305" stroke="var(--c-axis)" stroke-width="1" />
+<text x="196.15" y="322" text-anchor="middle" fill="var(--c-text)">40k €</text>
+<line x1="274.62" y1="300" x2="274.62" y2="305" stroke="var(--c-axis)" stroke-width="1" />
+<text x="274.62" y="322" text-anchor="middle" fill="var(--c-text)">50k €</text>
+<line x1="353.08" y1="300" x2="353.08" y2="305" stroke="var(--c-axis)" stroke-width="1" />
+<text x="353.08" y="322" text-anchor="middle" fill="var(--c-text)">60k €</text>
+<line x1="431.54" y1="300" x2="431.54" y2="305" stroke="var(--c-axis)" stroke-width="1" />
+<text x="431.54" y="322" text-anchor="middle" fill="var(--c-text)">70k €</text>
+<line x1="510.00" y1="300" x2="510.00" y2="305" stroke="var(--c-axis)" stroke-width="1" />
+<text x="510.00" y="322" text-anchor="middle" fill="var(--c-text)">80k €</text>
+<line x1="-5" y1="299.71" x2="0" y2="299.71" stroke="var(--c-axis)" stroke-width="1" />
+<text x="-10" y="303.71" text-anchor="end" fill="var(--c-text)">5.0 %</text>
+<line x1="-5" y1="250.29" x2="0" y2="250.29" stroke="var(--c-axis)" stroke-width="1" />
+<text x="-10" y="254.29" text-anchor="end" fill="var(--c-text)">10.0 %</text>
+<line x1="-5" y1="200.88" x2="0" y2="200.88" stroke="var(--c-axis)" stroke-width="1" />
+<text x="-10" y="204.88" text-anchor="end" fill="var(--c-text)">15.0 %</text>
+<line x1="-5" y1="151.46" x2="0" y2="151.46" stroke="var(--c-axis)" stroke-width="1" />
+<text x="-10" y="155.46" text-anchor="end" fill="var(--c-text)">20.0 %</text>
+<line x1="-5" y1="102.04" x2="0" y2="102.04" stroke="var(--c-axis)" stroke-width="1" />
+<text x="-10" y="106.04" text-anchor="end" fill="var(--c-text)">25.0 %</text>
+<line x1="-5" y1="52.63" x2="0" y2="52.63" stroke="var(--c-axis)" stroke-width="1" />
+<text x="-10" y="56.63" text-anchor="end" fill="var(--c-text)">30.0 %</text>
+<line x1="-5" y1="3.21" x2="0" y2="3.21" stroke="var(--c-axis)" stroke-width="1" />
+<text x="-10" y="7.21" text-anchor="end" fill="var(--c-text)">35.0 %</text>
+<text x="255" y="348" text-anchor="middle" fill="var(--c-title)" font-size="13">Bruto en € de 2026</text>
+<text transform="translate(-55,150) rotate(-90)" text-anchor="middle" fill="var(--c-title)" font-size="13">Tipo medio efectivo</text>
+<polyline points="0.00,275.38 7.85,249.50 15.69,226.67 23.54,206.38 31.38,188.80 39.23,182.22 47.08,176.27 54.92,170.86 62.77,165.93 70.62,161.40 78.46,157.24 86.31,153.39 94.15,149.83 102.00,146.53 109.85,142.54 117.69,138.08 125.54,133.91 133.38,130.00 141.23,126.32 149.08,122.86 156.92,119.60 164.77,116.52 172.62,113.60 180.46,110.84 188.31,108.23 196.15,105.74 204.00,103.37 211.85,101.12 219.69,98.97 227.54,96.92 235.38,94.95 243.23,93.08 251.08,91.28 258.92,89.56 266.77,87.91 274.62,86.05 282.46,82.71 290.31,80.05 298.15,77.67 306.00,75.38 313.85,73.17 321.69,71.03 329.54,68.98 337.38,66.99 345.23,65.07 353.08,63.22 360.92,61.43 368.77,59.69 376.62,58.01 384.46,56.38 392.31,54.80 400.15,53.27 408.00,51.79 415.85,50.35 423.69,48.95 431.54,47.59 439.38,46.27 447.23,44.98 455.08,43.73 462.92,42.52 470.77,41.34 478.62,40.18 486.46,38.74 494.31,36.76 502.15,34.84 510.00,32.96" fill="none" stroke="var(--c-s0)" stroke-width="2" stroke-linejoin="round" stroke-linecap="round" />
+<circle cx="0.00" cy="275.38" r="2" fill="var(--c-s0)" />
+<circle cx="7.85" cy="249.50" r="2" fill="var(--c-s0)" />
+<circle cx="15.69" cy="226.67" r="2" fill="var(--c-s0)" />
+<circle cx="23.54" cy="206.38" r="2" fill="var(--c-s0)" />
+<circle cx="31.38" cy="188.80" r="2" fill="var(--c-s0)" />
+<circle cx="39.23" cy="182.22" r="2" fill="var(--c-s0)" />
+<circle cx="47.08" cy="176.27" r="2" fill="var(--c-s0)" />
+<circle cx="54.92" cy="170.86" r="2" fill="var(--c-s0)" />
+<circle cx="62.77" cy="165.93" r="2" fill="var(--c-s0)" />
+<circle cx="70.62" cy="161.40" r="2" fill="var(--c-s0)" />
+<circle cx="78.46" cy="157.24" r="2" fill="var(--c-s0)" />
+<circle cx="86.31" cy="153.39" r="2" fill="var(--c-s0)" />
+<circle cx="94.15" cy="149.83" r="2" fill="var(--c-s0)" />
+<circle cx="102.00" cy="146.53" r="2" fill="var(--c-s0)" />
+<circle cx="109.85" cy="142.54" r="2" fill="var(--c-s0)" />
+<circle cx="117.69" cy="138.08" r="2" fill="var(--c-s0)" />
+<circle cx="125.54" cy="133.91" r="2" fill="var(--c-s0)" />
+<circle cx="133.38" cy="130.00" r="2" fill="var(--c-s0)" />
+<circle cx="141.23" cy="126.32" r="2" fill="var(--c-s0)" />
+<circle cx="149.08" cy="122.86" r="2" fill="var(--c-s0)" />
+<circle cx="156.92" cy="119.60" r="2" fill="var(--c-s0)" />
+<circle cx="164.77" cy="116.52" r="2" fill="var(--c-s0)" />
+<circle cx="172.62" cy="113.60" r="2" fill="var(--c-s0)" />
+<circle cx="180.46" cy="110.84" r="2" fill="var(--c-s0)" />
+<circle cx="188.31" cy="108.23" r="2" fill="var(--c-s0)" />
+<circle cx="196.15" cy="105.74" r="2" fill="var(--c-s0)" />
+<circle cx="204.00" cy="103.37" r="2" fill="var(--c-s0)" />
+<circle cx="211.85" cy="101.12" r="2" fill="var(--c-s0)" />
+<circle cx="219.69" cy="98.97" r="2" fill="var(--c-s0)" />
+<circle cx="227.54" cy="96.92" r="2" fill="var(--c-s0)" />
+<circle cx="235.38" cy="94.95" r="2" fill="var(--c-s0)" />
+<circle cx="243.23" cy="93.08" r="2" fill="var(--c-s0)" />
+<circle cx="251.08" cy="91.28" r="2" fill="var(--c-s0)" />
+<circle cx="258.92" cy="89.56" r="2" fill="var(--c-s0)" />
+<circle cx="266.77" cy="87.91" r="2" fill="var(--c-s0)" />
+<circle cx="274.62" cy="86.05" r="2" fill="var(--c-s0)" />
+<circle cx="282.46" cy="82.71" r="2" fill="var(--c-s0)" />
+<circle cx="290.31" cy="80.05" r="2" fill="var(--c-s0)" />
+<circle cx="298.15" cy="77.67" r="2" fill="var(--c-s0)" />
+<circle cx="306.00" cy="75.38" r="2" fill="var(--c-s0)" />
+<circle cx="313.85" cy="73.17" r="2" fill="var(--c-s0)" />
+<circle cx="321.69" cy="71.03" r="2" fill="var(--c-s0)" />
+<circle cx="329.54" cy="68.98" r="2" fill="var(--c-s0)" />
+<circle cx="337.38" cy="66.99" r="2" fill="var(--c-s0)" />
+<circle cx="345.23" cy="65.07" r="2" fill="var(--c-s0)" />
+<circle cx="353.08" cy="63.22" r="2" fill="var(--c-s0)" />
+<circle cx="360.92" cy="61.43" r="2" fill="var(--c-s0)" />
+<circle cx="368.77" cy="59.69" r="2" fill="var(--c-s0)" />
+<circle cx="376.62" cy="58.01" r="2" fill="var(--c-s0)" />
+<circle cx="384.46" cy="56.38" r="2" fill="var(--c-s0)" />
+<circle cx="392.31" cy="54.80" r="2" fill="var(--c-s0)" />
+<circle cx="400.15" cy="53.27" r="2" fill="var(--c-s0)" />
+<circle cx="408.00" cy="51.79" r="2" fill="var(--c-s0)" />
+<circle cx="415.85" cy="50.35" r="2" fill="var(--c-s0)" />
+<circle cx="423.69" cy="48.95" r="2" fill="var(--c-s0)" />
+<circle cx="431.54" cy="47.59" r="2" fill="var(--c-s0)" />
+<circle cx="439.38" cy="46.27" r="2" fill="var(--c-s0)" />
+<circle cx="447.23" cy="44.98" r="2" fill="var(--c-s0)" />
+<circle cx="455.08" cy="43.73" r="2" fill="var(--c-s0)" />
+<circle cx="462.92" cy="42.52" r="2" fill="var(--c-s0)" />
+<circle cx="470.77" cy="41.34" r="2" fill="var(--c-s0)" />
+<circle cx="478.62" cy="40.18" r="2" fill="var(--c-s0)" />
+<circle cx="486.46" cy="38.74" r="2" fill="var(--c-s0)" />
+<circle cx="494.31" cy="36.76" r="2" fill="var(--c-s0)" />
+<circle cx="502.15" cy="34.84" r="2" fill="var(--c-s0)" />
+<circle cx="510.00" cy="32.96" r="2" fill="var(--c-s0)" />
+<polyline points="0.00,286.36 7.85,282.41 15.69,259.75 23.54,239.61 31.38,221.59 39.23,205.37 47.08,195.78 54.92,189.59 62.77,183.94 70.62,178.76 78.46,173.99 86.31,169.59 94.15,165.52 102.00,161.74 109.85,158.21 117.69,154.93 125.54,151.85 133.38,147.67 141.23,143.32 149.08,139.22 156.92,135.36 164.77,131.72 172.62,128.27 180.46,125.00 188.31,121.90 196.15,118.95 204.00,116.15 211.85,113.48 219.69,110.94 227.54,108.51 235.38,106.19 243.23,103.97 251.08,101.84 258.92,99.80 266.77,97.85 274.62,95.98 282.46,93.74 290.31,90.68 298.15,87.73 306.00,84.90 313.85,82.17 321.69,79.53 329.54,76.99 337.38,75.18 345.23,73.45 353.08,71.79 360.92,70.18 368.77,68.62 376.62,67.11 384.46,65.65 392.31,64.23 400.15,62.86 408.00,61.53 415.85,60.23 423.69,58.98 431.54,57.76 439.38,56.57 447.23,55.42 455.08,54.30 462.92,53.21 470.77,52.14 478.62,51.11 486.46,50.10 494.31,49.12 502.15,48.17 510.00,47.23" fill="none" stroke="var(--c-s1)" stroke-width="2" stroke-linejoin="round" stroke-linecap="round" />
+<circle cx="0.00" cy="286.36" r="2" fill="var(--c-s1)" />
+<circle cx="7.85" cy="282.41" r="2" fill="var(--c-s1)" />
+<circle cx="15.69" cy="259.75" r="2" fill="var(--c-s1)" />
+<circle cx="23.54" cy="239.61" r="2" fill="var(--c-s1)" />
+<circle cx="31.38" cy="221.59" r="2" fill="var(--c-s1)" />
+<circle cx="39.23" cy="205.37" r="2" fill="var(--c-s1)" />
+<circle cx="47.08" cy="195.78" r="2" fill="var(--c-s1)" />
+<circle cx="54.92" cy="189.59" r="2" fill="var(--c-s1)" />
+<circle cx="62.77" cy="183.94" r="2" fill="var(--c-s1)" />
+<circle cx="70.62" cy="178.76" r="2" fill="var(--c-s1)" />
+<circle cx="78.46" cy="173.99" r="2" fill="var(--c-s1)" />
+<circle cx="86.31" cy="169.59" r="2" fill="var(--c-s1)" />
+<circle cx="94.15" cy="165.52" r="2" fill="var(--c-s1)" />
+<circle cx="102.00" cy="161.74" r="2" fill="var(--c-s1)" />
+<circle cx="109.85" cy="158.21" r="2" fill="var(--c-s1)" />
+<circle cx="117.69" cy="154.93" r="2" fill="var(--c-s1)" />
+<circle cx="125.54" cy="151.85" r="2" fill="var(--c-s1)" />
+<circle cx="133.38" cy="147.67" r="2" fill="var(--c-s1)" />
+<circle cx="141.23" cy="143.32" r="2" fill="var(--c-s1)" />
+<circle cx="149.08" cy="139.22" r="2" fill="var(--c-s1)" />
+<circle cx="156.92" cy="135.36" r="2" fill="var(--c-s1)" />
+<circle cx="164.77" cy="131.72" r="2" fill="var(--c-s1)" />
+<circle cx="172.62" cy="128.27" r="2" fill="var(--c-s1)" />
+<circle cx="180.46" cy="125.00" r="2" fill="var(--c-s1)" />
+<circle cx="188.31" cy="121.90" r="2" fill="var(--c-s1)" />
+<circle cx="196.15" cy="118.95" r="2" fill="var(--c-s1)" />
+<circle cx="204.00" cy="116.15" r="2" fill="var(--c-s1)" />
+<circle cx="211.85" cy="113.48" r="2" fill="var(--c-s1)" />
+<circle cx="219.69" cy="110.94" r="2" fill="var(--c-s1)" />
+<circle cx="227.54" cy="108.51" r="2" fill="var(--c-s1)" />
+<circle cx="235.38" cy="106.19" r="2" fill="var(--c-s1)" />
+<circle cx="243.23" cy="103.97" r="2" fill="var(--c-s1)" />
+<circle cx="251.08" cy="101.84" r="2" fill="var(--c-s1)" />
+<circle cx="258.92" cy="99.80" r="2" fill="var(--c-s1)" />
+<circle cx="266.77" cy="97.85" r="2" fill="var(--c-s1)" />
+<circle cx="274.62" cy="95.98" r="2" fill="var(--c-s1)" />
+<circle cx="282.46" cy="93.74" r="2" fill="var(--c-s1)" />
+<circle cx="290.31" cy="90.68" r="2" fill="var(--c-s1)" />
+<circle cx="298.15" cy="87.73" r="2" fill="var(--c-s1)" />
+<circle cx="306.00" cy="84.90" r="2" fill="var(--c-s1)" />
+<circle cx="313.85" cy="82.17" r="2" fill="var(--c-s1)" />
+<circle cx="321.69" cy="79.53" r="2" fill="var(--c-s1)" />
+<circle cx="329.54" cy="76.99" r="2" fill="var(--c-s1)" />
+<circle cx="337.38" cy="75.18" r="2" fill="var(--c-s1)" />
+<circle cx="345.23" cy="73.45" r="2" fill="var(--c-s1)" />
+<circle cx="353.08" cy="71.79" r="2" fill="var(--c-s1)" />
+<circle cx="360.92" cy="70.18" r="2" fill="var(--c-s1)" />
+<circle cx="368.77" cy="68.62" r="2" fill="var(--c-s1)" />
+<circle cx="376.62" cy="67.11" r="2" fill="var(--c-s1)" />
+<circle cx="384.46" cy="65.65" r="2" fill="var(--c-s1)" />
+<circle cx="392.31" cy="64.23" r="2" fill="var(--c-s1)" />
+<circle cx="400.15" cy="62.86" r="2" fill="var(--c-s1)" />
+<circle cx="408.00" cy="61.53" r="2" fill="var(--c-s1)" />
+<circle cx="415.85" cy="60.23" r="2" fill="var(--c-s1)" />
+<circle cx="423.69" cy="58.98" r="2" fill="var(--c-s1)" />
+<circle cx="431.54" cy="57.76" r="2" fill="var(--c-s1)" />
+<circle cx="439.38" cy="56.57" r="2" fill="var(--c-s1)" />
+<circle cx="447.23" cy="55.42" r="2" fill="var(--c-s1)" />
+<circle cx="455.08" cy="54.30" r="2" fill="var(--c-s1)" />
+<circle cx="462.92" cy="53.21" r="2" fill="var(--c-s1)" />
+<circle cx="470.77" cy="52.14" r="2" fill="var(--c-s1)" />
+<circle cx="478.62" cy="51.11" r="2" fill="var(--c-s1)" />
+<circle cx="486.46" cy="50.10" r="2" fill="var(--c-s1)" />
+<circle cx="494.31" cy="49.12" r="2" fill="var(--c-s1)" />
+<circle cx="502.15" cy="48.17" r="2" fill="var(--c-s1)" />
+<circle cx="510.00" cy="47.23" r="2" fill="var(--c-s1)" />
+<polyline points="0.00,286.36 7.85,286.36 15.69,270.62 23.54,254.33 31.38,234.47 39.23,218.78 47.08,207.14 54.92,193.08 62.77,181.78 70.62,176.89 78.46,172.38 86.31,168.22 94.15,164.37 102.00,160.79 109.85,157.46 117.69,154.35 125.54,149.77 133.38,145.36 141.23,141.22 149.08,137.32 156.92,133.65 164.77,130.18 172.62,126.90 180.46,123.79 188.31,120.83 196.15,118.03 204.00,115.36 211.85,112.82 219.69,110.40 227.54,108.09 235.38,105.88 243.23,103.77 251.08,101.75 258.92,99.81 266.77,97.95 274.62,96.16 282.46,93.66 290.31,90.78 298.15,88.01 306.00,85.34 313.85,82.77 321.69,80.29 329.54,77.90 337.38,76.21 345.23,74.63 353.08,73.12 360.92,71.65 368.77,70.22 376.62,68.85 384.46,67.51 392.31,66.22 400.15,64.96 408.00,63.75 415.85,62.57 423.69,61.42 431.54,60.31 439.38,59.22 447.23,58.17 455.08,57.15 462.92,56.15 470.77,55.18 478.62,54.24 486.46,53.32 494.31,52.42 502.15,51.55 510.00,50.70" fill="none" stroke="var(--c-s2)" stroke-width="2" stroke-linejoin="round" stroke-linecap="round" />
+<circle cx="0.00" cy="286.36" r="2" fill="var(--c-s2)" />
+<circle cx="7.85" cy="286.36" r="2" fill="var(--c-s2)" />
+<circle cx="15.69" cy="270.62" r="2" fill="var(--c-s2)" />
+<circle cx="23.54" cy="254.33" r="2" fill="var(--c-s2)" />
+<circle cx="31.38" cy="234.47" r="2" fill="var(--c-s2)" />
+<circle cx="39.23" cy="218.78" r="2" fill="var(--c-s2)" />
+<circle cx="47.08" cy="207.14" r="2" fill="var(--c-s2)" />
+<circle cx="54.92" cy="193.08" r="2" fill="var(--c-s2)" />
+<circle cx="62.77" cy="181.78" r="2" fill="var(--c-s2)" />
+<circle cx="70.62" cy="176.89" r="2" fill="var(--c-s2)" />
+<circle cx="78.46" cy="172.38" r="2" fill="var(--c-s2)" />
+<circle cx="86.31" cy="168.22" r="2" fill="var(--c-s2)" />
+<circle cx="94.15" cy="164.37" r="2" fill="var(--c-s2)" />
+<circle cx="102.00" cy="160.79" r="2" fill="var(--c-s2)" />
+<circle cx="109.85" cy="157.46" r="2" fill="var(--c-s2)" />
+<circle cx="117.69" cy="154.35" r="2" fill="var(--c-s2)" />
+<circle cx="125.54" cy="149.77" r="2" fill="var(--c-s2)" />
+<circle cx="133.38" cy="145.36" r="2" fill="var(--c-s2)" />
+<circle cx="141.23" cy="141.22" r="2" fill="var(--c-s2)" />
+<circle cx="149.08" cy="137.32" r="2" fill="var(--c-s2)" />
+<circle cx="156.92" cy="133.65" r="2" fill="var(--c-s2)" />
+<circle cx="164.77" cy="130.18" r="2" fill="var(--c-s2)" />
+<circle cx="172.62" cy="126.90" r="2" fill="var(--c-s2)" />
+<circle cx="180.46" cy="123.79" r="2" fill="var(--c-s2)" />
+<circle cx="188.31" cy="120.83" r="2" fill="var(--c-s2)" />
+<circle cx="196.15" cy="118.03" r="2" fill="var(--c-s2)" />
+<circle cx="204.00" cy="115.36" r="2" fill="var(--c-s2)" />
+<circle cx="211.85" cy="112.82" r="2" fill="var(--c-s2)" />
+<circle cx="219.69" cy="110.40" r="2" fill="var(--c-s2)" />
+<circle cx="227.54" cy="108.09" r="2" fill="var(--c-s2)" />
+<circle cx="235.38" cy="105.88" r="2" fill="var(--c-s2)" />
+<circle cx="243.23" cy="103.77" r="2" fill="var(--c-s2)" />
+<circle cx="251.08" cy="101.75" r="2" fill="var(--c-s2)" />
+<circle cx="258.92" cy="99.81" r="2" fill="var(--c-s2)" />
+<circle cx="266.77" cy="97.95" r="2" fill="var(--c-s2)" />
+<circle cx="274.62" cy="96.16" r="2" fill="var(--c-s2)" />
+<circle cx="282.46" cy="93.66" r="2" fill="var(--c-s2)" />
+<circle cx="290.31" cy="90.78" r="2" fill="var(--c-s2)" />
+<circle cx="298.15" cy="88.01" r="2" fill="var(--c-s2)" />
+<circle cx="306.00" cy="85.34" r="2" fill="var(--c-s2)" />
+<circle cx="313.85" cy="82.77" r="2" fill="var(--c-s2)" />
+<circle cx="321.69" cy="80.29" r="2" fill="var(--c-s2)" />
+<circle cx="329.54" cy="77.90" r="2" fill="var(--c-s2)" />
+<circle cx="337.38" cy="76.21" r="2" fill="var(--c-s2)" />
+<circle cx="345.23" cy="74.63" r="2" fill="var(--c-s2)" />
+<circle cx="353.08" cy="73.12" r="2" fill="var(--c-s2)" />
+<circle cx="360.92" cy="71.65" r="2" fill="var(--c-s2)" />
+<circle cx="368.77" cy="70.22" r="2" fill="var(--c-s2)" />
+<circle cx="376.62" cy="68.85" r="2" fill="var(--c-s2)" />
+<circle cx="384.46" cy="67.51" r="2" fill="var(--c-s2)" />
+<circle cx="392.31" cy="66.22" r="2" fill="var(--c-s2)" />
+<circle cx="400.15" cy="64.96" r="2" fill="var(--c-s2)" />
+<circle cx="408.00" cy="63.75" r="2" fill="var(--c-s2)" />
+<circle cx="415.85" cy="62.57" r="2" fill="var(--c-s2)" />
+<circle cx="423.69" cy="61.42" r="2" fill="var(--c-s2)" />
+<circle cx="431.54" cy="60.31" r="2" fill="var(--c-s2)" />
+<circle cx="439.38" cy="59.22" r="2" fill="var(--c-s2)" />
+<circle cx="447.23" cy="58.17" r="2" fill="var(--c-s2)" />
+<circle cx="455.08" cy="57.15" r="2" fill="var(--c-s2)" />
+<circle cx="462.92" cy="56.15" r="2" fill="var(--c-s2)" />
+<circle cx="470.77" cy="55.18" r="2" fill="var(--c-s2)" />
+<circle cx="478.62" cy="54.24" r="2" fill="var(--c-s2)" />
+<circle cx="486.46" cy="53.32" r="2" fill="var(--c-s2)" />
+<circle cx="494.31" cy="52.42" r="2" fill="var(--c-s2)" />
+<circle cx="502.15" cy="51.55" r="2" fill="var(--c-s2)" />
+<circle cx="510.00" cy="50.70" r="2" fill="var(--c-s2)" />
+<polyline points="0.00,286.36 7.85,279.10 15.69,254.53 23.54,232.69 31.38,213.15 39.23,195.56 47.08,179.65 54.92,173.08 62.77,168.35 70.62,164.01 78.46,160.02 86.31,156.33 94.15,152.16 102.00,147.04 109.85,142.27 117.69,137.81 125.54,133.65 133.38,129.74 141.23,126.08 149.08,122.62 156.92,119.37 164.77,116.29 172.62,113.39 180.46,110.63 188.31,108.02 196.15,105.54 204.00,103.17 211.85,100.92 219.69,98.78 227.54,96.73 235.38,94.23 243.23,90.96 251.08,87.83 258.92,84.84 266.77,81.96 274.62,79.20 282.46,76.55 290.31,73.99 298.15,71.54 306.00,69.18 313.85,66.90 321.69,64.85 329.54,63.42 337.38,62.04 345.23,60.71 353.08,59.42 360.92,58.17 368.77,56.97 376.62,55.80 384.46,54.67 392.31,53.58 400.15,52.51 408.00,51.48 415.85,50.48 423.69,49.51 431.54,48.57 439.38,47.65 447.23,46.76 455.08,45.89 462.92,44.18 470.77,42.32 478.62,40.50 486.46,38.73 494.31,37.01 502.15,35.33 510.00,33.70" fill="none" stroke="var(--c-s3)" stroke-width="2" stroke-linejoin="round" stroke-linecap="round" />
+<circle cx="0.00" cy="286.36" r="2" fill="var(--c-s3)" />
+<circle cx="7.85" cy="279.10" r="2" fill="var(--c-s3)" />
+<circle cx="15.69" cy="254.53" r="2" fill="var(--c-s3)" />
+<circle cx="23.54" cy="232.69" r="2" fill="var(--c-s3)" />
+<circle cx="31.38" cy="213.15" r="2" fill="var(--c-s3)" />
+<circle cx="39.23" cy="195.56" r="2" fill="var(--c-s3)" />
+<circle cx="47.08" cy="179.65" r="2" fill="var(--c-s3)" />
+<circle cx="54.92" cy="173.08" r="2" fill="var(--c-s3)" />
+<circle cx="62.77" cy="168.35" r="2" fill="var(--c-s3)" />
+<circle cx="70.62" cy="164.01" r="2" fill="var(--c-s3)" />
+<circle cx="78.46" cy="160.02" r="2" fill="var(--c-s3)" />
+<circle cx="86.31" cy="156.33" r="2" fill="var(--c-s3)" />
+<circle cx="94.15" cy="152.16" r="2" fill="var(--c-s3)" />
+<circle cx="102.00" cy="147.04" r="2" fill="var(--c-s3)" />
+<circle cx="109.85" cy="142.27" r="2" fill="var(--c-s3)" />
+<circle cx="117.69" cy="137.81" r="2" fill="var(--c-s3)" />
+<circle cx="125.54" cy="133.65" r="2" fill="var(--c-s3)" />
+<circle cx="133.38" cy="129.74" r="2" fill="var(--c-s3)" />
+<circle cx="141.23" cy="126.08" r="2" fill="var(--c-s3)" />
+<circle cx="149.08" cy="122.62" r="2" fill="var(--c-s3)" />
+<circle cx="156.92" cy="119.37" r="2" fill="var(--c-s3)" />
+<circle cx="164.77" cy="116.29" r="2" fill="var(--c-s3)" />
+<circle cx="172.62" cy="113.39" r="2" fill="var(--c-s3)" />
+<circle cx="180.46" cy="110.63" r="2" fill="var(--c-s3)" />
+<circle cx="188.31" cy="108.02" r="2" fill="var(--c-s3)" />
+<circle cx="196.15" cy="105.54" r="2" fill="var(--c-s3)" />
+<circle cx="204.00" cy="103.17" r="2" fill="var(--c-s3)" />
+<circle cx="211.85" cy="100.92" r="2" fill="var(--c-s3)" />
+<circle cx="219.69" cy="98.78" r="2" fill="var(--c-s3)" />
+<circle cx="227.54" cy="96.73" r="2" fill="var(--c-s3)" />
+<circle cx="235.38" cy="94.23" r="2" fill="var(--c-s3)" />
+<circle cx="243.23" cy="90.96" r="2" fill="var(--c-s3)" />
+<circle cx="251.08" cy="87.83" r="2" fill="var(--c-s3)" />
+<circle cx="258.92" cy="84.84" r="2" fill="var(--c-s3)" />
+<circle cx="266.77" cy="81.96" r="2" fill="var(--c-s3)" />
+<circle cx="274.62" cy="79.20" r="2" fill="var(--c-s3)" />
+<circle cx="282.46" cy="76.55" r="2" fill="var(--c-s3)" />
+<circle cx="290.31" cy="73.99" r="2" fill="var(--c-s3)" />
+<circle cx="298.15" cy="71.54" r="2" fill="var(--c-s3)" />
+<circle cx="306.00" cy="69.18" r="2" fill="var(--c-s3)" />
+<circle cx="313.85" cy="66.90" r="2" fill="var(--c-s3)" />
+<circle cx="321.69" cy="64.85" r="2" fill="var(--c-s3)" />
+<circle cx="329.54" cy="63.42" r="2" fill="var(--c-s3)" />
+<circle cx="337.38" cy="62.04" r="2" fill="var(--c-s3)" />
+<circle cx="345.23" cy="60.71" r="2" fill="var(--c-s3)" />
+<circle cx="353.08" cy="59.42" r="2" fill="var(--c-s3)" />
+<circle cx="360.92" cy="58.17" r="2" fill="var(--c-s3)" />
+<circle cx="368.77" cy="56.97" r="2" fill="var(--c-s3)" />
+<circle cx="376.62" cy="55.80" r="2" fill="var(--c-s3)" />
+<circle cx="384.46" cy="54.67" r="2" fill="var(--c-s3)" />
+<circle cx="392.31" cy="53.58" r="2" fill="var(--c-s3)" />
+<circle cx="400.15" cy="52.51" r="2" fill="var(--c-s3)" />
+<circle cx="408.00" cy="51.48" r="2" fill="var(--c-s3)" />
+<circle cx="415.85" cy="50.48" r="2" fill="var(--c-s3)" />
+<circle cx="423.69" cy="49.51" r="2" fill="var(--c-s3)" />
+<circle cx="431.54" cy="48.57" r="2" fill="var(--c-s3)" />
+<circle cx="439.38" cy="47.65" r="2" fill="var(--c-s3)" />
+<circle cx="447.23" cy="46.76" r="2" fill="var(--c-s3)" />
+<circle cx="455.08" cy="45.89" r="2" fill="var(--c-s3)" />
+<circle cx="462.92" cy="44.18" r="2" fill="var(--c-s3)" />
+<circle cx="470.77" cy="42.32" r="2" fill="var(--c-s3)" />
+<circle cx="478.62" cy="40.50" r="2" fill="var(--c-s3)" />
+<circle cx="486.46" cy="38.73" r="2" fill="var(--c-s3)" />
+<circle cx="494.31" cy="37.01" r="2" fill="var(--c-s3)" />
+<circle cx="502.15" cy="35.33" r="2" fill="var(--c-s3)" />
+<circle cx="510.00" cy="33.70" r="2" fill="var(--c-s3)" />
+<polyline points="0.00,285.18 7.85,285.18 15.69,280.84 23.54,257.47 31.38,236.56 39.23,217.75 47.08,200.72 54.92,185.24 62.77,171.11 70.62,158.16 78.46,153.71 86.31,148.43 94.15,143.23 102.00,138.39 109.85,133.89 117.69,129.69 125.54,125.76 133.38,122.08 141.23,118.62 149.08,115.36 156.92,112.29 164.77,109.39 172.62,106.64 180.46,104.04 188.31,101.58 196.15,99.24 204.00,97.01 211.85,94.88 219.69,91.59 227.54,88.22 235.38,84.99 243.23,81.91 251.08,78.96 258.92,76.13 266.77,73.41 274.62,70.81 282.46,68.31 290.31,65.90 298.15,63.58 306.00,61.35 313.85,59.21 321.69,57.13 329.54,55.13 337.38,53.20 345.23,51.34 353.08,49.54 360.92,48.43 368.77,47.38 376.62,46.36 384.46,45.38 392.31,44.43 400.15,43.50 408.00,42.61 415.85,41.74 423.69,40.89 431.54,39.62 439.38,37.71 447.23,35.86 455.08,34.06 462.92,32.31 470.77,30.60 478.62,28.94 486.46,27.32 494.31,25.75 502.15,24.21 510.00,22.71" fill="none" stroke="var(--c-s4)" stroke-width="2" stroke-linejoin="round" stroke-linecap="round" />
+<circle cx="0.00" cy="285.18" r="2" fill="var(--c-s4)" />
+<circle cx="7.85" cy="285.18" r="2" fill="var(--c-s4)" />
+<circle cx="15.69" cy="280.84" r="2" fill="var(--c-s4)" />
+<circle cx="23.54" cy="257.47" r="2" fill="var(--c-s4)" />
+<circle cx="31.38" cy="236.56" r="2" fill="var(--c-s4)" />
+<circle cx="39.23" cy="217.75" r="2" fill="var(--c-s4)" />
+<circle cx="47.08" cy="200.72" r="2" fill="var(--c-s4)" />
+<circle cx="54.92" cy="185.24" r="2" fill="var(--c-s4)" />
+<circle cx="62.77" cy="171.11" r="2" fill="var(--c-s4)" />
+<circle cx="70.62" cy="158.16" r="2" fill="var(--c-s4)" />
+<circle cx="78.46" cy="153.71" r="2" fill="var(--c-s4)" />
+<circle cx="86.31" cy="148.43" r="2" fill="var(--c-s4)" />
+<circle cx="94.15" cy="143.23" r="2" fill="var(--c-s4)" />
+<circle cx="102.00" cy="138.39" r="2" fill="var(--c-s4)" />
+<circle cx="109.85" cy="133.89" r="2" fill="var(--c-s4)" />
+<circle cx="117.69" cy="129.69" r="2" fill="var(--c-s4)" />
+<circle cx="125.54" cy="125.76" r="2" fill="var(--c-s4)" />
+<circle cx="133.38" cy="122.08" r="2" fill="var(--c-s4)" />
+<circle cx="141.23" cy="118.62" r="2" fill="var(--c-s4)" />
+<circle cx="149.08" cy="115.36" r="2" fill="var(--c-s4)" />
+<circle cx="156.92" cy="112.29" r="2" fill="var(--c-s4)" />
+<circle cx="164.77" cy="109.39" r="2" fill="var(--c-s4)" />
+<circle cx="172.62" cy="106.64" r="2" fill="var(--c-s4)" />
+<circle cx="180.46" cy="104.04" r="2" fill="var(--c-s4)" />
+<circle cx="188.31" cy="101.58" r="2" fill="var(--c-s4)" />
+<circle cx="196.15" cy="99.24" r="2" fill="var(--c-s4)" />
+<circle cx="204.00" cy="97.01" r="2" fill="var(--c-s4)" />
+<circle cx="211.85" cy="94.88" r="2" fill="var(--c-s4)" />
+<circle cx="219.69" cy="91.59" r="2" fill="var(--c-s4)" />
+<circle cx="227.54" cy="88.22" r="2" fill="var(--c-s4)" />
+<circle cx="235.38" cy="84.99" r="2" fill="var(--c-s4)" />
+<circle cx="243.23" cy="81.91" r="2" fill="var(--c-s4)" />
+<circle cx="251.08" cy="78.96" r="2" fill="var(--c-s4)" />
+<circle cx="258.92" cy="76.13" r="2" fill="var(--c-s4)" />
+<circle cx="266.77" cy="73.41" r="2" fill="var(--c-s4)" />
+<circle cx="274.62" cy="70.81" r="2" fill="var(--c-s4)" />
+<circle cx="282.46" cy="68.31" r="2" fill="var(--c-s4)" />
+<circle cx="290.31" cy="65.90" r="2" fill="var(--c-s4)" />
+<circle cx="298.15" cy="63.58" r="2" fill="var(--c-s4)" />
+<circle cx="306.00" cy="61.35" r="2" fill="var(--c-s4)" />
+<circle cx="313.85" cy="59.21" r="2" fill="var(--c-s4)" />
+<circle cx="321.69" cy="57.13" r="2" fill="var(--c-s4)" />
+<circle cx="329.54" cy="55.13" r="2" fill="var(--c-s4)" />
+<circle cx="337.38" cy="53.20" r="2" fill="var(--c-s4)" />
+<circle cx="345.23" cy="51.34" r="2" fill="var(--c-s4)" />
+<circle cx="353.08" cy="49.54" r="2" fill="var(--c-s4)" />
+<circle cx="360.92" cy="48.43" r="2" fill="var(--c-s4)" />
+<circle cx="368.77" cy="47.38" r="2" fill="var(--c-s4)" />
+<circle cx="376.62" cy="46.36" r="2" fill="var(--c-s4)" />
+<circle cx="384.46" cy="45.38" r="2" fill="var(--c-s4)" />
+<circle cx="392.31" cy="44.43" r="2" fill="var(--c-s4)" />
+<circle cx="400.15" cy="43.50" r="2" fill="var(--c-s4)" />
+<circle cx="408.00" cy="42.61" r="2" fill="var(--c-s4)" />
+<circle cx="415.85" cy="41.74" r="2" fill="var(--c-s4)" />
+<circle cx="423.69" cy="40.89" r="2" fill="var(--c-s4)" />
+<circle cx="431.54" cy="39.62" r="2" fill="var(--c-s4)" />
+<circle cx="439.38" cy="37.71" r="2" fill="var(--c-s4)" />
+<circle cx="447.23" cy="35.86" r="2" fill="var(--c-s4)" />
+<circle cx="455.08" cy="34.06" r="2" fill="var(--c-s4)" />
+<circle cx="462.92" cy="32.31" r="2" fill="var(--c-s4)" />
+<circle cx="470.77" cy="30.60" r="2" fill="var(--c-s4)" />
+<circle cx="478.62" cy="28.94" r="2" fill="var(--c-s4)" />
+<circle cx="486.46" cy="27.32" r="2" fill="var(--c-s4)" />
+<circle cx="494.31" cy="25.75" r="2" fill="var(--c-s4)" />
+<circle cx="502.15" cy="24.21" r="2" fill="var(--c-s4)" />
+<circle cx="510.00" cy="22.71" r="2" fill="var(--c-s4)" />
+<polyline points="0.00,284.88 7.85,284.88 15.69,284.88 23.54,250.63 31.38,215.01 39.23,197.25 47.08,181.19 54.92,166.58 62.77,155.79 70.62,151.34 78.46,145.59 86.31,140.28 94.15,135.37 102.00,130.81 109.85,126.57 117.69,122.60 125.54,118.89 133.38,115.42 141.23,112.15 149.08,109.08 156.92,106.18 164.77,103.44 172.62,100.86 180.46,98.40 188.31,96.08 196.15,93.52 204.00,89.85 211.85,86.35 219.69,83.02 227.54,79.83 235.38,76.79 243.23,73.88 251.08,71.10 258.92,68.43 266.77,65.87 274.62,63.41 282.46,61.05 290.31,58.78 298.15,56.59 306.00,54.49 313.85,52.46 321.69,50.51 329.54,48.62 337.38,46.80 345.23,45.04 353.08,43.34 360.92,41.69 368.77,40.60 376.62,39.67 384.46,38.78 392.31,37.91 400.15,37.05 408.00,35.05 415.85,33.12 423.69,31.23 431.54,29.41 439.38,27.63 447.23,25.90 455.08,24.22 462.92,22.59 470.77,21.00 478.62,19.45 486.46,17.94 494.31,16.47 502.15,15.03 510.00,13.64" fill="none" stroke="var(--c-s5)" stroke-width="2" stroke-linejoin="round" stroke-linecap="round" />
+<circle cx="0.00" cy="284.88" r="2" fill="var(--c-s5)" />
+<circle cx="7.85" cy="284.88" r="2" fill="var(--c-s5)" />
+<circle cx="15.69" cy="284.88" r="2" fill="var(--c-s5)" />
+<circle cx="23.54" cy="250.63" r="2" fill="var(--c-s5)" />
+<circle cx="31.38" cy="215.01" r="2" fill="var(--c-s5)" />
+<circle cx="39.23" cy="197.25" r="2" fill="var(--c-s5)" />
+<circle cx="47.08" cy="181.19" r="2" fill="var(--c-s5)" />
+<circle cx="54.92" cy="166.58" r="2" fill="var(--c-s5)" />
+<circle cx="62.77" cy="155.79" r="2" fill="var(--c-s5)" />
+<circle cx="70.62" cy="151.34" r="2" fill="var(--c-s5)" />
+<circle cx="78.46" cy="145.59" r="2" fill="var(--c-s5)" />
+<circle cx="86.31" cy="140.28" r="2" fill="var(--c-s5)" />
+<circle cx="94.15" cy="135.37" r="2" fill="var(--c-s5)" />
+<circle cx="102.00" cy="130.81" r="2" fill="var(--c-s5)" />
+<circle cx="109.85" cy="126.57" r="2" fill="var(--c-s5)" />
+<circle cx="117.69" cy="122.60" r="2" fill="var(--c-s5)" />
+<circle cx="125.54" cy="118.89" r="2" fill="var(--c-s5)" />
+<circle cx="133.38" cy="115.42" r="2" fill="var(--c-s5)" />
+<circle cx="141.23" cy="112.15" r="2" fill="var(--c-s5)" />
+<circle cx="149.08" cy="109.08" r="2" fill="var(--c-s5)" />
+<circle cx="156.92" cy="106.18" r="2" fill="var(--c-s5)" />
+<circle cx="164.77" cy="103.44" r="2" fill="var(--c-s5)" />
+<circle cx="172.62" cy="100.86" r="2" fill="var(--c-s5)" />
+<circle cx="180.46" cy="98.40" r="2" fill="var(--c-s5)" />
+<circle cx="188.31" cy="96.08" r="2" fill="var(--c-s5)" />
+<circle cx="196.15" cy="93.52" r="2" fill="var(--c-s5)" />
+<circle cx="204.00" cy="89.85" r="2" fill="var(--c-s5)" />
+<circle cx="211.85" cy="86.35" r="2" fill="var(--c-s5)" />
+<circle cx="219.69" cy="83.02" r="2" fill="var(--c-s5)" />
+<circle cx="227.54" cy="79.83" r="2" fill="var(--c-s5)" />
+<circle cx="235.38" cy="76.79" r="2" fill="var(--c-s5)" />
+<circle cx="243.23" cy="73.88" r="2" fill="var(--c-s5)" />
+<circle cx="251.08" cy="71.10" r="2" fill="var(--c-s5)" />
+<circle cx="258.92" cy="68.43" r="2" fill="var(--c-s5)" />
+<circle cx="266.77" cy="65.87" r="2" fill="var(--c-s5)" />
+<circle cx="274.62" cy="63.41" r="2" fill="var(--c-s5)" />
+<circle cx="282.46" cy="61.05" r="2" fill="var(--c-s5)" />
+<circle cx="290.31" cy="58.78" r="2" fill="var(--c-s5)" />
+<circle cx="298.15" cy="56.59" r="2" fill="var(--c-s5)" />
+<circle cx="306.00" cy="54.49" r="2" fill="var(--c-s5)" />
+<circle cx="313.85" cy="52.46" r="2" fill="var(--c-s5)" />
+<circle cx="321.69" cy="50.51" r="2" fill="var(--c-s5)" />
+<circle cx="329.54" cy="48.62" r="2" fill="var(--c-s5)" />
+<circle cx="337.38" cy="46.80" r="2" fill="var(--c-s5)" />
+<circle cx="345.23" cy="45.04" r="2" fill="var(--c-s5)" />
+<circle cx="353.08" cy="43.34" r="2" fill="var(--c-s5)" />
+<circle cx="360.92" cy="41.69" r="2" fill="var(--c-s5)" />
+<circle cx="368.77" cy="40.60" r="2" fill="var(--c-s5)" />
+<circle cx="376.62" cy="39.67" r="2" fill="var(--c-s5)" />
+<circle cx="384.46" cy="38.78" r="2" fill="var(--c-s5)" />
+<circle cx="392.31" cy="37.91" r="2" fill="var(--c-s5)" />
+<circle cx="400.15" cy="37.05" r="2" fill="var(--c-s5)" />
+<circle cx="408.00" cy="35.05" r="2" fill="var(--c-s5)" />
+<circle cx="415.85" cy="33.12" r="2" fill="var(--c-s5)" />
+<circle cx="423.69" cy="31.23" r="2" fill="var(--c-s5)" />
+<circle cx="431.54" cy="29.41" r="2" fill="var(--c-s5)" />
+<circle cx="439.38" cy="27.63" r="2" fill="var(--c-s5)" />
+<circle cx="447.23" cy="25.90" r="2" fill="var(--c-s5)" />
+<circle cx="455.08" cy="24.22" r="2" fill="var(--c-s5)" />
+<circle cx="462.92" cy="22.59" r="2" fill="var(--c-s5)" />
+<circle cx="470.77" cy="21.00" r="2" fill="var(--c-s5)" />
+<circle cx="478.62" cy="19.45" r="2" fill="var(--c-s5)" />
+<circle cx="486.46" cy="17.94" r="2" fill="var(--c-s5)" />
+<circle cx="494.31" cy="16.47" r="2" fill="var(--c-s5)" />
+<circle cx="502.15" cy="15.03" r="2" fill="var(--c-s5)" />
+<circle cx="510.00" cy="13.64" r="2" fill="var(--c-s5)" />
+<rect x="528" y="0" width="14" height="3" fill="var(--c-s0)" />
+<text x="550" y="6" fill="var(--c-title)" font-size="12">2012</text>
+<rect x="528" y="22" width="14" height="3" fill="var(--c-s1)" />
+<text x="550" y="28" fill="var(--c-title)" font-size="12">2015</text>
+<rect x="528" y="44" width="14" height="3" fill="var(--c-s2)" />
+<text x="550" y="50" fill="var(--c-title)" font-size="12">2018</text>
+<rect x="528" y="66" width="14" height="3" fill="var(--c-s3)" />
+<text x="550" y="72" fill="var(--c-title)" font-size="12">2022</text>
+<rect x="528" y="88" width="14" height="3" fill="var(--c-s4)" />
+<text x="550" y="94" fill="var(--c-title)" font-size="12">2024</text>
+<rect x="528" y="110" width="14" height="3" fill="var(--c-s5)" />
+<text x="550" y="116" fill="var(--c-title)" font-size="12">2026</text>
 </g>
 </svg>

--- a/scripts/render-charts.ts
+++ b/scripts/render-charts.ts
@@ -14,7 +14,26 @@ import { INFLACION_A_2026 } from '../src/inflacion.ts';
 const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 const OUT_DIR = join(REPO_ROOT, 'docs', 'assets');
 
-const PALETTE = ['#1f77b4', '#d62728', '#2ca02c', '#9467bd', '#ff7f0e', '#17becf'] as const;
+export const PALETTE_LIGHT = {
+  bg: '#f7f3ec',
+  axis: '#333333',
+  grid: '#e5e5e5',
+  text: '#444444',
+  title: '#222222',
+  series: ['#1f77b4', '#d62728', '#2ca02c', '#9467bd', '#ff7f0e', '#17becf'] as const,
+} as const;
+
+export const PALETTE_DARK = {
+  bg: '#1a1612',
+  axis: '#f3ede2',
+  grid: '#3a342c',
+  text: '#d4cdbf',
+  title: '#f3ede2',
+  series: ['#5d9ec9', '#e87073', '#66bf66', '#b89bd6', '#ffaa57', '#71d6e0'] as const,
+} as const;
+
+// Alias que mantiene la firma actual del código de render (Tarea 7 lo migra a var()).
+const PALETTE = PALETTE_LIGHT.series;
 
 interface Series {
   label: string;

--- a/scripts/render-charts.ts
+++ b/scripts/render-charts.ts
@@ -14,13 +14,17 @@ import { INFLACION_A_2026 } from '../src/inflacion.ts';
 const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 const OUT_DIR = join(REPO_ROOT, 'docs', 'assets');
 
+// Paleta de series tab10-derivada, ajustada para alcanzar ≥ 3:1 sobre `bg`
+// (WCAG 2.1 SC 1.4.11, non-text contrast). Los valores originales
+// (#ff7f0e ≈ 2.29:1, #17becf ≈ 2.04:1) no eran perceivables sobre la paleta
+// editorial cálida.
 export const PALETTE_LIGHT = {
   bg: '#f7f3ec',
   axis: '#333333',
   grid: '#e5e5e5',
   text: '#444444',
   title: '#222222',
-  series: ['#1f77b4', '#d62728', '#2ca02c', '#9467bd', '#ff7f0e', '#17becf'] as const,
+  series: ['#1f77b4', '#d62728', '#2ca02c', '#9467bd', '#cc6600', '#00838f'] as const,
 } as const;
 
 export const PALETTE_DARK = {

--- a/scripts/render-charts.ts
+++ b/scripts/render-charts.ts
@@ -8,8 +8,8 @@
 import { mkdirSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { calcularNomina } from '../src/pipeline.ts';
-import { INFLACION_A_2026 } from '../src/inflacion.ts';
+import { calcularNomina } from '../src/pipeline';
+import { INFLACION_A_2026 } from '../src/inflacion';
 
 const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 const OUT_DIR = join(REPO_ROOT, 'docs', 'assets');
@@ -36,12 +36,8 @@ export const PALETTE_DARK = {
   series: ['#5d9ec9', '#e87073', '#66bf66', '#b89bd6', '#ffaa57', '#71d6e0'] as const,
 } as const;
 
-// Alias que mantiene la firma actual del código de render (Tarea 7 lo migra a var()).
-const PALETTE = PALETTE_LIGHT.series;
-
 interface Series {
   label: string;
-  color: string;
   points: [number, number][];
 }
 
@@ -90,6 +86,44 @@ function escapeXml(s: string): string {
     .replace(/"/g, '&quot;');
 }
 
+interface ChartPalette {
+  bg: string;
+  axis: string;
+  grid: string;
+  text: string;
+  title: string;
+  series: readonly string[];
+}
+
+function paletteStyleBlock(): string {
+  const L: ChartPalette = PALETTE_LIGHT;
+  const D: ChartPalette = PALETTE_DARK;
+  const seriesVars = (p: ChartPalette, indent: string): string =>
+    p.series.map((c, i) => `${indent}--c-s${String(i)}: ${c};`).join('\n');
+  return [
+    '<style>',
+    '  :root {',
+    `    --c-bg: ${L.bg};`,
+    `    --c-axis: ${L.axis};`,
+    `    --c-grid: ${L.grid};`,
+    `    --c-text: ${L.text};`,
+    `    --c-title: ${L.title};`,
+    seriesVars(L, '    '),
+    '  }',
+    '  @media (prefers-color-scheme: dark) {',
+    '    :root {',
+    `      --c-bg: ${D.bg};`,
+    `      --c-axis: ${D.axis};`,
+    `      --c-grid: ${D.grid};`,
+    `      --c-text: ${D.text};`,
+    `      --c-title: ${D.title};`,
+    seriesVars(D, '      '),
+    '    }',
+    '  }',
+    '</style>',
+  ].join('\n');
+}
+
 function renderChart(spec: ChartSpec): string {
   const W = spec.width ?? 760;
   const H = spec.height ?? 420;
@@ -119,84 +153,79 @@ function renderChart(spec: ChartSpec): string {
   );
   parts.push(`<title id="${spec.slug}-title">${escapeXml(spec.title)}</title>`);
   parts.push(`<desc id="${spec.slug}-desc">${escapeXml(spec.desc)}</desc>`);
-  parts.push(`<rect width="${String(W)}" height="${String(H)}" fill="#ffffff" />`);
+  parts.push(paletteStyleBlock());
+  parts.push(`<rect width="${String(W)}" height="${String(H)}" fill="var(--c-bg)" />`);
 
-  // Title
   parts.push(
-    `<text x="${String(M.left)}" y="${String(M.top - 25)}" font-size="16" font-weight="600" fill="#222">${escapeXml(spec.title)}</text>`,
+    `<text x="${String(M.left)}" y="${String(M.top - 25)}" font-size="16" font-weight="600" fill="var(--c-title)">${escapeXml(spec.title)}</text>`,
   );
 
-  // Plot area transform
   parts.push(`<g transform="translate(${String(M.left)},${String(M.top)})">`);
 
-  // Gridlines (horizontal)
   for (const t of yTicks) {
     const yp = y(t);
     parts.push(
-      `<line x1="0" y1="${yp.toFixed(2)}" x2="${String(innerW)}" y2="${yp.toFixed(2)}" stroke="#e5e5e5" stroke-width="1" />`,
+      `<line x1="0" y1="${yp.toFixed(2)}" x2="${String(innerW)}" y2="${yp.toFixed(2)}" stroke="var(--c-grid)" stroke-width="1" />`,
     );
   }
 
-  // Axes
   parts.push(
-    `<line x1="0" y1="${String(innerH)}" x2="${String(innerW)}" y2="${String(innerH)}" stroke="#333" stroke-width="1" />`,
+    `<line x1="0" y1="${String(innerH)}" x2="${String(innerW)}" y2="${String(innerH)}" stroke="var(--c-axis)" stroke-width="1" />`,
   );
-  parts.push(`<line x1="0" y1="0" x2="0" y2="${String(innerH)}" stroke="#333" stroke-width="1" />`);
+  parts.push(
+    `<line x1="0" y1="0" x2="0" y2="${String(innerH)}" stroke="var(--c-axis)" stroke-width="1" />`,
+  );
 
-  // X ticks + labels
   for (const t of xTicks) {
     const xp = x(t);
     parts.push(
-      `<line x1="${xp.toFixed(2)}" y1="${String(innerH)}" x2="${xp.toFixed(2)}" y2="${String(innerH + 5)}" stroke="#333" stroke-width="1" />`,
+      `<line x1="${xp.toFixed(2)}" y1="${String(innerH)}" x2="${xp.toFixed(2)}" y2="${String(innerH + 5)}" stroke="var(--c-axis)" stroke-width="1" />`,
     );
     parts.push(
-      `<text x="${xp.toFixed(2)}" y="${String(innerH + 22)}" text-anchor="middle" fill="#444">${escapeXml(spec.xFormat(t))}</text>`,
+      `<text x="${xp.toFixed(2)}" y="${String(innerH + 22)}" text-anchor="middle" fill="var(--c-text)">${escapeXml(spec.xFormat(t))}</text>`,
     );
   }
 
-  // Y ticks + labels
   for (const t of yTicks) {
     const yp = y(t);
     parts.push(
-      `<line x1="-5" y1="${yp.toFixed(2)}" x2="0" y2="${yp.toFixed(2)}" stroke="#333" stroke-width="1" />`,
+      `<line x1="-5" y1="${yp.toFixed(2)}" x2="0" y2="${yp.toFixed(2)}" stroke="var(--c-axis)" stroke-width="1" />`,
     );
     parts.push(
-      `<text x="-10" y="${(yp + 4).toFixed(2)}" text-anchor="end" fill="#444">${escapeXml(spec.yFormat(t))}</text>`,
+      `<text x="-10" y="${(yp + 4).toFixed(2)}" text-anchor="end" fill="var(--c-text)">${escapeXml(spec.yFormat(t))}</text>`,
     );
   }
 
-  // Axis labels
   parts.push(
-    `<text x="${String(innerW / 2)}" y="${String(innerH + 48)}" text-anchor="middle" fill="#222" font-size="13">${escapeXml(spec.xLabel)}</text>`,
+    `<text x="${String(innerW / 2)}" y="${String(innerH + 48)}" text-anchor="middle" fill="var(--c-title)" font-size="13">${escapeXml(spec.xLabel)}</text>`,
   );
   parts.push(
-    `<text transform="translate(-55,${String(innerH / 2)}) rotate(-90)" text-anchor="middle" fill="#222" font-size="13">${escapeXml(spec.yLabel)}</text>`,
+    `<text transform="translate(-55,${String(innerH / 2)}) rotate(-90)" text-anchor="middle" fill="var(--c-title)" font-size="13">${escapeXml(spec.yLabel)}</text>`,
   );
 
-  // Series
-  for (const s of spec.series) {
+  for (const [si, s] of spec.series.entries()) {
+    const colorVar = `var(--c-s${String(si)})`;
     const points = s.points.map(([px, py]) => `${x(px).toFixed(2)},${y(py).toFixed(2)}`).join(' ');
     parts.push(
-      `<polyline points="${points}" fill="none" stroke="${s.color}" stroke-width="2" stroke-linejoin="round" stroke-linecap="round" />`,
+      `<polyline points="${points}" fill="none" stroke="${colorVar}" stroke-width="2" stroke-linejoin="round" stroke-linecap="round" />`,
     );
-    // dots
     for (const [px, py] of s.points) {
       parts.push(
-        `<circle cx="${x(px).toFixed(2)}" cy="${y(py).toFixed(2)}" r="2" fill="${s.color}" />`,
+        `<circle cx="${x(px).toFixed(2)}" cy="${y(py).toFixed(2)}" r="2" fill="${colorVar}" />`,
       );
     }
   }
 
-  // Legend
   if (spec.series.length > 1 || spec.series[0]?.label) {
     const lx = innerW + 18;
     let ly = 0;
-    for (const s of spec.series) {
+    for (const [si, s] of spec.series.entries()) {
+      const colorVar = `var(--c-s${String(si)})`;
       parts.push(
-        `<rect x="${String(lx)}" y="${String(ly)}" width="14" height="3" fill="${s.color}" />`,
+        `<rect x="${String(lx)}" y="${String(ly)}" width="14" height="3" fill="${colorVar}" />`,
       );
       parts.push(
-        `<text x="${String(lx + 22)}" y="${String(ly + 6)}" fill="#222" font-size="12">${escapeXml(s.label)}</text>`,
+        `<text x="${String(lx + 22)}" y="${String(ly + 6)}" fill="var(--c-title)" font-size="12">${escapeXml(s.label)}</text>`,
       );
       ly += 22;
     }
@@ -209,11 +238,19 @@ function renderChart(spec: ChartSpec): string {
 
 // ---- Chart specs ----
 
+function inflacionFor(anio: number): number {
+  const mult = INFLACION_A_2026[anio];
+  if (mult === undefined) {
+    throw new Error(`render-charts: INFLACION_A_2026[${String(anio)}] no definido`);
+  }
+  return mult;
+}
+
 function chartNetoRealMismoNominal(): ChartSpec {
   const points: [number, number][] = [];
   for (let a = 2012; a <= 2026; a++) {
     const n = calcularNomina(30000, a);
-    points.push([a, n.salarioNeto * INFLACION_A_2026[a]]);
+    points.push([a, n.salarioNeto * inflacionFor(a)]);
   }
   return {
     slug: 'neto-real-mismo-nominal',
@@ -223,21 +260,20 @@ function chartNetoRealMismoNominal(): ChartSpec {
     yLabel: 'Neto en € de 2026',
     xFormat: (v) => String(Math.round(v)),
     yFormat: (v) => Math.round(v).toLocaleString('es-ES') + ' €',
-    series: [{ label: 'Neto real (€ 2026)', color: PALETTE[0], points }],
+    series: [{ label: 'Neto real (€ 2026)', points }],
   };
 }
 
 function brutoSeriesByYear(years: number[]): Series[] {
   const series: Series[] = [];
-  let i = 0;
   for (const a of years) {
     const points: [number, number][] = [];
-    const mult = INFLACION_A_2026[a];
+    const mult = inflacionFor(a);
     for (let b = 15000; b <= 80000; b += 1000) {
       const n = calcularNomina(b / mult, a);
       points.push([b, n.salarioNeto * mult]);
     }
-    series.push({ label: String(a), color: PALETTE[i++ % PALETTE.length], points });
+    series.push({ label: String(a), points });
   }
   return series;
 }
@@ -257,17 +293,16 @@ function chartNetoRealBrutoRealFijo(): ChartSpec {
 
 function chartTipoMedioEfectivo(): ChartSpec {
   const series: Series[] = [];
-  let i = 0;
   for (const a of [2012, 2015, 2018, 2022, 2024, 2026]) {
     const points: [number, number][] = [];
-    const mult = INFLACION_A_2026[a];
+    const mult = inflacionFor(a);
     for (let b = 15000; b <= 80000; b += 1000) {
       const brutoNominal = b / mult;
       const n = calcularNomina(brutoNominal, a);
       const tipo = ((n.cotSocTrabajador + n.irpfFinal) / brutoNominal) * 100;
       points.push([b, tipo]);
     }
-    series.push({ label: String(a), color: PALETTE[i++ % PALETTE.length], points });
+    series.push({ label: String(a), points });
   }
   return {
     slug: 'tipo-medio-efectivo',

--- a/src/ui/theme.css
+++ b/src/ui/theme.css
@@ -32,7 +32,61 @@
   --container-gutter: 24px;
 
   /* Schemes */
-  color-scheme: light;
+  color-scheme: light dark;
+}
+
+/* Dark mode editorial.
+ *
+ * Pure @media en producción (auto-detección del SO). El selector dual
+ * :root[data-theme='dark'] existe únicamente como hook de tests
+ * (test/a11y.browser.test.ts, test/charts.browser.test.ts).
+ *
+ * Si este bloque crece > ~60 líneas, considerar extraer a tokens-dark.css.
+ */
+@media (prefers-color-scheme: dark) {
+  :root {
+    --paper: #1a1612;
+    --paper-deep: #100d0a;
+    --surface: #241f1a;
+    --ink: #f3ede2;
+    --ink-soft: #d4cdbf;
+    --ink-mute: #9a9388;
+    --rule: #3a342c;
+    --accent: #e89052;
+    --accent-soft: #6a3e22;
+    --cta-ink: #1a1612;
+    --paper-translucent: rgba(243, 237, 226, 0.75);
+    --neto: #6ab07a;
+    --ss: #8a8e9e;
+  }
+
+  /* La banda Excel se construye sobre --ink en light; al invertirse perdería
+   * la jerarquía "banda final = punto más oscuro". Forzar paper-deep. */
+  .excel-band {
+    background: var(--paper-deep);
+    color: var(--ink);
+  }
+}
+
+:root[data-theme='dark'] {
+  --paper: #1a1612;
+  --paper-deep: #100d0a;
+  --surface: #241f1a;
+  --ink: #f3ede2;
+  --ink-soft: #d4cdbf;
+  --ink-mute: #9a9388;
+  --rule: #3a342c;
+  --accent: #e89052;
+  --accent-soft: #6a3e22;
+  --cta-ink: #1a1612;
+  --paper-translucent: rgba(243, 237, 226, 0.75);
+  --neto: #6ab07a;
+  --ss: #8a8e9e;
+}
+
+:root[data-theme='dark'] .excel-band {
+  background: var(--paper-deep);
+  color: var(--ink);
 }
 
 /* Reset essentials (replaces what Pico used to do) */

--- a/src/ui/theme.css
+++ b/src/ui/theme.css
@@ -11,12 +11,14 @@
   /* Palette */
   --paper: #f7f3ec; /* warm off-white, page background */
   --paper-deep: #f1ebdf; /* used in history section */
+  --surface: #ffffff; /* elevated cards / inputs / v-bar empty / multi-cell */
   --ink: #1a1a1a; /* primary text   — vs --paper: 15.74:1 (WCAG AA, large+normal) */
   --ink-soft: #444444; /* body prose     — vs --paper:  8.81:1 (WCAG AA, large+normal) */
   --ink-mute: #666666; /* eyebrows, captions — vs --paper: 5.19:1 (WCAG AA normal) */
   --rule: #d4cdbf; /* hairlines, borders */
   --accent: #a84e1a; /* burnt orange   — vs --paper: 5.04:1, vs --paper-deep: 4.69:1 (WCAG AA); #fff on accent: 5.57:1 */
   --accent-soft: #f9c79c; /* lighter accent fills (background only, not used as text) */
+  --cta-ink: #ffffff; /* text on --accent (CTA, v-amount on fill) */
   --paper-translucent: rgba(247, 243, 236, 0.75); /* --paper at 75% opacity, for use on --ink bg */
   --neto: #2f6b3c; /* deep green     — vs --paper: 5.77:1; #fff on neto: 6.38:1 (WCAG AA) */
   --ss: #4a5a6e; /* slate          — vs --paper: 6.37:1; #fff on ss:   7.05:1 (WCAG AA) */

--- a/src/ui/theme.css
+++ b/src/ui/theme.css
@@ -154,7 +154,7 @@ select {
   font-family: var(--font-display);
   font-size: 1.1rem;
   padding: 12px 14px;
-  background: #fff;
+  background: var(--surface);
   color: var(--ink);
   border: 1px solid var(--rule);
   border-radius: 4px;
@@ -256,7 +256,7 @@ details[open] > summary::before {
 .cta {
   display: inline-block;
   background: var(--accent);
-  color: #fff;
+  color: var(--cta-ink);
   padding: 12px 22px;
   border-radius: 4px;
   font-family: var(--font-body);
@@ -385,7 +385,7 @@ details > summary:focus-visible {
 }
 .v-bar {
   height: 22px;
-  background: #fff;
+  background: var(--surface);
   border: 1px solid var(--rule);
   border-radius: 3px;
   overflow: hidden;
@@ -421,7 +421,7 @@ details > summary:focus-visible {
   }
 }
 .multi-cell {
-  background: #fff;
+  background: var(--surface);
   border: 1px solid var(--rule);
   border-radius: 6px;
   padding: 12px;
@@ -536,7 +536,7 @@ input[type='range']#input-anio::-webkit-slider-thumb {
   height: 18px;
   border-radius: 50%;
   background: var(--accent);
-  border: 2px solid #fff;
+  border: 2px solid var(--surface);
   box-shadow: 0 0 0 1px var(--accent);
   margin-top: -7px; /* centra el thumb sobre el track de 4px */
   cursor: pointer;
@@ -546,7 +546,7 @@ input[type='range']#input-anio::-moz-range-thumb {
   height: 18px;
   border-radius: 50%;
   background: var(--accent);
-  border: 2px solid #fff;
+  border: 2px solid var(--surface);
   box-shadow: 0 0 0 1px var(--accent);
   cursor: pointer;
 }

--- a/src/ui/theme.css
+++ b/src/ui/theme.css
@@ -338,7 +338,7 @@ details[open] > summary::before {
   margin: 0 calc(-1 * var(--container-gutter));
 }
 .excel-band h3 {
-  color: var(--paper);
+  color: inherit;
 }
 .excel-band .lead {
   color: var(--paper-translucent);

--- a/test/a11y.browser.test.ts
+++ b/test/a11y.browser.test.ts
@@ -31,47 +31,52 @@ function setupApp(): HTMLElement {
   return app;
 }
 
-describe('a11y: SPA passes axe-core (WCAG 2.1 AA)', () => {
-  beforeEach(() => {
-    document.documentElement.dataset.theme = 'light';
-  });
+function suiteFor(theme: 'light' | 'dark'): void {
+  describe(`a11y: SPA passes axe-core (WCAG 2.1 AA) — ${theme}`, () => {
+    beforeEach(() => {
+      document.documentElement.dataset.theme = theme;
+    });
 
-  afterEach(() => {
-    document.body.innerHTML = '';
-    delete document.documentElement.dataset.theme;
-  });
+    afterEach(() => {
+      document.body.innerHTML = '';
+      delete document.documentElement.dataset.theme;
+    });
 
-  it('has no serious or critical violations on initial render', async () => {
-    setupApp();
-    await waitForRender('#hero-section');
-    const violations = await scanForCriticalViolations();
-    expect(violations, JSON.stringify(violations, null, 2)).toEqual([]);
-  });
+    it('has no serious or critical violations on initial render', async () => {
+      setupApp();
+      await waitForRender('#hero-section');
+      const violations = await scanForCriticalViolations();
+      expect(violations, JSON.stringify(violations, null, 2)).toEqual([]);
+    });
 
-  it('has no serious or critical violations after changing bruto', async () => {
-    setupApp();
-    await waitForRender('#hero-section');
-    const input = document.querySelector<HTMLInputElement>('#input-bruto');
-    if (!input) throw new Error('bruto input missing');
-    input.value = '45000';
-    input.dispatchEvent(new Event('input', { bubbles: true }));
-    await new Promise((r) => setTimeout(r, 500));
-    const violations = await scanForCriticalViolations();
-    expect(violations, JSON.stringify(violations, null, 2)).toEqual([]);
-  });
+    it('has no serious or critical violations after changing bruto', async () => {
+      setupApp();
+      await waitForRender('#hero-section');
+      const input = document.querySelector<HTMLInputElement>('#input-bruto');
+      if (!input) throw new Error('bruto input missing');
+      input.value = '45000';
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+      await new Promise((r) => setTimeout(r, 500));
+      const violations = await scanForCriticalViolations();
+      expect(violations, JSON.stringify(violations, null, 2)).toEqual([]);
+    });
 
-  it('has no serious or critical violations while the Excel button shows aria-busy', async () => {
-    // We set aria-busy directly rather than clicking the button: a real click
-    // would trigger the full 15-year x 100k-row workbook build (minutes of
-    // CPU). The point of this scan is to verify the busy-state markup is
-    // accessible, not to exercise SheetJS.
-    setupApp();
-    await waitForRender('#hero-section');
-    const button = document.querySelector<HTMLButtonElement>('#excel-download');
-    if (!button) throw new Error('excel-download button missing');
-    button.setAttribute('aria-busy', 'true');
-    button.disabled = true;
-    const violations = await scanForCriticalViolations();
-    expect(violations, JSON.stringify(violations, null, 2)).toEqual([]);
+    it('has no serious or critical violations while the Excel button shows aria-busy', async () => {
+      // We set aria-busy directly rather than clicking the button: a real click
+      // would trigger the full 15-year x 100k-row workbook build (minutes of
+      // CPU). The point of this scan is to verify the busy-state markup is
+      // accessible, not to exercise SheetJS.
+      setupApp();
+      await waitForRender('#hero-section');
+      const button = document.querySelector<HTMLButtonElement>('#excel-download');
+      if (!button) throw new Error('excel-download button missing');
+      button.setAttribute('aria-busy', 'true');
+      button.disabled = true;
+      const violations = await scanForCriticalViolations();
+      expect(violations, JSON.stringify(violations, null, 2)).toEqual([]);
+    });
   });
-});
+}
+
+suiteFor('light');
+suiteFor('dark');

--- a/test/charts.browser.test.ts
+++ b/test/charts.browser.test.ts
@@ -1,9 +1,18 @@
 // test/charts.browser.test.ts
+import '../src/ui/theme.css';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { renderStackedBar, type StackedBarData } from '../src/ui/charts/stacked-bar';
 import { renderVasos, type VasosData } from '../src/ui/charts/vasos';
 import { renderGapArea, type GapAreaData } from '../src/ui/charts/gap-area';
 import { renderMultiples, type MultiplesData } from '../src/ui/charts/multiples';
+
+function setTheme(theme: 'light' | 'dark'): void {
+  document.documentElement.dataset.theme = theme;
+}
+
+function clearTheme(): void {
+  delete document.documentElement.dataset.theme;
+}
 
 let host: HTMLElement;
 beforeEach(() => {
@@ -12,6 +21,7 @@ beforeEach(() => {
 });
 afterEach(() => {
   document.body.innerHTML = '';
+  clearTheme();
 });
 
 describe('renderStackedBar', () => {
@@ -151,5 +161,70 @@ describe('renderMultiples', () => {
     );
     expect(xLabels).toContain('2012');
     expect(xLabels).toContain('2026');
+  });
+});
+
+describe('charts: var(--token) fills resolve in both themes', () => {
+  const stacked: StackedBarData = {
+    bruto: 30_000,
+    neto: 24_518,
+    irpf: 3_577,
+    cotSocTrabajador: 1_905,
+  };
+  const vasosData: VasosData = {
+    tramos: [
+      { idx: 1, tipo: 0.19, hasta: 12_450, baseAplicada: 12_450, cuota: 2_366 },
+      { idx: 2, tipo: 0.24, hasta: 20_200, baseAplicada: 7_750, cuota: 1_860 },
+    ],
+    baseImponible: 20_200,
+  };
+
+  function firstFill(selector: string): string {
+    const el = host.querySelector(selector);
+    if (!el) throw new Error(`charts test: ${selector} not in DOM`);
+    return getComputedStyle(el).fill;
+  }
+
+  it('stacked-bar .segment fill resolves to a non-transparent color in light', () => {
+    setTheme('light');
+    renderStackedBar(host, stacked);
+    const fill = firstFill('rect.segment');
+    expect(fill).not.toBe('');
+    expect(fill).not.toBe('rgba(0, 0, 0, 0)');
+    expect(fill).not.toBe('none');
+  });
+
+  it('stacked-bar .segment fill resolves to a non-transparent color in dark', () => {
+    setTheme('dark');
+    renderStackedBar(host, stacked);
+    const fill = firstFill('rect.segment');
+    expect(fill).not.toBe('');
+    expect(fill).not.toBe('rgba(0, 0, 0, 0)');
+    expect(fill).not.toBe('none');
+  });
+
+  it('stacked-bar .segment fill differs between light and dark themes', () => {
+    setTheme('light');
+    renderStackedBar(host, stacked);
+    const light = firstFill('rect.segment');
+
+    document.body.innerHTML = '<div id="host"></div>';
+    host = document.getElementById('host') as HTMLElement;
+
+    setTheme('dark');
+    renderStackedBar(host, stacked);
+    const dark = firstFill('rect.segment');
+
+    expect(dark).not.toBe(light);
+  });
+
+  it('vasos .v-fill background resolves in both themes', () => {
+    setTheme('dark');
+    renderVasos(host, vasosData);
+    const fill = host.querySelector<HTMLElement>('.v-fill');
+    if (!fill) throw new Error('charts test: .v-fill not in DOM');
+    const bg = getComputedStyle(fill).backgroundColor;
+    expect(bg).not.toBe('');
+    expect(bg).not.toBe('rgba(0, 0, 0, 0)');
   });
 });

--- a/test/contrast.test.ts
+++ b/test/contrast.test.ts
@@ -9,7 +9,7 @@ import { readFileSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
-import { PALETTE_LIGHT, PALETTE_DARK } from '../scripts/render-charts.ts';
+import { PALETTE_LIGHT, PALETTE_DARK } from '../scripts/render-charts';
 
 const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 const THEME_CSS = readFileSync(join(REPO_ROOT, 'src/ui/theme.css'), 'utf8');
@@ -30,7 +30,9 @@ function parseProps(body: string): Tokens {
   const re = /--([a-z][a-z0-9-]*)\s*:\s*([^;]+);/gi;
   let m: RegExpExecArray | null;
   while ((m = re.exec(clean)) !== null) {
-    out[`--${m[1]}`] = m[2].trim();
+    const [, name, value] = m;
+    if (name === undefined || value === undefined) continue;
+    out[`--${name}`] = value.trim();
   }
   return out;
 }
@@ -38,7 +40,9 @@ function parseProps(body: string): Tokens {
 /** Tokens del `:root` light (primer bloque `:root { ... }`). */
 function parseLightTokens(css: string): Tokens {
   const match = css.match(/:root\s*\{([\s\S]*?)\}/);
-  if (!match) throw new Error('contrast: no :root block found in theme.css');
+  if (!match || match[1] === undefined) {
+    throw new Error('contrast: no :root block found in theme.css');
+  }
   return parseProps(match[1]);
 }
 
@@ -47,7 +51,9 @@ function parseDarkTokens(css: string): Tokens {
   const match = css.match(
     /@media\s*\(\s*prefers-color-scheme:\s*dark\s*\)\s*\{\s*:root\s*\{([\s\S]*?)\}\s*\}/,
   );
-  if (!match) throw new Error('contrast: no dark @media :root block found in theme.css');
+  if (!match || match[1] === undefined) {
+    throw new Error('contrast: no dark @media :root block found in theme.css');
+  }
   return parseProps(match[1]);
 }
 
@@ -70,9 +76,13 @@ function parseColor(v: string): { r: number; g: number; b: number; a: number } {
     };
   }
   const rgba = s.match(/^rgba?\(([^)]+)\)$/i);
-  if (rgba) {
+  if (rgba && rgba[1] !== undefined) {
     const parts = rgba[1].split(',').map((p) => Number(p.trim()));
-    return { r: parts[0], g: parts[1], b: parts[2], a: parts[3] ?? 1 };
+    const [r, g, b, a] = parts;
+    if (r === undefined || g === undefined || b === undefined) {
+      throw new Error(`contrast: malformed rgba '${v}'`);
+    }
+    return { r, g, b, a: a ?? 1 };
   }
   throw new Error(`contrast: unsupported color '${v}'`);
 }
@@ -111,9 +121,9 @@ function resolve(tokens: Tokens, value: string, depth = 0): string {
   if (depth > 8) throw new Error(`contrast: token resolution too deep for '${value}'`);
   const v = value.trim();
   const varMatch = v.match(/^var\(\s*(--[a-z0-9-]+)\s*\)$/i);
-  if (varMatch) {
+  if (varMatch && varMatch[1] !== undefined) {
     const next = tokens[varMatch[1]];
-    if (!next) throw new Error(`contrast: unresolved var ${varMatch[1]}`);
+    if (next === undefined) throw new Error(`contrast: unresolved var ${varMatch[1]}`);
     return resolve(tokens, next, depth + 1);
   }
   return v;

--- a/test/contrast.test.ts
+++ b/test/contrast.test.ts
@@ -16,12 +16,20 @@ const THEME_CSS = readFileSync(join(REPO_ROOT, 'src/ui/theme.css'), 'utf8');
 
 type Tokens = Record<string, string>;
 
+/** Elimina comentarios `/* ... *\/` del cuerpo CSS para que `--paper` que
+ * aparece dentro de un comentario (e.g. "vs --paper: 15.74:1") no contamine
+ * los tokens. */
+function stripComments(css: string): string {
+  return css.replace(/\/\*[\s\S]*?\*\//g, '');
+}
+
 /** Extrae custom properties (`--name: value`) del cuerpo dado. */
 function parseProps(body: string): Tokens {
+  const clean = stripComments(body);
   const out: Tokens = {};
   const re = /--([a-z][a-z0-9-]*)\s*:\s*([^;]+);/gi;
   let m: RegExpExecArray | null;
-  while ((m = re.exec(body)) !== null) {
+  while ((m = re.exec(clean)) !== null) {
     out[`--${m[1]}`] = m[2].trim();
   }
   return out;
@@ -142,7 +150,10 @@ const SPA_PAIRS: Pair[] = [
   { fg: '--cta-ink', bg: '--accent', min: 4.5, label: 'cta-ink on accent' },
   { fg: '--ink', bg: '--surface', min: 4.5, label: 'ink on surface' },
   { fg: '--ink-soft', bg: '--surface', min: 4.5, label: 'ink-soft on surface' },
-  { fg: '--paper-translucent', bg: '--ink', over: '--ink', min: 4.5, label: 'paper-translucent on ink' },
+  // `--paper-translucent` se usa en `.excel-band .lead`. El bg real cambia con
+  // el tema (--ink en light, --paper-deep en dark por override). axe-core
+  // verifica este caso en el DOM rendered — no lo replicamos aquí como par
+  // estático porque tendría que ser theme-dependent.
 ];
 
 describe('contrast: SPA tokens meet WCAG 2.1 AA in both schemes', () => {
@@ -161,7 +172,7 @@ describe('contrast: SPA tokens meet WCAG 2.1 AA in both schemes', () => {
   }
 });
 
-describe('contrast: manual chart palette meets WCAG 2.1 AA in both schemes', () => {
+describe('contrast: manual chart palette meets WCAG 2.1 in both schemes', () => {
   const variants = [
     { name: 'light', p: PALETTE_LIGHT },
     { name: 'dark', p: PALETTE_DARK },
@@ -169,10 +180,20 @@ describe('contrast: manual chart palette meets WCAG 2.1 AA in both schemes', () 
 
   for (const v of variants) {
     const bg = parseColor(v.p.bg);
-    for (const fg of [v.p.axis, v.p.text, v.p.title, ...v.p.series]) {
-      it(`${v.name}: ${fg} on ${v.p.bg} ≥ 4.5:1`, () => {
+    // Text-like elements (axis labels, body text, titles) — WCAG 2.1 SC 1.4.3
+    // requires ≥ 4.5:1 for normal text.
+    for (const fg of [v.p.axis, v.p.text, v.p.title]) {
+      it(`${v.name} text: ${fg} on ${v.p.bg} ≥ 4.5:1`, () => {
         const r = ratio(parseColor(fg), bg);
         expect(r, `actual ${r.toFixed(2)}:1`).toBeGreaterThanOrEqual(4.5);
+      });
+    }
+    // Series lines/markers are non-text graphical objects — WCAG 2.1
+    // SC 1.4.11 requires ≥ 3:1 to be perceivable.
+    for (const fg of v.p.series) {
+      it(`${v.name} series: ${fg} on ${v.p.bg} ≥ 3:1`, () => {
+        const r = ratio(parseColor(fg), bg);
+        expect(r, `actual ${r.toFixed(2)}:1`).toBeGreaterThanOrEqual(3);
       });
     }
   }

--- a/test/contrast.test.ts
+++ b/test/contrast.test.ts
@@ -115,12 +115,12 @@ function resolve(tokens: Tokens, value: string, depth = 0): string {
 function contrastBetween(tokens: Tokens, fgName: string, bgName: string, overName?: string): number {
   const fg = parseColor(resolve(tokens, tokens[fgName] ?? fgName));
   const bg = parseColor(resolve(tokens, tokens[bgName] ?? bgName));
-  if (fg.a < 1) {
-    const over = parseColor(resolve(tokens, tokens[overName ?? bgName] ?? overName ?? bgName));
-    const flat = flatten(fg, over);
-    return ratio(flat, { r: bg.r, g: bg.g, b: bg.b });
+  if (fg.a >= 1) {
+    return ratio({ r: fg.r, g: fg.g, b: fg.b }, { r: bg.r, g: bg.g, b: bg.b });
   }
-  return ratio({ r: fg.r, g: fg.g, b: fg.b }, { r: bg.r, g: bg.g, b: bg.b });
+  const overKey = overName ?? bgName;
+  const over = parseColor(resolve(tokens, tokens[overKey] ?? overKey));
+  return ratio(flatten(fg, over), { r: bg.r, g: bg.g, b: bg.b });
 }
 
 interface Pair {

--- a/test/contrast.test.ts
+++ b/test/contrast.test.ts
@@ -110,7 +110,10 @@ function luminance({ r, g, b }: { r: number; g: number; b: number }): number {
 }
 
 /** Ratio WCAG 2.1 entre dos colores opacos. */
-function ratio(a: { r: number; g: number; b: number }, b: { r: number; g: number; b: number }): number {
+function ratio(
+  a: { r: number; g: number; b: number },
+  b: { r: number; g: number; b: number },
+): number {
   const L1 = Math.max(luminance(a), luminance(b));
   const L2 = Math.min(luminance(a), luminance(b));
   return (L1 + 0.05) / (L2 + 0.05);
@@ -130,7 +133,12 @@ function resolve(tokens: Tokens, value: string, depth = 0): string {
 }
 
 /** Calcula contraste entre dos token-names, aplanando alpha sobre `over` si hace falta. */
-function contrastBetween(tokens: Tokens, fgName: string, bgName: string, overName?: string): number {
+function contrastBetween(
+  tokens: Tokens,
+  fgName: string,
+  bgName: string,
+  overName?: string,
+): number {
   const fg = parseColor(resolve(tokens, tokens[fgName] ?? fgName));
   const bg = parseColor(resolve(tokens, tokens[bgName] ?? bgName));
   if (fg.a >= 1) {

--- a/test/contrast.test.ts
+++ b/test/contrast.test.ts
@@ -1,0 +1,179 @@
+// test/contrast.test.ts
+//
+// Verifica los ratios de contraste WCAG 2.1 para todos los pares texto/fondo
+// críticos de la SPA y los SVGs del manual, en ambos esquemas (light + dark).
+// No se hardcodean colores: se parsean los tokens definidos en
+// src/ui/theme.css y se importan las paletas de scripts/render-charts.ts.
+
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { PALETTE_LIGHT, PALETTE_DARK } from '../scripts/render-charts.ts';
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const THEME_CSS = readFileSync(join(REPO_ROOT, 'src/ui/theme.css'), 'utf8');
+
+type Tokens = Record<string, string>;
+
+/** Extrae custom properties (`--name: value`) del cuerpo dado. */
+function parseProps(body: string): Tokens {
+  const out: Tokens = {};
+  const re = /--([a-z][a-z0-9-]*)\s*:\s*([^;]+);/gi;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(body)) !== null) {
+    out[`--${m[1]}`] = m[2].trim();
+  }
+  return out;
+}
+
+/** Tokens del `:root` light (primer bloque `:root { ... }`). */
+function parseLightTokens(css: string): Tokens {
+  const match = css.match(/:root\s*\{([\s\S]*?)\}/);
+  if (!match) throw new Error('contrast: no :root block found in theme.css');
+  return parseProps(match[1]);
+}
+
+/** Tokens del bloque `@media (prefers-color-scheme: dark) { :root { ... } }`. */
+function parseDarkTokens(css: string): Tokens {
+  const match = css.match(
+    /@media\s*\(\s*prefers-color-scheme:\s*dark\s*\)\s*\{\s*:root\s*\{([\s\S]*?)\}\s*\}/,
+  );
+  if (!match) throw new Error('contrast: no dark @media :root block found in theme.css');
+  return parseProps(match[1]);
+}
+
+/** Combina light + dark: cualquier token no redefinido en dark hereda de light. */
+function resolveTokens(light: Tokens, dark: Tokens): Tokens {
+  return { ...light, ...dark };
+}
+
+/** Parsea `#rgb`, `#rrggbb` o `rgba(r, g, b, a)` a {r,g,b,a} en [0..255], a en [0..1]. */
+function parseColor(v: string): { r: number; g: number; b: number; a: number } {
+  const s = v.trim();
+  if (s.startsWith('#')) {
+    const hex = s.slice(1);
+    const expand = hex.length === 3 ? hex.replace(/(.)/g, '$1$1') : hex;
+    return {
+      r: parseInt(expand.slice(0, 2), 16),
+      g: parseInt(expand.slice(2, 4), 16),
+      b: parseInt(expand.slice(4, 6), 16),
+      a: 1,
+    };
+  }
+  const rgba = s.match(/^rgba?\(([^)]+)\)$/i);
+  if (rgba) {
+    const parts = rgba[1].split(',').map((p) => Number(p.trim()));
+    return { r: parts[0], g: parts[1], b: parts[2], a: parts[3] ?? 1 };
+  }
+  throw new Error(`contrast: unsupported color '${v}'`);
+}
+
+/** Compone color con alpha sobre fondo opaco — devuelve hex {r,g,b}. */
+function flatten(
+  fg: { r: number; g: number; b: number; a: number },
+  bg: { r: number; g: number; b: number },
+): { r: number; g: number; b: number } {
+  const a = fg.a;
+  return {
+    r: Math.round(fg.r * a + bg.r * (1 - a)),
+    g: Math.round(fg.g * a + bg.g * (1 - a)),
+    b: Math.round(fg.b * a + bg.b * (1 - a)),
+  };
+}
+
+/** Luminancia relativa WCAG 2.1. */
+function luminance({ r, g, b }: { r: number; g: number; b: number }): number {
+  const channel = (c: number): number => {
+    const s = c / 255;
+    return s <= 0.03928 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
+  };
+  return 0.2126 * channel(r) + 0.7152 * channel(g) + 0.0722 * channel(b);
+}
+
+/** Ratio WCAG 2.1 entre dos colores opacos. */
+function ratio(a: { r: number; g: number; b: number }, b: { r: number; g: number; b: number }): number {
+  const L1 = Math.max(luminance(a), luminance(b));
+  const L2 = Math.min(luminance(a), luminance(b));
+  return (L1 + 0.05) / (L2 + 0.05);
+}
+
+/** Resuelve un token (que puede ser hex/rgba/`var(--otro)`) recursivamente. */
+function resolve(tokens: Tokens, value: string, depth = 0): string {
+  if (depth > 8) throw new Error(`contrast: token resolution too deep for '${value}'`);
+  const v = value.trim();
+  const varMatch = v.match(/^var\(\s*(--[a-z0-9-]+)\s*\)$/i);
+  if (varMatch) {
+    const next = tokens[varMatch[1]];
+    if (!next) throw new Error(`contrast: unresolved var ${varMatch[1]}`);
+    return resolve(tokens, next, depth + 1);
+  }
+  return v;
+}
+
+/** Calcula contraste entre dos token-names, aplanando alpha sobre `over` si hace falta. */
+function contrastBetween(tokens: Tokens, fgName: string, bgName: string, overName?: string): number {
+  const fg = parseColor(resolve(tokens, tokens[fgName] ?? fgName));
+  const bg = parseColor(resolve(tokens, tokens[bgName] ?? bgName));
+  if (fg.a < 1) {
+    const over = parseColor(resolve(tokens, tokens[overName ?? bgName] ?? overName ?? bgName));
+    const flat = flatten(fg, over);
+    return ratio(flat, { r: bg.r, g: bg.g, b: bg.b });
+  }
+  return ratio({ r: fg.r, g: fg.g, b: fg.b }, { r: bg.r, g: bg.g, b: bg.b });
+}
+
+interface Pair {
+  fg: string;
+  bg: string;
+  /** Si el `fg` es translucent, sobre qué token aplanarlo. */
+  over?: string;
+  min: number;
+  label: string;
+}
+
+const SPA_PAIRS: Pair[] = [
+  { fg: '--ink', bg: '--paper', min: 4.5, label: 'ink on paper' },
+  { fg: '--ink-soft', bg: '--paper', min: 4.5, label: 'ink-soft on paper' },
+  { fg: '--ink-mute', bg: '--paper', min: 4.5, label: 'ink-mute on paper' },
+  { fg: '--accent', bg: '--paper', min: 4.5, label: 'accent on paper' },
+  { fg: '--neto', bg: '--paper', min: 4.5, label: 'neto on paper' },
+  { fg: '--ss', bg: '--paper', min: 4.5, label: 'ss on paper' },
+  { fg: '--cta-ink', bg: '--accent', min: 4.5, label: 'cta-ink on accent' },
+  { fg: '--ink', bg: '--surface', min: 4.5, label: 'ink on surface' },
+  { fg: '--ink-soft', bg: '--surface', min: 4.5, label: 'ink-soft on surface' },
+  { fg: '--paper-translucent', bg: '--ink', over: '--ink', min: 4.5, label: 'paper-translucent on ink' },
+];
+
+describe('contrast: SPA tokens meet WCAG 2.1 AA in both schemes', () => {
+  const light = parseLightTokens(THEME_CSS);
+  const dark = resolveTokens(light, parseDarkTokens(THEME_CSS));
+
+  for (const p of SPA_PAIRS) {
+    it(`light: ${p.label} ≥ ${p.min}:1`, () => {
+      const r = contrastBetween(light, p.fg, p.bg, p.over);
+      expect(r, `actual ${r.toFixed(2)}:1`).toBeGreaterThanOrEqual(p.min);
+    });
+    it(`dark: ${p.label} ≥ ${p.min}:1`, () => {
+      const r = contrastBetween(dark, p.fg, p.bg, p.over);
+      expect(r, `actual ${r.toFixed(2)}:1`).toBeGreaterThanOrEqual(p.min);
+    });
+  }
+});
+
+describe('contrast: manual chart palette meets WCAG 2.1 AA in both schemes', () => {
+  const variants = [
+    { name: 'light', p: PALETTE_LIGHT },
+    { name: 'dark', p: PALETTE_DARK },
+  ] as const;
+
+  for (const v of variants) {
+    const bg = parseColor(v.p.bg);
+    for (const fg of [v.p.axis, v.p.text, v.p.title, ...v.p.series]) {
+      it(`${v.name}: ${fg} on ${v.p.bg} ≥ 4.5:1`, () => {
+        const r = ratio(parseColor(fg), bg);
+        expect(r, `actual ${r.toFixed(2)}:1`).toBeGreaterThanOrEqual(4.5);
+      });
+    }
+  }
+});


### PR DESCRIPTION
## Summary

- Activa dark mode editorial vía `@media (prefers-color-scheme: dark)` + hook `[data-theme='dark']` para tests, sin JS en producción.
- Paleta "Tinta sobre papel quemado": paper `#1a1612`, ink `#f3ede2`, accent `#e89052`, neto `#6ab07a`, ss `#8a8e9e`. Dos tokens nuevos: `--surface` y `--cta-ink`.
- Los 3 SVGs estáticos del manual son theme-aware vía `<style>` interno con paleta light + bloque `@media` dark (`--c-bg`, `--c-axis`, `--c-grid`, `--c-text`, `--c-title`, `--c-s0..s5`).
- Nueva suite WCAG (`test/contrast.test.ts`) cubre los pares críticos de SPA y manual en ambos esquemas (36 checks).
- `test/a11y.browser.test.ts` parametrizado por tema (axe-core 3×light + 3×dark).
- `test/charts.browser.test.ts` añade 4 verificaciones de fills `var()` en light/dark.
- Fix de `.excel-band h3` (`color: var(--paper)` → `color: inherit`) para que herede del padre y respete el override dark — sin él el h3 caía a 1.07:1 en dark.

Closes #70.

## Test plan

- [ ] `npm run format:check && npm run lint && npm run typecheck && npm test` pasa
- [ ] `npm run test:browser` (axe-core en light + dark, charts en dark) pasa
- [ ] `npm run lighthouse` se mantiene en perf ≥ 0.85 / a11y ≥ 0.95 (light)
- [ ] Verificación visual manual de la SPA en dark vía DevTools `Emulate CSS prefers-color-scheme: dark`
- [ ] Verificación visual de los 3 SVGs del manual en dark